### PR TITLE
feat(008): unified abilities table — 24-column schema, JSON registry,…

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/007-upgrade-access-control"
+  "feature_directory": "specs/008-unified-abilities-table"
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -4,7 +4,7 @@
 
 **Spec**: `specs/001-sitewide-ability-management/` | **Status**: Complete
 
-Lets site administrators view, search, sort, filter, and override the metadata of every ability registered via the WordPress Abilities API (`wp_get_ability()`). Overrides are stored per-site in `{prefix}acrossai_abilities_overwrite` via BerlinDB; the registry is the source of truth — only fields that differ from registry defaults are persisted.
+Lets site administrators view, search, sort, filter, and override the metadata of every ability registered via the WordPress Abilities API (`wp_get_ability()`). Overrides are stored per-site in `{prefix}acrossai_abilities` (column `source != 'db'`) via BerlinDB; the registry is the source of truth — only fields that differ from registry defaults are persisted.
 
 ### What admins can do
 
@@ -31,7 +31,122 @@ All endpoints require `manage_options` + nonce (`wp_rest`).
 
 ### Key technical decisions
 
-- **Storage**: BerlinDB custom table — override-only, no registry duplication
+- **Storage**: BerlinDB custom table (`wp_acrossai_abilities`, `source != 'db'` rows) — override-only, no registry duplication
 - **Tri-state fields**: PHP `true` / `false` / `null` map to MySQL `1` / `0` / `NULL` (Inherit)
 - **MCP server data**: collected via `wpboilerplate/wpb-mcp-servers-list` at `rest_api_init` priority 20
 - **UI**: DataViews table + DataForms slide-in drawer (createPortal)
+
+---
+
+## Custom Abilities — Unified Table
+
+**Spec**: `docs/features/008-custom-abilities/008-unified-table.md` | **Status**: Planned (Spec 008)
+
+Creates the `{prefix}acrossai_abilities` table — a single 24-column BerlinDB table that serves both the Sitewide Ability Management module (override rows, `source != 'db'`) and the upcoming Custom Abilities module (new abilities, `source = 'db'`). Replaces the old `{prefix}acrossai_abilities_overwrite` table (plugin is pre-launch; no migration needed).
+
+### What this spec delivers
+
+- **4 new BerlinDB classes** under `includes/Modules/Abilities/Database/`: Schema, Row, Table, Query
+- **Query CRUD**: `insert_ability`, `get_ability_by_id`, `update_ability`, `delete_ability`, `slug_exists`
+- **Query chainable filters**: `by_source`, `enabled_only`, `search`, `with_pagination`, `order_by`
+- **Updated Sitewide classes** (`AcrossAI_Sitewide_Table/Schema/Row/Query`) pointing at the new table name with all 24 columns
+- **Updated `AcrossAI_Activator`** calling `AcrossAI_Abilities_Table::instance()->maybe_upgrade()`
+
+### Table: `{prefix}acrossai_abilities` — 24 columns
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | bigint unsigned PK | |
+| `ability_slug` | varchar(255) UNIQUE | `namespace/name` format |
+| `label` | varchar(255) null | Display name (source=db only) |
+| `description` | longtext null | |
+| `category` | varchar(100) null | WP Abilities API category slug |
+| `enabled` | tinyint(1) default 1 | Auto-register flag (source=db only) |
+| `provider` | varchar(100) null | Plugin/theme identifier |
+| `source` | varchar(50) default 'db' | `db` \| `plugin` \| `theme` \| `core` |
+| `site_allowed` | tinyint(1) null | NULL=inherit / 1=allow / 0=block |
+| `callback_type` | varchar(50) default 'noop' | `noop` \| `filter_hook` \| `wp_remote_post` \| `php_code` |
+| `callback_config` | longtext null | JSON: type-specific config |
+| `input_schema` | longtext null | JSON Schema Draft 7 |
+| `output_schema` | longtext null | JSON Schema Draft 7 |
+| `show_in_rest` | tinyint(1) null | NULL=registry default |
+| `show_in_mcp` | tinyint(1) null | NULL=registry default |
+| `mcp_type` | varchar(50) null | `tool` \| `resource` \| `prompt` |
+| `mcp_servers` | longtext null | JSON array; NULL=all servers |
+| `readonly` | tinyint(1) null | Tri-state |
+| `destructive` | tinyint(1) null | Tri-state |
+| `idempotent` | tinyint(1) null | Tri-state |
+| `created_at` | datetime | |
+| `updated_at` | datetime | ON UPDATE CURRENT_TIMESTAMP |
+| `created_by` | bigint unsigned null | |
+| `updated_by` | bigint unsigned null | |
+
+---
+
+## Custom Abilities — Business Logic + REST
+
+**Spec**: `docs/features/008-custom-abilities/009-business-logic-rest.md` | **Status**: Planned (Spec 009) | **Depends on**: Spec 008
+
+Wires up the processor that auto-registers `source=db` abilities at `wp_abilities_api_init`, plus full REST CRUD under `/wp-json/acrossai-abilities-manager/v1/abilities`. No admin UI yet (that's Spec 010).
+
+### What this spec delivers
+
+- **`AcrossAI_Abilities_Processor`** — fetches enabled `source=db` rows, builds `execute_callback` closures, calls `wp_register_ability()` for each
+- **`AcrossAI_Abilities_Validator`** — validates all fields; `php_code` uses `token_get_all()` syntax check + blocked-functions list
+- **`AcrossAI_Abilities_Sanitizer`** — sanitizes and casts all fields for DB storage; calls existing `AcrossAI_Sanitizer` tri-state helpers
+- **`AcrossAI_Abilities_Formatter`** — formats DB rows for REST responses (ISO 8601 dates, MCP shape)
+- **5 REST controllers** under `includes/Modules/Abilities/Rest/`
+
+### Callback types
+
+| Type | Execution |
+|------|-----------|
+| `noop` | Returns `[]` immediately |
+| `filter_hook` | `apply_filters('acrossai_ability_execute_{hook_name}', [], $input)` |
+| `wp_remote_post` | HTTP POST `$input` as JSON body; returns decoded response |
+| `php_code` | `eval()` code with `$input` in scope; blocked: `eval exec system passthru shell_exec popen proc_open file_put_contents unlink` |
+
+### Slug convention
+
+- Fixed prefix: `acrossai-abilities/` — Write controller prepends it; user sends suffix only
+- All `source=db` rows must have the `acrossai-abilities/` prefix
+
+### REST endpoints
+
+All endpoints require `manage_options`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/acrossai-abilities-manager/v1/abilities` | Paginated list with search/filter |
+| GET | `/acrossai-abilities-manager/v1/abilities/{id}` | Single ability |
+| POST | `/acrossai-abilities-manager/v1/abilities` | Create (slug prefix injected) |
+| POST | `/acrossai-abilities-manager/v1/abilities/{id}` | Update (identity fields stripped for source≠db) |
+| DELETE | `/acrossai-abilities-manager/v1/abilities/{id}` | Delete (204) |
+| GET | `/acrossai-abilities-manager/v1/abilities/mcp/tools` | MCP tool abilities |
+| GET | `/acrossai-abilities-manager/v1/abilities/mcp/resources` | MCP resource abilities |
+| GET | `/acrossai-abilities-manager/v1/abilities/mcp/prompts` | MCP prompt abilities |
+| GET | `/acrossai-abilities-manager/v1/ability-categories` | `wp_get_ability_categories()` |
+
+---
+
+## Custom Abilities — React UI + Admin Shell
+
+**Spec**: `docs/features/008-custom-abilities/010-react-ui.md` | **Status**: Planned (Spec 010) | **Depends on**: Spec 009
+
+Admin submenu page + React app for creating, editing, and managing custom abilities. Built after Spec 009 because the page enqueues a webpack bundle that doesn't exist until this spec runs.
+
+### What this spec delivers
+
+- **Admin PHP shell**: `AcrossAI_Abilities_Menu` (submenu), `AcrossAI_Abilities_Page` (mount point), `AcrossAI_Abilities_Assets` (enqueue + `wp_add_inline_script`)
+- **React app** at `src/js/abilities/` using `@wordpress/dataviews` (list) + `@wordpress/dataforms` (form)
+- **AbilitiesList** — searchable/filterable table with source badge (Custom / Plugin / Theme / Core), enabled toggle, bulk actions
+- **AbilityForm Variant A** (source=db) — all fields editable; category `<select>` from REST; `php_code` shows monospace `<textarea>`
+- **AbilityForm Variant B** (source≠db) — identity fields (label, description, category, callback) read-only; override fields editable
+- **webpack entry** `js/abilities` added to `webpack.config.js`
+- **`admin_menu` hook** wired in `includes/Main.php`
+
+### Key technical decisions
+
+- **Asset data**: `window.acrossaiAbilities = { restNamespace, nonce, currentUserId }` via `wp_add_inline_script()` (not `wp_localize_script`)
+- **Slug display**: prefix `acrossai-abilities/` shown read-only; user edits suffix only
+- **Separate webpack entry**: `build/js/abilities.js` + `build/js/abilities.asset.php` — does not share bundle with main manager assets

--- a/docs/features/008-custom-abilities/008-unified-table.md
+++ b/docs/features/008-custom-abilities/008-unified-table.md
@@ -1,0 +1,385 @@
+# Spec 008 — Unified Abilities Table
+
+**Branch**: `008-unified-abilities-table`
+**Depends on**: nothing (first in the 008-010 series)
+**Blocks**: Spec 009
+
+> **Dev-only note**: Plugin has not launched — no backward compatibility or data migration needed.
+> Drop the old table manually before running: `wp db query "DROP TABLE IF EXISTS wp_acrossai_abilities_overwrite;"`
+
+---
+
+## What this spec does
+
+- Updates 5 existing files — **no new files created**
+- Renames DB table from `acrossai_abilities_overwrite` → `acrossai_abilities` (Sitewide_Table)
+- Expands schema from 16 → 24 columns (Sitewide_Schema + Sitewide_Table DDL)
+- Adds typed properties + `get_json_fields()` static method + filter-driven JSON decode loop (Sitewide_Row)
+- Switches `$table_name` + adds `by_source()` + filter-driven JSON encode loop (Sitewide_Query)
+- Updates uninstall.php to drop the new table name
+
+Zero code duplication: the 4 existing Sitewide classes become the unified layer.
+`AcrossAI_Abilities_Query` (new in Spec 009) will also call `AcrossAI_Sitewide_Row::get_json_fields()`.
+
+---
+
+## Database Table: `{prefix}acrossai_abilities` — 24 columns
+
+**New table** — created fresh by `AcrossAI_Sitewide_Table::maybe_upgrade()` on plugin (de)activate.
+
+| Column | Type | Null | Default | Notes |
+|---|---|---|---|---|
+| `id` | bigint unsigned | NO | AUTO_INCREMENT | PK |
+| `ability_slug` | varchar(255) | NO | `''` | UNIQUE — `namespace/name` |
+| `label` | varchar(255) | YES | NULL | Display name — populated for source=db, NULL for overrides |
+| `description` | longtext | YES | NULL | |
+| `category` | varchar(100) | YES | NULL | WP Abilities API category slug (required by `wp_register_ability()`) |
+| `status` | varchar(20) | NO | `'draft'` | `draft` \| `publish` — `publish` always registers, no separate flag |
+| `provider` | varchar(100) | YES | NULL | Plugin/theme slug that originally owns the ability |
+| `source` | varchar(50) | YES | `'db'` | `db` \| `plugin` \| `theme` \| `core` |
+| `site_allowed` | tinyint(1) | YES | NULL | NULL=registry / 1=force-allow / 0=force-block (source≠db only) |
+| `callback_type` | varchar(50) | NO | `'noop'` | `noop` \| `filter_hook` \| `wp_remote_post` \| `php_code` |
+| `callback_config` | longtext | YES | NULL | JSON: type-specific config |
+| `input_schema` | longtext | YES | NULL | JSON Schema Draft 7 |
+| `output_schema` | longtext | YES | NULL | JSON Schema Draft 7 |
+| `show_in_rest` | tinyint(1) | YES | NULL | NULL=registry default / 1=yes / 0=no |
+| `show_in_mcp` | tinyint(1) | YES | NULL | NULL=registry default / 1=yes / 0=no |
+| `mcp_type` | varchar(100) | YES | NULL | `tool` \| `resource` \| `prompt` |
+| `mcp_servers` | longtext | YES | NULL | JSON array of server IDs; NULL=all servers |
+| `readonly` | tinyint(1) | YES | NULL | Tri-state: NULL=inherit / 0=false / 1=true |
+| `destructive` | tinyint(1) | YES | NULL | Tri-state |
+| `idempotent` | tinyint(1) | YES | NULL | Tri-state |
+| `created_at` | datetime | NO | CURRENT_TIMESTAMP | |
+| `updated_at` | datetime | NO | CURRENT_TIMESTAMP | ON UPDATE CURRENT_TIMESTAMP |
+| `created_by` | bigint unsigned | YES | NULL | |
+| `updated_by` | bigint unsigned | YES | NULL | |
+
+**Indexes**: `PRIMARY KEY (id)`, `UNIQUE KEY ability_slug (ability_slug(191))`, `KEY idx_status (status)`, `KEY idx_source (source)`, `KEY idx_updated_at (updated_at)`
+
+### `status` column semantics
+
+| status | meaning | registered at wp_abilities_api_init? |
+|---|---|---|
+| `draft` | Saved but incomplete — not live | No |
+| `publish` | Complete and active | Yes — always |
+
+- New abilities always start as `draft` — all field changes auto-save instantly as user fills the form
+- User explicitly clicks **Publish** button → `status` changes to `'publish'` → ability goes live on next boot
+- Override rows (source≠db): default `publish`, status not semantically used
+- **No save button for editing existing abilities** — every field change on an existing ability sends `POST /abilities/{id}` with only the changed field. BerlinDB partial update (`update_item($id, $fields)`) means untouched columns are never overwritten.
+
+### Row type semantics
+
+| Column | source=db | source=plugin/theme/core |
+|---|---|---|
+| `label`, `category`, `description` | Required / editable | Read-only (from WP registry) |
+| `status` | `draft`/`publish` — Publish button | N/A (`publish` by default) |
+| `callback_type/config`, `input/output_schema` | Editable | Read-only |
+| `site_allowed` | N/A | Editable (instant save) |
+| `show_in_rest/mcp`, `mcp_type/servers` | Editable (instant save) | Editable (instant save) |
+| `readonly`, `destructive`, `idempotent` | Editable (instant save) | Editable (instant save) |
+
+---
+
+## Callback Types
+
+| `callback_type` | `callback_config` shape | Execution |
+|---|---|---|
+| `noop` | `{}` or NULL | Returns `[]` immediately |
+| `filter_hook` | `{"hook_name": "my_hook"}` | `apply_filters('acrossai_ability_execute_{hook_name}', [], $input)` |
+| `wp_remote_post` | `{"url": "https://...", "method": "POST", "timeout": 30}` | HTTP POST `$input` as JSON body, returns decoded response |
+| `php_code` | `{"code": "return strtoupper($input);"}` | `eval()` the code with `$input` in scope; returns result |
+
+### `php_code` details
+
+- **`callback_config.code`**: raw PHP — no `<?php` tag. Receives `$input` and must `return` the result.
+- **Execution**: wrapped in an isolated closure — `$fn = function($input) { <code> }; return $fn($input);`
+- **Access**: `manage_options` only — same trust level as editing `functions.php`
+- **Size limit**: 64 KB
+- **Blocked functions**: `eval`, `exec`, `system`, `passthru`, `shell_exec`, `popen`, `proc_open`, `file_put_contents`, `unlink`
+- **Validation**: `token_get_all()` syntax check + blocked-function scan
+
+---
+
+## Slug Convention
+
+- Fixed prefix: `acrossai-abilities/`
+- User enters suffix only (e.g. `my-ability`) → stored as `acrossai-abilities/my-ability`
+- Write controller prepends prefix; form shows prefix read-only; list strips prefix for display
+
+---
+
+## Architecture (follows plugin AGENTS.md rules)
+
+- **Singleton pattern** on every class
+- **Hook wiring** only in `includes/Main.php` via `$this->loader->add_action()`
+- **BerlinDB layer**: `AcrossAI_Sitewide_Query` is the only entry point for DB reads/writes — no direct `$wpdb` SQL in any other class
+- **ABSPATH guard** on every PHP file
+
+---
+
+## Zero-Duplication Architecture
+
+The 4 existing Sitewide classes are the **single source of truth**. No new Table/Schema/Row classes.
+`AcrossAI_Sitewide_Row::get_json_fields()` is called by both `AcrossAI_Sitewide_Query` and (in Spec 009) `AcrossAI_Abilities_Query`.
+
+---
+
+## Files NOT to Touch
+
+| File | Reason |
+|---|---|
+| `includes/Main.php` | Line 279 `AcrossAI_Sitewide_Table::instance()` stays as-is — class still exists |
+| `includes/AcrossAI_Activator.php` | `(new AcrossAI_Sitewide_Table())->maybe_upgrade()` stays as-is |
+| `tests/phpunit/sitewide/SitewideQueryTest.php` | No table-name assertions — no change needed |
+
+---
+
+## Files to Modify (5)
+
+### `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Table.php`
+
+- `$name` → `'acrossai_abilities'`
+- `$db_version_key` → `'acrossai_abilities_db_version'`
+- `$version` stays `'1.0.0'` (pre-launch, fresh install only — do NOT change)
+- `set_schema()` → full 24-column DDL + 5 indexes: `PRIMARY KEY (id)`, `UNIQUE KEY ability_slug(191)`, `KEY idx_status (status)`, `KEY idx_source (source)`, `KEY idx_updated_at (updated_at)`
+
+### `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Schema.php`
+
+Add 8 new column definitions after the `source` column definition:
+
+| Column | type | length | null | default |
+|---|---|---|---|---|
+| `label` | varchar | 255 | true | null |
+| `description` | longtext | — | true | null |
+| `category` | varchar | 100 | true | null |
+| `status` | varchar | 20 | false | `'draft'` |
+| `callback_type` | varchar | 50 | false | `'noop'` |
+| `callback_config` | longtext | — | true | null |
+| `input_schema` | longtext | — | true | null |
+| `output_schema` | longtext | — | true | null |
+
+`mcp_type` length stays `'100'` — do NOT change.
+
+### `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Row.php`
+
+1. Add 8 new typed properties after `$source`:
+   ```php
+   public ?string $label         = null;
+   public ?string $description   = null;
+   public ?string $category      = null;
+   public string  $status        = 'draft';
+   public string  $callback_type = 'noop';
+   public ?string $callback_config = null;
+   public ?string $input_schema  = null;
+   public ?string $output_schema = null;
+   ```
+
+2. Add `public static function get_json_fields(): array` — single source of truth for all JSON-encoded fields:
+   ```php
+   public static function get_json_fields(): array {
+       return apply_filters(
+           'acrossai_abilities_json_fields',
+           [ 'mcp_servers', 'callback_config', 'input_schema', 'output_schema' ]
+       );
+   }
+   ```
+
+3. Replace hardcoded `mcp_servers` JSON decode in constructor with filter-driven loop:
+   ```php
+   foreach ( self::get_json_fields() as $field ) {
+       if ( property_exists( $this, $field ) && null !== $this->$field ) {
+           $decoded      = json_decode( $this->$field, true );
+           $this->$field = is_array( $decoded ) ? $decoded : null;
+       }
+   }
+   ```
+
+### `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Query.php`
+
+1. `$table_name` → `'acrossai_abilities'`
+
+2. In `save_override()`: replace ONLY the first `mcp_servers` JSON encode block with a filter-driven loop:
+   ```php
+   foreach ( AcrossAI_Sitewide_Row::get_json_fields() as $field ) {
+       if ( isset( $fields[ $field ] ) && is_array( $fields[ $field ] ) ) {
+           $fields[ $field ] = wp_json_encode( $fields[ $field ] );
+       }
+   }
+   ```
+   The following 3 blocks MUST remain unchanged:
+   - Tri-state bool→int cast for `site_allowed`, `readonly`, `destructive`, `idempotent`, `show_in_rest`, `show_in_mcp`
+   - `mcp_type` value validation guard (blocks invalid values before DB write)
+   - `mcp_servers` non-string guard (ensures value is string or null after encoding)
+
+3. Add `by_source()` method:
+   ```php
+   public function by_source( string $source ): array {
+       return $this->query( [ 'source' => $source, 'number' => 0 ] );
+   }
+   ```
+
+4. All other existing methods (`get_override_by_slug`, `delete_override_by_slug`, `get_all_overrides`) — unchanged.
+
+### `uninstall.php`
+
+- `DROP TABLE IF EXISTS wp_acrossai_abilities_overwrite` → `DROP TABLE IF EXISTS wp_acrossai_abilities`
+- `delete_option( 'acrossai_abilities_overwrite_db_version' )` → `delete_option( 'acrossai_abilities_db_version' )`
+- Update inline comment: "sitewide ability overrides table" → "unified abilities table"
+
+---
+
+## Speckit commands — run in order
+
+### Step 1 — Create feature branch
+```
+/speckit.git.feature
+```
+When prompted, enter: `008-unified-abilities-table`
+
+---
+
+### Step 2 — Write the spec
+```
+/speckit.specify Unified abilities table: update AcrossAI_Sitewide_Table ($name=acrossai_abilities, $db_version_key=acrossai_abilities_db_version, $version stays 1.0.0, expand set_schema() to 24 columns with 5 indexes — no enabled column). Add 8 new column definitions to AcrossAI_Sitewide_Schema after source: label (varchar/255 null), description (longtext null), category (varchar/100 null), status (varchar/20 not null default draft), callback_type (varchar/50 not null default noop), callback_config (longtext null), input_schema (longtext null), output_schema (longtext null). Keep mcp_type length=100 unchanged. Update AcrossAI_Sitewide_Row: add 8 typed properties after $source (no enabled), add public static get_json_fields() returning apply_filters(acrossai_abilities_json_fields, [mcp_servers, callback_config, input_schema, output_schema]), replace hardcoded mcp_servers JSON decode with filter-driven loop over get_json_fields(). Update AcrossAI_Sitewide_Query: $table_name=acrossai_abilities, in save_override() replace only the first mcp_servers JSON encode block with a filter-driven loop over AcrossAI_Sitewide_Row::get_json_fields() (keep tri-state cast, mcp_type guard, mcp_servers non-string guard unchanged), add by_source(string $source): array method. Update uninstall.php: DROP TABLE wp_acrossai_abilities (not overwrite), delete_option acrossai_abilities_db_version. Do NOT touch includes/Main.php or includes/AcrossAI_Activator.php.
+```
+
+---
+
+### Step 3 — Generate plan with memory context
+```
+/speckit.memory-md.plan-with-memory
+```
+
+---
+
+### Step 4 — Architecture + security validation
+```
+/speckit.architecture-guard.governed-plan
+/speckit.security-review.plan
+```
+
+---
+
+### Step 5 — Generate tasks
+```
+/speckit.architecture-guard.governed-tasks
+```
+
+---
+
+### Step 6 — Implement
+```
+/speckit.architecture-guard.governed-implement
+```
+
+---
+
+### Step 7 — Quality gates (run after implement)
+```bash
+php -l includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Table.php
+php -l includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Schema.php
+php -l includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Row.php
+php -l includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Query.php
+php -l uninstall.php
+
+composer run phpcs
+composer run phpstan
+```
+
+---
+
+### Step 8 — Post-implement review
+```
+/speckit.analyze
+/speckit.architecture-guard.architecture-review
+/speckit.security-review.staged
+```
+
+---
+
+### Step 9 — Save memory + commit
+```
+/speckit.memory-md.capture-from-diff
+/speckit.git.commit
+```
+
+---
+
+## Manual testing
+
+### Before running: drop old table + reactivate the plugin
+```bash
+# Drop the old table (dev only — no migration needed)
+wp db query "DROP TABLE IF EXISTS wp_acrossai_abilities_overwrite;"
+
+# Reactivate to trigger maybe_upgrade()
+wp plugin deactivate acrossai-abilities-manager
+wp plugin activate acrossai-abilities-manager
+```
+
+### 1. Confirm new table exists with 24 columns
+```bash
+wp db query "DESCRIBE wp_acrossai_abilities;"
+# Expected: 24 rows — one per column
+# Check these columns exist: id, ability_slug, label, description, category,
+# status, provider, source, site_allowed, callback_type, callback_config,
+# input_schema, output_schema, show_in_rest, show_in_mcp, mcp_type,
+# mcp_servers, readonly, destructive, idempotent,
+# created_at, updated_at, created_by, updated_by
+```
+
+### 2. Confirm old table is gone
+```bash
+wp db query "SHOW TABLES LIKE 'wp_acrossai_abilities_overwrite';"
+# Expected: Empty set (no rows)
+```
+
+### 3. Confirm indexes
+```bash
+wp db query "SHOW INDEX FROM wp_acrossai_abilities;"
+# Expected indexes: PRIMARY, ability_slug (UNIQUE), idx_status, idx_source, idx_updated_at
+```
+
+### 4. Confirm db_version_key set
+```bash
+wp option get acrossai_abilities_db_version
+# Expected: version number (e.g. "1")
+```
+
+### 5. Confirm get_json_fields() returns correct fields
+```bash
+wp eval "
+use AcrossAI_Abilities_Manager\Includes\Modules\Sitewide\Database\AcrossAI_Sitewide_Row;
+\$fields = AcrossAI_Sitewide_Row::get_json_fields();
+echo implode(', ', \$fields) . PHP_EOL;
+"
+# Expected: mcp_servers, callback_config, input_schema, output_schema
+```
+
+### 6. Confirm feature 001 sitewide UI still works
+- Go to WP Admin → Abilities Manager → Sitewide Abilities
+- List should load without errors
+- Save a new override → confirm it writes to `wp_acrossai_abilities`
+
+```bash
+wp db query "SELECT id, ability_slug, source, site_allowed FROM wp_acrossai_abilities LIMIT 5;"
+# Expected: any saved overrides appear here with source=plugin/theme/core
+```
+
+### 7. Confirm Feature 004 Override Processor still works
+```bash
+wp eval "
+do_action('wp_abilities_api_init');
+\$ability = wp_get_ability('core/get-site-info');
+echo \$ability ? 'core/get-site-info still registered' : 'BROKEN';
+"
+# Expected: core/get-site-info still registered
+```
+
+---
+
+## What NOT to test yet (spec 009+)
+- REST API endpoints (not created until spec 009)
+- Custom ability creation via REST (not wired until spec 009)
+- Admin submenu page (not created until spec 010)

--- a/docs/features/008-custom-abilities/009-business-logic-rest.md
+++ b/docs/features/008-custom-abilities/009-business-logic-rest.md
@@ -1,0 +1,430 @@
+# Spec 009 — Abilities Business Logic + REST
+
+**Branch**: `009-abilities-business-logic-rest`
+**Depends on**: Spec 008 (`wp_acrossai_abilities` table must exist with 24 columns)
+**Blocks**: Spec 010
+
+---
+
+## What this spec does
+
+- `AcrossAI_Abilities_Processor` — registers `source=db, status=publish` abilities at `wp_abilities_api_init`
+- `AcrossAI_Abilities_Query` — new BerlinDB Query class; sole DB entry point for all Abilities module reads/writes; reuses `AcrossAI_Sitewide_Row::get_json_fields()` for JSON encode/decode
+- `AcrossAI_Abilities_Validator` — validates all fields including `php_code` syntax check
+- `AcrossAI_Abilities_Sanitizer` — sanitizes and casts all fields for DB storage
+- `AcrossAI_Abilities_Formatter` — formats DB rows for REST responses
+- 5 REST controllers under `/wp-json/acrossai-abilities-manager/v1/abilities`
+- `GET /ability-categories` endpoint returning registered WP ability categories
+- Wires Processor + REST orchestrator into `includes/Main.php`
+
+---
+
+## New file: `AcrossAI_Abilities_Query`
+
+```
+includes/Modules/Abilities/Database/
+└── AcrossAI_Abilities_Query.php   — BerlinDB Query: singleton
+                                     $table_name   = 'acrossai_abilities'
+                                     $table_schema = AcrossAI_Sitewide_Schema::class
+                                     $item_shape   = AcrossAI_Sitewide_Row::class
+```
+
+**CRUD methods**: `insert_ability()`, `get_ability_by_id()`, `update_ability()`, `delete_ability()`, `slug_exists()`
+
+**Filter methods** (each returns `AcrossAI_Sitewide_Row[]`):
+`by_source()`, `published_only()`, `search()`, `with_pagination()`, `order_by()`
+
+**JSON encode/decode**: uses `AcrossAI_Sitewide_Row::get_json_fields()` — the same filter-driven list as the Sitewide_Query. No duplication.
+
+```php
+// Example — encode JSON fields before insert/update
+foreach ( AcrossAI_Sitewide_Row::get_json_fields() as $field ) {
+    if ( isset( $data[ $field ] ) && is_array( $data[ $field ] ) ) {
+        $data[ $field ] = wp_json_encode( $data[ $field ] );
+    }
+}
+```
+
+---
+
+## Processor: `AcrossAI_Abilities_Processor`
+
+Hooks into `wp_abilities_api_init` at priority 10.
+
+**Registration filter**: `source = 'db' AND status = 'publish'`
+
+For each qualifying row, calls `wp_register_ability()` with:
+- `label` — from row
+- `description` — from row
+- `category` — from row (required by WP Abilities API)
+- `execute_callback` — closure built by `build_execute_callback()` based on `callback_type`
+- `permission_callback` — `'__return_true'` unless overridden
+
+### Callback execution per `callback_type`
+
+| `callback_type` | Execution |
+|---|---|
+| `noop` | Returns `[]` immediately |
+| `filter_hook` | `apply_filters('acrossai_ability_execute_{hook_name}', [], $input)` |
+| `wp_remote_post` | HTTP POST `$input` as JSON body; returns decoded response |
+| `php_code` | Wrapped closure: `$fn = function($input) { <code> }; return $fn($input);` |
+
+### `php_code` details
+
+- **`callback_config.code`**: raw PHP — no `<?php` tag. Receives `$input` and must `return` the result.
+- **Execution**: wrapped in an isolated closure
+- **Access**: `manage_options` only — same trust level as editing `functions.php`
+- **Size limit**: 64 KB
+- **Blocked functions**: `eval`, `exec`, `system`, `passthru`, `shell_exec`, `popen`, `proc_open`, `file_put_contents`, `unlink`
+- **Validation**: `token_get_all()` syntax check + blocked-function scan (enforced in Validator before save)
+
+---
+
+## Slug Convention
+
+- Fixed prefix: `acrossai-abilities/`
+- User sends suffix only → Write controller prepends `acrossai-abilities/` before DB insert
+- All `source=db` rows must have the `acrossai-abilities/` prefix
+- List strips prefix for display; form shows prefix read-only
+
+---
+
+## Instant Save (Sparse Update)
+
+There is **no save button** for editing an existing ability. Every field change triggers an immediate `POST /abilities/{id}` with only the changed field(s) in the request body. The Write controller calls `AcrossAI_Abilities_Query::update_ability($id, $fields)` which calls BerlinDB's `update_item()` — only the passed columns are written; untouched columns keep their current DB value.
+
+**Exception**: the **Publish** button for new `source=db` abilities. New abilities are auto-saved as `status='draft'`. Clicking Publish sends `POST /abilities/{id}` with `{"status": "publish"}` — a single-field sparse update.
+
+---
+
+## REST Layer
+
+**Namespace**: `acrossai-abilities-manager/v1`
+**Permission**: all endpoints require `manage_options`
+
+```
+includes/Modules/Abilities/Rest/
+├── AcrossAI_Abilities_Rest_Controller.php       — Orchestrator: singleton, register_routes(), check_permission()
+├── AcrossAI_Abilities_Read_Controller.php       — GET /abilities (list + search/filter/pagination)
+│                                                   GET /abilities/{id}
+├── AcrossAI_Abilities_Write_Controller.php      — POST /abilities (create — slug prefix injected)
+│                                                   POST /abilities/{id} (update — sparse, source≠db strips identity fields)
+│                                                   DELETE /abilities/{id} (204)
+├── AcrossAI_Abilities_Mcp_Controller.php        — GET /abilities/mcp/tools
+│                                                   GET /abilities/mcp/resources
+│                                                   GET /abilities/mcp/prompts
+└── AcrossAI_Abilities_Categories_Controller.php — GET /ability-categories → wp_get_ability_categories()
+```
+
+### Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/acrossai-abilities-manager/v1/abilities` | Paginated list with search/filter/sort |
+| GET | `/acrossai-abilities-manager/v1/abilities/{id}` | Single ability by ID |
+| POST | `/acrossai-abilities-manager/v1/abilities` | Create (slug prefix injected; starts as draft) |
+| POST | `/acrossai-abilities-manager/v1/abilities/{id}` | Sparse update (only passed fields written) |
+| DELETE | `/acrossai-abilities-manager/v1/abilities/{id}` | Delete (204) |
+| GET | `/acrossai-abilities-manager/v1/abilities/mcp/tools` | MCP tool abilities |
+| GET | `/acrossai-abilities-manager/v1/abilities/mcp/resources` | MCP resource abilities |
+| GET | `/acrossai-abilities-manager/v1/abilities/mcp/prompts` | MCP prompt abilities |
+| GET | `/acrossai-abilities-manager/v1/ability-categories` | `wp_get_ability_categories()` |
+
+### source≠db update rules
+
+For `source=plugin/theme/core` rows, the Write controller strips identity fields from the update payload before saving:
+- **Stripped** (read-only from WP registry): `label`, `description`, `category`, `callback_type`, `callback_config`, `input_schema`, `output_schema`
+- **Allowed** (override fields): `site_allowed`, `show_in_rest`, `show_in_mcp`, `mcp_type`, `mcp_servers`, `readonly`, `destructive`, `idempotent`
+
+---
+
+## Reuse from existing code
+
+| Existing file | Reuse |
+|---|---|
+| `includes/Utilities/AcrossAI_Sanitizer.php` | Call `sanitize_tri_state()`, `sanitize_mcp_type()`, `sanitize_mcp_servers_array()` |
+| `includes/Utilities/AcrossAI_Protected_Abilities.php` | Filter protected slug prefixes in Read controller |
+| `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Row::get_json_fields()` | JSON field list for encode/decode in AcrossAI_Abilities_Query |
+| `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Query.php` | BerlinDB Query singleton pattern reference |
+
+---
+
+## Files to Create (9)
+
+```
+includes/Modules/Abilities/Database/
+└── AcrossAI_Abilities_Query.php
+
+includes/Modules/Abilities/
+└── AcrossAI_Abilities_Processor.php
+
+includes/Utilities/
+├── AcrossAI_Abilities_Validator.php
+├── AcrossAI_Abilities_Sanitizer.php
+└── AcrossAI_Abilities_Formatter.php
+
+includes/Modules/Abilities/Rest/
+├── AcrossAI_Abilities_Rest_Controller.php
+├── AcrossAI_Abilities_Read_Controller.php
+├── AcrossAI_Abilities_Write_Controller.php
+├── AcrossAI_Abilities_Mcp_Controller.php
+└── AcrossAI_Abilities_Categories_Controller.php
+```
+
+## Files to Modify (1)
+
+| File | Change |
+|---|---|
+| `includes/Main.php` | Wire `AcrossAI_Abilities_Processor` at `wp_abilities_api_init P10`; wire `AcrossAI_Abilities_Rest_Controller` at `rest_api_init` — **no `admin_menu` hook yet** (that's Spec 010) |
+
+---
+
+## Speckit commands — run in order
+
+### Step 1 — Create feature branch
+```
+/speckit.git.feature
+```
+When prompted, enter: `009-abilities-business-logic-rest`
+
+---
+
+### Step 2 — Write the spec
+```
+/speckit.specify Abilities business logic and REST API: create AcrossAI_Abilities_Query (BerlinDB Query singleton, table_name=acrossai_abilities, table_schema=AcrossAI_Sitewide_Schema, item_shape=AcrossAI_Sitewide_Row, CRUD: insert_ability/get_ability_by_id/update_ability/delete_ability/slug_exists, filters: by_source/published_only/search/with_pagination/order_by, JSON encode/decode via AcrossAI_Sitewide_Row::get_json_fields()). Create AcrossAI_Abilities_Processor that hooks into wp_abilities_api_init priority 10, fetches source=db AND status=publish rows (no enabled flag — publish means always live), and registers each via wp_register_ability() with label/description/category and build_execute_callback() closure (noop=return [], filter_hook=apply_filters, wp_remote_post=HTTP POST JSON, php_code=eval in isolated closure, blocked functions: eval exec system passthru shell_exec popen proc_open file_put_contents unlink). Create Validator (validate_slug, validate_label, validate_category, validate_callback_config all 4 types, validate_php_code token_get_all syntax check + blocked function scan, validate_schema, validate_mcp_type, validate_source, validate_status, validate_ability aggregate). Create Sanitizer (sanitize all fields, sanitize_php_code strips PHP tags, calls AcrossAI_Sanitizer::sanitize_tri_state() and sanitize_mcp_type() and sanitize_mcp_servers_array()). Create Formatter (format_for_response Row to stdClass with ISO 8601 datetimes, format_for_mcp filter show_in_mcp + mcp_type). REST layer: orchestrator singleton + Read (GET /abilities list with search/filter/pagination, GET /abilities/{id}) + Write (POST /abilities create with acrossai-abilities/ slug prefix injection and status=draft default, POST /abilities/{id} sparse update with source!=db identity field stripping, DELETE /abilities/{id} 204) + Mcp (GET /abilities/mcp/tools|resources|prompts) + Categories (GET /ability-categories from wp_get_ability_categories). All endpoints require manage_options. Wire Processor at wp_abilities_api_init P10 and REST orchestrator at rest_api_init in includes/Main.php only. No admin_menu hook.
+```
+
+---
+
+### Step 3 — Generate plan with memory context
+```
+/speckit.memory-md.plan-with-memory
+```
+
+---
+
+### Step 4 — Architecture + security validation
+```
+/speckit.architecture-guard.governed-plan
+/speckit.security-review.plan
+```
+
+---
+
+### Step 5 — Generate tasks
+```
+/speckit.architecture-guard.governed-tasks
+```
+
+---
+
+### Step 6 — Implement
+```
+/speckit.architecture-guard.governed-implement
+```
+
+---
+
+### Step 7 — Quality gates (run after implement)
+```bash
+php -l includes/Modules/Abilities/Database/AcrossAI_Abilities_Query.php
+php -l includes/Modules/Abilities/AcrossAI_Abilities_Processor.php
+php -l includes/Utilities/AcrossAI_Abilities_Validator.php
+php -l includes/Utilities/AcrossAI_Abilities_Sanitizer.php
+php -l includes/Utilities/AcrossAI_Abilities_Formatter.php
+php -l includes/Modules/Abilities/Rest/AcrossAI_Abilities_Rest_Controller.php
+php -l includes/Modules/Abilities/Rest/AcrossAI_Abilities_Read_Controller.php
+php -l includes/Modules/Abilities/Rest/AcrossAI_Abilities_Write_Controller.php
+php -l includes/Modules/Abilities/Rest/AcrossAI_Abilities_Mcp_Controller.php
+php -l includes/Modules/Abilities/Rest/AcrossAI_Abilities_Categories_Controller.php
+php -l includes/Main.php
+
+composer run phpcs
+composer run phpstan
+```
+
+---
+
+### Step 8 — Post-implement review
+```
+/speckit.analyze
+/speckit.architecture-guard.architecture-review
+/speckit.security-review.staged
+```
+
+---
+
+### Step 9 — Save memory + commit
+```
+/speckit.memory-md.capture-from-diff
+/speckit.git.commit
+```
+
+---
+
+## Manual testing
+
+### Setup: insert a test ability with status=publish
+```bash
+wp db query "
+INSERT INTO wp_acrossai_abilities
+  (ability_slug, label, description, category, status, source, callback_type, show_in_rest)
+VALUES
+  ('acrossai-abilities/test-noop', 'Test Noop', 'A test ability', 'site', 'publish', 'db', 'noop', 1);
+"
+# Note: status='publish' required for Processor to register it
+```
+
+### 1. Confirm REST routes are registered
+```bash
+wp eval "do_action('rest_api_init'); \$server = rest_get_server(); print_r(array_filter(array_keys(\$server->get_routes()), function(\$r){ return strpos(\$r, 'abilities') !== false; }));"
+# Expected: routes for /acrossai-abilities-manager/v1/abilities and sub-paths
+```
+
+### 2. GET ability categories
+```bash
+wp eval "
+\$req = new WP_REST_Request('GET', '/acrossai-abilities-manager/v1/ability-categories');
+\$res = rest_do_request(\$req);
+echo json_encode(\$res->get_data(), JSON_PRETTY_PRINT);
+"
+# Expected: JSON array of {slug, label} objects
+```
+
+### 3. GET abilities list
+```bash
+wp eval "
+\$req = new WP_REST_Request('GET', '/acrossai-abilities-manager/v1/abilities');
+\$req->set_param('per_page', 10);
+\$res = rest_do_request(\$req);
+echo json_encode(\$res->get_data(), JSON_PRETTY_PRINT);
+"
+# Expected: array of ability objects including test-noop
+```
+
+### 4. POST — create new ability (status defaults to draft)
+```bash
+wp eval "
+\$req = new WP_REST_Request('POST', '/acrossai-abilities-manager/v1/abilities');
+\$req->set_body_params([
+  'ability_slug'  => 'rest-created',
+  'label'         => 'REST Created',
+  'description'   => 'Created via REST test',
+  'category'      => 'site',
+  'source'        => 'db',
+  'callback_type' => 'noop',
+]);
+\$res = rest_do_request(\$req);
+echo \$res->get_status() . PHP_EOL;
+echo json_encode(\$res->get_data(), JSON_PRETTY_PRINT);
+"
+# Expected: 201, ability_slug='acrossai-abilities/rest-created', status='draft'
+```
+
+### 5. POST — publish ability (sparse update, single field)
+```bash
+wp eval "
+\$row = \$GLOBALS['wpdb']->get_row(\"SELECT id FROM wp_acrossai_abilities WHERE ability_slug = 'acrossai-abilities/rest-created'\");
+\$req = new WP_REST_Request('POST', '/acrossai-abilities-manager/v1/abilities/' . \$row->id);
+\$req->set_body_params(['status' => 'publish']);
+\$res = rest_do_request(\$req);
+echo \$res->get_status() . PHP_EOL;
+echo json_encode(\$res->get_data(), JSON_PRETTY_PRINT);
+"
+# Expected: 200, status='publish'
+```
+
+### 6. POST — create ability with php_code callback
+```bash
+wp eval "
+\$req = new WP_REST_Request('POST', '/acrossai-abilities-manager/v1/abilities');
+\$req->set_body_params([
+  'ability_slug'   => 'php-upper',
+  'label'          => 'PHP Uppercase',
+  'category'       => 'site',
+  'source'         => 'db',
+  'callback_type'  => 'php_code',
+  'callback_config'=> json_encode(['code' => 'return strtoupper(\$input);']),
+]);
+\$res = rest_do_request(\$req);
+echo \$res->get_status() . PHP_EOL;
+"
+# Expected: 201
+```
+
+### 7. POST — blocked function in php_code (security check)
+```bash
+wp eval "
+\$req = new WP_REST_Request('POST', '/acrossai-abilities-manager/v1/abilities');
+\$req->set_body_params([
+  'ability_slug'   => 'dangerous',
+  'label'          => 'Dangerous',
+  'category'       => 'site',
+  'source'         => 'db',
+  'callback_type'  => 'php_code',
+  'callback_config'=> json_encode(['code' => 'exec(\"rm -rf /\");']),
+]);
+\$res = rest_do_request(\$req);
+echo \$res->get_status() . PHP_EOL;
+"
+# Expected: 400 validation error
+```
+
+### 8. Confirm Processor registers only published abilities
+```bash
+wp eval "
+do_action('wp_abilities_api_categories_init');
+do_action('wp_abilities_api_init');
+\$ability = wp_get_ability('acrossai-abilities/test-noop');
+echo \$ability ? 'REGISTERED: ' . \$ability->get_label() : 'NOT REGISTERED';
+echo PHP_EOL;
+\$draft = wp_get_ability('acrossai-abilities/rest-created');
+echo \$draft ? 'draft REGISTERED (wrong)' : 'draft NOT REGISTERED (correct)';
+"
+# Expected: REGISTERED: Test Noop / draft NOT REGISTERED (correct)
+```
+
+### 9. Verify slug prefix enforcement
+```bash
+wp db query "SELECT ability_slug, status FROM wp_acrossai_abilities WHERE source='db';"
+# Expected: all source=db rows have the acrossai-abilities/ prefix
+```
+
+### 10. Permission check — non-admin user
+```bash
+wp eval "
+wp_set_current_user(0);
+\$req = new WP_REST_Request('GET', '/acrossai-abilities-manager/v1/abilities');
+\$res = rest_do_request(\$req);
+echo \$res->get_status() . PHP_EOL;
+"
+# Expected: 401 or 403
+```
+
+### 11. DELETE ability
+```bash
+wp eval "
+\$row = \$GLOBALS['wpdb']->get_row(\"SELECT id FROM wp_acrossai_abilities WHERE ability_slug = 'acrossai-abilities/rest-created'\");
+\$req = new WP_REST_Request('DELETE', '/acrossai-abilities-manager/v1/abilities/' . \$row->id);
+\$res = rest_do_request(\$req);
+echo \$res->get_status() . PHP_EOL;
+"
+# Expected: 204
+```
+
+### 12. Feature 001 Override Processor still works
+```bash
+wp eval "
+do_action('wp_abilities_api_init');
+\$ability = wp_get_ability('core/get-site-info');
+echo \$ability ? 'core/get-site-info still registered' : 'BROKEN';
+"
+# Expected: core/get-site-info still registered
+```
+
+---
+
+## What NOT to test yet (spec 010)
+- Admin submenu page (not created until spec 010)
+- React UI components (not created until spec 010)
+- webpack build output (not configured until spec 010)

--- a/docs/features/008-custom-abilities/010-react-ui.md
+++ b/docs/features/008-custom-abilities/010-react-ui.md
@@ -1,0 +1,348 @@
+# Spec 010 — Abilities React UI + Admin Shell
+
+**Branch**: `010-abilities-react-ui`
+**Depends on**: Spec 009 (REST endpoints must exist and return data)
+**Blocks**: nothing (final spec in 008-010 series)
+
+> **UI design**: Finalize the React component design in Claude Artifacts / Claude Design before implementing this spec.
+> Reference existing pattern: `src/js/sitewide/` for `@wordpress/dataviews` + REST client patterns.
+
+---
+
+## What this spec does
+
+- `AcrossAI_Abilities_Menu` — registers "Custom Abilities" submenu under Abilities Manager
+- `AcrossAI_Abilities_Page` — renders the React mount point `<div id="acrossai-abilities-root"></div>`
+- `AcrossAI_Abilities_Assets` — enqueues the built JS bundle + passes `window.acrossaiAbilities` via `wp_add_inline_script()`
+- React app under `src/js/abilities/`:
+  - `AbilitiesList` — `@wordpress/dataviews` table with search, source filter, status filter, bulk actions
+  - `AbilityForm` — `@wordpress/dataforms` form with Variant A (source=db, all fields editable) and Variant B (source≠db, identity fields read-only)
+  - `php_code` callback type renders a monospace `<textarea>` for the code body
+  - Category field is a `<select>` populated from `GET /ability-categories`
+  - **Draft/Publish workflow**: new abilities auto-save as draft; explicit Publish button transitions to `status=publish`
+  - **No save button for edits**: every field change on an existing ability saves instantly
+- `webpack.config.js` — new entry `'js/abilities': 'src/js/abilities/index.js'`
+- Wires `admin_menu` hook in `includes/Main.php`
+
+---
+
+## Draft / Publish Workflow
+
+| State | What it means | UI |
+|---|---|---|
+| `status=draft` | Ability saved but not live | "Draft" badge in list; Publish button in form |
+| `status=publish` | Ability is live — registered at boot | "Published" badge; no Publish button |
+
+### New ability flow
+1. User clicks "Add New Ability"
+2. Form opens in "new ability" mode — all fields blank
+3. User types in any field → `POST /abilities` on first change (creates row with `status=draft`)
+4. Subsequent changes → `POST /abilities/{id}` with only the changed field (sparse update)
+5. User clicks **Publish** → `POST /abilities/{id}` with `{"status": "publish"}` → ability goes live
+
+### Existing ability editing (no save button)
+- Any toggle, select change, or text field blur → `POST /abilities/{id}` with only the changed field
+- No confirmation dialog; changes are instant
+- No risk of data loss from untouched fields — BerlinDB partial update writes only passed columns
+
+---
+
+## Variant A vs Variant B Forms
+
+### Variant A — source=db (Custom ability)
+All fields editable:
+- Slug: `acrossai-abilities/` prefix read-only + editable suffix input
+- Label, Description, Category (dropdown from REST)
+- Status badge + Publish button (if draft)
+- Callback Type select: `noop` | `filter_hook` | `wp_remote_post` | `php_code`
+- Callback Config: JSON field (or monospace `<textarea>` for `php_code`)
+- Input Schema / Output Schema
+- show_in_rest, show_in_mcp, mcp_type, mcp_servers
+- readonly, destructive, idempotent (tri-state selects)
+
+### Variant B — source=plugin/theme/core (Override row)
+Identity section (read-only info panel — not editable inputs):
+- Slug, Label, Description, Category, Callback Type, Callback Config
+
+Override fields (fully editable, instant save):
+- site_allowed toggle
+- show_in_rest, show_in_mcp, mcp_type, mcp_servers
+- readonly, destructive, idempotent (tri-state selects)
+
+---
+
+## `AbilitiesList` columns and filters
+
+| Column | Notes |
+|---|---|
+| Slug | Strip `acrossai-abilities/` prefix for display |
+| Label | — |
+| Category | — |
+| Source | Badge: **Custom** / **Plugin** / **Theme** / **Core** |
+| Status | Badge: **Draft** / **Published** (source=db only) |
+| Callback Type | — |
+| MCP Type | — |
+| Actions | Edit / Delete |
+
+**Filters**: search (slug/label), source, status (Draft / Published)
+**Bulk actions**: Publish, Unpublish, Delete
+
+---
+
+## Files to Create
+
+### Admin PHP shell
+```
+admin/Partials/
+├── AcrossAI_Abilities_Menu.php    — singleton, add_submenu_page under acrossai-abilities-manager
+├── AcrossAI_Abilities_Page.php    — renders <div id="acrossai-abilities-root"></div>
+└── AcrossAI_Abilities_Assets.php  — wp_enqueue_script('acrossai-abilities', build/js/abilities.js)
+                                      wp_add_inline_script():
+                                        window.acrossaiAbilities = { restNamespace, nonce, currentUserId }
+```
+
+### React UI
+```
+src/js/abilities/
+├── index.js                           — mounts root into #acrossai-abilities-root
+├── api/
+│   └── useAbilities.js                — fetchList(params), fetchOne(id), create(data),
+│                                        update(id, fields), remove(id), fetchCategories()
+└── components/
+    ├── AbilitiesManager.jsx           — root: toggles list ↔ form
+    ├── AbilitiesList.jsx              — @wordpress/dataviews table (columns + filters + bulk)
+    └── AbilityForm.jsx                — @wordpress/dataforms
+                                         Variant A: all fields editable + Publish button
+                                         Variant B: identity read-only panel + override fields
+                                         php_code: monospace <textarea>
+
+src/scss/abilities/
+└── admin.scss
+```
+
+## Files to Modify (3)
+
+| File | Change |
+|---|---|
+| `webpack.config.js` | Add entry: `'js/abilities': 'src/js/abilities/index.js'` |
+| `includes/Main.php` | Add `admin_menu` hook → `AcrossAI_Abilities_Menu::instance()` |
+| `admin/Main.php` | Add `is_abilities_page()` helper + conditional enqueue for `acrossai-abilities` page |
+
+---
+
+## Reuse from existing code
+
+| Existing file | Reuse |
+|---|---|
+| `src/js/sitewide/` | `@wordpress/dataviews` + Redux store + REST client pattern reference |
+| `src/js/sitewide/components/AbilityEditPanel.jsx` | Override fields UI pattern reference |
+| `admin/Partials/LogsMenu.php` | Admin submenu singleton pattern reference |
+| `admin/Partials/LogsAssets.php` | Asset enqueue + `wp_add_inline_script()` pattern reference |
+
+---
+
+## Speckit commands — run in order
+
+### Step 1 — Create feature branch
+```
+/speckit.git.feature
+```
+When prompted, enter: `010-abilities-react-ui`
+
+---
+
+### Step 2 — Write the spec
+```
+/speckit.specify Abilities React UI and admin shell: create admin PHP shell (AcrossAI_Abilities_Menu singleton adds submenu under acrossai-abilities-manager, AcrossAI_Abilities_Page renders div#acrossai-abilities-root, AcrossAI_Abilities_Assets enqueues build/js/abilities.js and passes window.acrossaiAbilities={restNamespace,nonce,currentUserId} via wp_add_inline_script). React app in src/js/abilities/: index.js mounts root; api/useAbilities.js hooks for fetchList(params), fetchOne(id), create(data), update(id,fields) sparse update, remove(id), fetchCategories(); components/AbilitiesManager.jsx toggles between list and form views; components/AbilitiesList.jsx uses @wordpress/dataviews table with columns slug(strip acrossai-abilities/ prefix for display), label, category, source badge(Custom/Plugin/Theme/Core), status badge(Draft/Published for source=db only), callback_type, mcp_type, actions(edit/delete), filters(search, source, status), bulk actions(publish, unpublish, delete — no enable/disable, there is no enabled column); components/AbilityForm.jsx uses @wordpress/dataforms: Variant A (source=db, all fields editable: slug prefix read-only+suffix editable, label, description, category dropdown from REST, status badge+Publish button if draft, callback_type select, callback_config JSON field or monospace textarea for php_code, input_schema/output_schema, show_in_rest/show_in_mcp/mcp_type/mcp_servers, readonly/destructive/idempotent tri-state — NO enabled toggle, publish=always live) and Variant B (source!=db, identity fields label/description/category/callback as read-only info panel, override fields site_allowed/show_in_rest/show_in_mcp/mcp_type/mcp_servers/readonly/destructive/idempotent fully editable); no save button for existing abilities (every field change triggers instant POST /abilities/{id} sparse update); Publish button only for new draft abilities (POST /abilities/{id} with {status:publish}); src/scss/abilities/admin.scss for component styles; webpack entry js/abilities pointing to src/js/abilities/index.js; admin_menu hook in includes/Main.php; admin/Main.php gets is_abilities_page() helper + conditional enqueue.
+```
+
+---
+
+### Step 3 — Generate plan with memory context
+```
+/speckit.memory-md.plan-with-memory
+```
+
+---
+
+### Step 4 — Architecture + security validation
+```
+/speckit.architecture-guard.governed-plan
+/speckit.security-review.plan
+```
+
+---
+
+### Step 5 — Generate tasks
+```
+/speckit.architecture-guard.governed-tasks
+```
+
+---
+
+### Step 6 — Implement
+```
+/speckit.architecture-guard.governed-implement
+```
+
+---
+
+### Step 7 — Quality gates (run after implement)
+```bash
+# Build JS bundle
+npm run build
+
+# Confirm build output exists
+ls -la build/js/abilities.js
+ls -la build/js/abilities.asset.php
+
+# PHP syntax check all new files
+php -l admin/Partials/AcrossAI_Abilities_Menu.php
+php -l admin/Partials/AcrossAI_Abilities_Page.php
+php -l admin/Partials/AcrossAI_Abilities_Assets.php
+php -l includes/Main.php
+php -l admin/Main.php
+
+composer run phpcs
+composer run phpstan
+npm run lint:js
+```
+
+---
+
+### Step 8 — Post-implement review
+```
+/speckit.analyze
+/speckit.architecture-guard.architecture-review
+/speckit.security-review.staged
+```
+
+---
+
+### Step 9 — Save memory + commit
+```
+/speckit.memory-md.capture-from-diff
+/speckit.git.commit
+```
+
+---
+
+## Manual testing
+
+### Setup: ensure spec 009 test abilities exist
+```bash
+wp db query "SELECT ability_slug, label, status, source FROM wp_acrossai_abilities LIMIT 5;"
+# Expected: at least one source=db row; ideally one draft and one publish
+# If empty, insert:
+wp db query "
+INSERT INTO wp_acrossai_abilities
+  (ability_slug, label, description, category, status, source, callback_type, show_in_rest)
+VALUES
+  ('acrossai-abilities/ui-test-pub', 'UI Test Published', 'Published ability', 'site', 'publish', 'db', 'noop', 1),
+  ('acrossai-abilities/ui-test-draft', 'UI Test Draft', 'Draft ability', 'site', 'draft', 'db', 'noop', 1);
+"
+```
+
+### 1. Confirm webpack output
+```bash
+ls -la build/js/abilities.js
+ls -la build/js/abilities.asset.php
+# Expected: both files exist and abilities.js is non-zero size
+```
+
+### 2. Confirm admin submenu appears
+- Go to WP Admin → Abilities Manager
+- Expected: "Custom Abilities" submenu item visible
+
+### 3. Confirm React app mounts
+- Click "Custom Abilities" submenu
+- Open browser console — Expected: no JS errors
+- Expected: `<div id="acrossai-abilities-root">` contains rendered React content
+
+### 4. Confirm abilities list loads
+- Expected: table renders with ability rows
+- Expected: columns visible: Slug, Label, Category, Source, Status, Callback Type, MCP Type, Actions
+- Expected: source=db rows show "Custom" badge; source=plugin shows "Plugin" badge
+- Expected: `status=publish` rows show "Published" badge; `status=draft` rows show "Draft" badge
+
+### 5. Search filter
+- Type in the search box
+- Expected: list filters by slug/label
+
+### 6. Source filter
+- Select "Custom" from the source filter dropdown
+- Expected: only source=db rows visible
+
+### 7. Add New Ability — starts as draft
+- Click "Add New Ability"
+- Expected: form opens in Variant A mode (all fields editable)
+- Type a suffix (e.g. `form-test`) in the slug suffix field
+- Expected: `POST /abilities` fires immediately, row created with `status=draft`
+- Fill in Label → Expected: `POST /abilities/{id}` fires with only `{label: "..."}` (sparse)
+- Expected: no save button visible — every change auto-saves
+
+### 9. Publish button
+- Expected: "Publish" button visible when `status=draft`
+- Click Publish → Expected: `POST /abilities/{id}` with `{status: "publish"}`
+- Expected: badge changes from "Draft" to "Published", Publish button disappears
+
+### 10. Category dropdown populated
+- In Add New Ability form: Expected category `<select>` contains entries from `GET /ability-categories`
+- Expected: not empty
+
+### 11. php_code callback type
+- In a new or existing source=db ability, select Callback Type → `php_code`
+- Expected: monospace `<textarea>` appears labeled "PHP code (no opening tag). Variable `$input` contains the ability input."
+- Type code and change focus → Expected: sparse update fires immediately
+
+### 12. Edit ability — Variant A (source=db)
+- Click Edit on a source=db row
+- Expected: all fields are editable (no enabled toggle — `status=publish` means always live)
+- Change any field → Expected: saves instantly, no save button
+
+### 13. Edit ability — Variant B (source≠db override row)
+- If a source=plugin override row exists, click Edit
+- Expected: label, description, category, callback_type rendered as read-only info panel
+- Expected: site_allowed, show_in_rest, show_in_mcp, mcp_type, mcp_servers, readonly, destructive, idempotent are editable
+- Change an override field → Expected: saves instantly
+
+### 14. Slug prefix display
+- In the form, slug input shows `acrossai-abilities/` read-only prefix + editable suffix
+- Expected: user cannot edit the prefix portion
+- Expected: stored slug has full `acrossai-abilities/<suffix>` format
+
+### 15. Delete ability
+- Click Delete on `acrossai-abilities/form-test` → confirm dialog
+- Expected: row disappears, REST DELETE returns 204
+
+### 16. Bulk actions
+- Select multiple source=db rows
+- Expected: bulk action toolbar appears with Publish, Unpublish, Delete
+- Select "Unpublish" → Expected: all selected rows change to `status=draft` / "Draft" badge
+
+### 17. window.acrossaiAbilities data
+```js
+// In browser console on Custom Abilities page:
+console.log(window.acrossaiAbilities);
+// Expected: { restNamespace: 'acrossai-abilities-manager/v1', nonce: '<string>', currentUserId: <number> }
+```
+
+### 18. Feature 001 Sitewide Abilities page still works
+- Go to WP Admin → Abilities Manager → Sitewide Abilities
+- Expected: loads without errors, list renders, overrides save correctly
+
+### 19. Feature 001 Override Processor still works
+```bash
+wp eval "
+do_action('wp_abilities_api_init');
+\$ability = wp_get_ability('core/get-site-info');
+echo \$ability ? 'STILL WORKING' : 'BROKEN';
+"
+# Expected: STILL WORKING
+```
+
+---
+
+## What NOT to test (future specs)
+- Execution logger (Spec 006) — not yet started
+- Access control per-ability rules on custom abilities (Spec 003 extension)

--- a/docs/memory/ARCHITECTURE.md
+++ b/docs/memory/ARCHITECTURE.md
@@ -23,9 +23,13 @@ and a REST-API-first admin UI backed by @wordpress/dataviews.
   registrations at `plugins_loaded P20` via PATH A/B branching. Wires
   `wp_register_ability_args`, `wp_abilities_api_init`, and
   `mcp_adapter_expose_ability` directly in `boot()` (ARCH-ADV-001 deviation).
-- **`includes/Modules/Sitewide/Database/`**: BerlinDB table, query, schema,
-  and row classes for override persistence. `AcrossAI_Sitewide_Row::__construct()`
-  decodes `mcp_servers` JSON to `array|null`.
+- **`includes/Modules/Abilities/Database/`**: BerlinDB table, query, schema,
+  and row classes for the unified `wp_acrossai_abilities` table (24 columns).
+  `AcrossAI_Abilities_Row::__construct()` decodes `callback_config`, `input_schema`,
+  `output_schema`, and `mcp_servers` JSON fields to `array|null`.
+- **`includes/Modules/Sitewide/Database/`**: BerlinDB Sitewide classes — thin
+  wrappers that now point at `wp_acrossai_abilities` (same table as Abilities module).
+  `source != 'db'` rows are the sitewide override rows managed by this module.
 - **`includes/Modules/Sitewide/Rest/`**: REST sub-controller split:
   `AcrossAI_Sitewide_Abilities_Controller` (read), `AcrossAI_Sitewide_Override_Controller`
   (write), `AcrossAI_Sitewide_Bulk_Controller` (bulk), `AcrossAI_Sitewide_Mcp_Controller`

--- a/docs/memory/DECISIONS.md
+++ b/docs/memory/DECISIONS.md
@@ -1,5 +1,73 @@
 # Decisions
 
+---
+
+### 2026-05-22 — BerlinDB Table singletons must NOT have a private constructor (DEC-TABLE-SOFT-SINGLETON)
+
+**Context**
+`AcrossAI_Activator` calls `(new AcrossAI_Sitewide_Table())->maybe_upgrade()` directly. Adding `private function __construct()` to `AcrossAI_Sitewide_Table` — even as part of enforcing the singleton pattern — causes a fatal error because Activator is not a subclass and cannot call a private constructor. FR-015 forbids touching Activator.
+
+**Decision**
+BerlinDB `Table` subclasses in this plugin use a **soft singleton**: `$_instance` + `instance()` are present but no `private function __construct()` is added. Singleton behaviour is convention-enforced, not language-enforced. This is the required pattern for any Table class that is also instantiated via `new` elsewhere (e.g., in Activator or tests).
+
+BerlinDB `Query`, `Schema`, and `Row` subclasses are free to use private constructors because they are never directly instantiated via `new` outside their own `instance()` method.
+
+**Rule**
+- `AcrossAI_Sitewide_Table` and any future `*_Table` class: **no `private function __construct()`**
+- `*_Query` classes: private constructor is fine (always accessed via `::instance()`)
+- `*_Row` / `*_Schema` classes: BerlinDB instantiates these internally — do not add constructors that break parent behaviour
+
+**Future mistake prevented**
+Architecture reviews flagging "missing private constructor" on a Table class MUST check whether any other class calls `new ClassName()` before adding the private constructor. If they do, keep the soft singleton pattern.
+
+**Evidence**
+Feature 008 (2026-05-22): Adding `private function __construct()` to `AcrossAI_Sitewide_Table` caused a PHP fatal error on plugin activation — `AcrossAI_Activator::activate()` calls `new AcrossAI_Sitewide_Table()` on line 40. Fix: remove private constructor, keep `instance()` method.
+
+**Where to look next**
+`includes/AcrossAI_Activator.php` (line 40 — direct instantiation),
+`includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Table.php` (soft singleton example)
+
+---
+
+### 2026-05-22 — JSON registry fields get a 64 KB size guard at the DB layer (DEC-JSON-SIZE-GUARD)
+
+**Context**
+TASK-SEC-001 (security review, Feature 008): `save_override()` now encodes four registry-driven JSON fields instead of one hardcoded `mcp_servers` field. The reviewer flagged that oversized payloads could flow through the expanded path without a DB-layer boundary.
+
+**Decision**
+Add a 64 KB `strlen()` guard inside the JSON registry loop in `save_override()`. If `wp_json_encode()` produces a string longer than 65 536 bytes, store `null` for that field and continue (same behaviour as encode failure). This mirrors the 64 KB php_code size limit stated in the spec and is belt-and-suspenders only — caller-side (REST layer) validation remains required and is the primary enforcement point (N4 advisory).
+
+**Rule**
+The constant `$max_json_bytes = 65536` is defined locally in `save_override()`. If ever changed, update both the DB layer and the REST validator (Spec 009 `AcrossAI_Abilities_Validator`).
+
+**Why not depth-limit here?**
+`json_decode()` default max depth is 512. Enforcing a lower depth limit at the DB layer requires a recursive check or try/catch that adds complexity with low marginal gain for admin-only data. Depth validation is delegated to Spec 009's `validate_schema()`.
+
+**Where to look next**
+`AcrossAI_Sitewide_Query::save_override()` (JSON registry loop),
+`AcrossAI_Abilities_Validator` (Spec 009 — depth validation)
+
+---
+
+### 2026-05-22 — by_source() is an authorization-free DB helper; all callers must gate it (DEC-BY-SOURCE-AUTHZ)
+
+**Context**
+TASK-SEC-002 (security review, Feature 008): `by_source()` is public and returns all matching records with no built-in capability check. The reviewer flagged that a future caller could accidentally expose ability metadata without a permission gate.
+
+**Decision**
+Keep `by_source()` as a raw DB-layer helper with no internal capability check. The authorization contract is documented in the docblock with an explicit `AUTHORIZATION CONTRACT` header naming the risk (OWASP A01:2025) and the canonical gate (REST `permission_callback`). This is the same pattern as all other Query methods in the plugin.
+
+Adding a capability check inside the DB layer would couple access-control logic to the query layer, break server-side internal callers (e.g., the Processor which runs before a user context exists), and violate separation of concerns.
+
+**Rule**
+Every public method on `*_Query` classes is an authorization-free data accessor. Access control belongs in the REST controller `permission_callback` or the admin page capability check — never inside the Query class.
+
+**Where to look next**
+`AcrossAI_Sitewide_Query::by_source()` (docblock with AUTHORIZATION CONTRACT note),
+`AcrossAI_Abilities_Rest_Controller::check_permission()` (Spec 009 — canonical gate)
+
+---
+
 ## Entry Lifecycle
 
 Each decision follows this lifecycle:

--- a/includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Query.php
+++ b/includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Query.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * BerlinDB Query class for ability override records.
+ * BerlinDB Query class for ability records.
  *
  * @package    AcrossAI_Abilities_Manager
  * @subpackage AcrossAI_Abilities_Manager/includes/Modules/Sitewide/Database
@@ -15,7 +15,7 @@ use BerlinDB\Database\Query;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Provides CRUD operations for the acrossai_abilities_overwrite table.
+ * Provides CRUD operations for the acrossai_abilities table.
  *
  * @since 0.1.0
  */
@@ -40,7 +40,7 @@ class AcrossAI_Sitewide_Query extends Query {
 	 *
 	 * @var string
 	 */
-	protected $table_name = 'acrossai_abilities_overwrite';
+	protected $table_name = 'acrossai_abilities';
 
 	/**
 	 * Singleton instance.
@@ -48,6 +48,15 @@ class AcrossAI_Sitewide_Query extends Query {
 	 * @var AcrossAI_Sitewide_Query|null
 	 */
 	protected static $_instance = null;
+
+	/**
+	 * Private constructor — enforces singleton pattern.
+	 *
+	 * @since  0.1.0
+	 */
+	private function __construct() {
+		parent::__construct();
+	}
 
 	/**
 	 * Get the singleton instance of this query.
@@ -90,19 +99,14 @@ class AcrossAI_Sitewide_Query extends Query {
 	 * On INSERT: sets created_at and created_by.
 	 * On UPDATE: sets updated_at and updated_by only — does NOT overwrite created_at/created_by (A1/A2).
 	 *
+	 * JSON field size/depth validation is the caller's responsibility.
+	 *
 	 * @since  0.1.0
 	 * @param  string $slug   Ability slug.
 	 * @param  array  $fields Field values to save.
 	 * @return bool
 	 */
 	public function save_override( string $slug, array $fields ): bool {
-		// JSON-encode mcp_servers before passing to BerlinDB — the column is longtext and
-		// BerlinDB does NOT auto-encode PHP arrays. Without this the DB receives "[Array]"
-		// instead of valid JSON, and mcp_servers would be lost on read.
-		if ( isset( $fields['mcp_servers'] ) && is_array( $fields['mcp_servers'] ) ) {
-			$fields['mcp_servers'] = wp_json_encode( $fields['mcp_servers'] );
-		}
-
 		// Cast PHP booleans to integers for all tinyint tri-state columns.
 		// $wpdb->insert/update auto-detects format: is_int() → %d, otherwise → %s.
 		// PHP false is not an int, so without this cast it gets format %s → '' (empty
@@ -114,6 +118,41 @@ class AcrossAI_Sitewide_Query extends Query {
 		foreach ( $tri_state_columns as $col ) {
 			if ( array_key_exists( $col, $fields ) && is_bool( $fields[ $col ] ) ) {
 				$fields[ $col ] = (int) $fields[ $col ]; // true → 1, false → 0.
+			}
+		}
+
+		// F2 enum guards — strip invalid enum values before BerlinDB write.
+		// Placed after tri-state cast (FR-018: tri-state block must come first).
+		if ( array_key_exists( 'status', $fields ) && null !== $fields['status'] ) {
+			if ( ! in_array( $fields['status'], array( 'draft', 'publish' ), true ) ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'acrossai: invalid status value blocked before DB write' );
+				unset( $fields['status'] );
+			}
+		}
+		if ( array_key_exists( 'callback_type', $fields ) && null !== $fields['callback_type'] ) {
+			if ( ! in_array( $fields['callback_type'], array( 'noop', 'filter_hook', 'wp_remote_post', 'php_code' ), true ) ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'acrossai: invalid callback_type value blocked before DB write' );
+				unset( $fields['callback_type'] );
+			}
+		}
+
+		// JSON-encode all registered JSON longtext fields before passing to BerlinDB.
+		// BerlinDB does NOT auto-encode PHP arrays. Registry is extensible via
+		// acrossai_abilities_json_fields filter (SC-005).
+		// On encode failure, or if the encoded string exceeds 64 KB, store null.
+		// TASK-SEC-001: This is a DB-layer size guard; caller-side validation is still
+		// required before reaching this method (N4 advisory).
+		$max_json_bytes = 65536; // 64 KB — consistent with php_code field limit (spec).
+		foreach ( AcrossAI_Sitewide_Row::get_json_fields() as $json_field ) {
+			if ( isset( $fields[ $json_field ] ) && is_array( $fields[ $json_field ] ) ) {
+				$encoded = wp_json_encode( $fields[ $json_field ] );
+				if ( false === $encoded || strlen( $encoded ) > $max_json_bytes ) {
+					$fields[ $json_field ] = null;
+				} else {
+					$fields[ $json_field ] = $encoded;
+				}
 			}
 		}
 
@@ -200,5 +239,44 @@ class AcrossAI_Sitewide_Query extends Query {
 			}
 		}
 		return $indexed;
+	}
+
+	/**
+	 * Retrieve all ability rows matching the given source value.
+	 *
+	 * Uses number => 0 (BerlinDB unlimited query — NOT -1, which absint() converts
+	 * to 1, silently limiting results to a single row).
+	 *
+	 * AUTHORIZATION CONTRACT (TASK-SEC-002):
+	 * This is a raw DB-layer helper. It performs no capability check.
+	 * Every caller that surfaces results to a HTTP response or admin screen
+	 * MUST call current_user_can( 'manage_options' ) before invoking this method.
+	 * Callers that skip this check create an unauthenticated data-disclosure path
+	 * (OWASP A01:2025). REST controller permission_callback is the canonical gate.
+	 *
+	 * @since  0.1.0
+	 * @param  string|null $source Source value to match (e.g. 'db', 'plugin', 'core').
+	 *                             Returns empty array for null or empty string (FR-011).
+	 * @return AcrossAI_Sitewide_Row[]
+	 */
+	public function by_source( ?string $source ): array {
+		if ( null === $source || '' === $source ) {
+			return array();
+		}
+
+		$results = $this->query(
+			array(
+				'source' => $source,
+				'number' => 0,
+			)
+		);
+
+		$rows = array();
+		foreach ( $results as $row ) {
+			if ( $row instanceof AcrossAI_Sitewide_Row ) {
+				$rows[] = $row;
+			}
+		}
+		return $rows;
 	}
 }

--- a/includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Row.php
+++ b/includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Row.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * BerlinDB Row class for a single ability override record.
+ * BerlinDB Row class for a single ability record.
  *
  * @package    AcrossAI_Abilities_Manager
  * @subpackage AcrossAI_Abilities_Manager/includes/Modules/Sitewide/Database
@@ -16,7 +16,7 @@ use AcrossAI_Abilities_Manager\Includes\Utilities\AcrossAI_Sanitizer;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Represents a single row from the acrossai_abilities_overwrite table.
+ * Represents a single row from the acrossai_abilities table.
  *
  * Tinyint → PHP bool/null casting is delegated to AcrossAI_Sanitizer::cast_tri_state()
  * and MUST NOT be duplicated here (RF-02).
@@ -25,16 +25,24 @@ defined( 'ABSPATH' ) || exit;
  *
  * @property int         $id
  * @property string      $ability_slug
+ * @property string|null $label
+ * @property string|null $description
+ * @property string|null $category
+ * @property string      $status
  * @property string|null $provider
- * @property string|null $source
+ * @property string      $source
  * @property bool|null   $site_allowed
- * @property bool|null   $readonly
- * @property bool|null   $destructive
- * @property bool|null   $idempotent
+ * @property string      $callback_type
+ * @property array|null  $callback_config
+ * @property array|null  $input_schema
+ * @property array|null  $output_schema
  * @property bool|null   $show_in_rest
  * @property bool|null   $show_in_mcp
  * @property string|null $mcp_type
- * @property string|null $mcp_servers
+ * @property array|null  $mcp_servers
+ * @property bool|null   $readonly
+ * @property bool|null   $destructive
+ * @property bool|null   $idempotent
  * @property string      $created_at
  * @property string|null $updated_at
  * @property int|null    $created_by
@@ -57,6 +65,34 @@ class AcrossAI_Sitewide_Row extends Row {
 	public $ability_slug = '';
 
 	/**
+	 * Display name. NULL = no override (FR-021: nullable).
+	 *
+	 * @var string|null
+	 */
+	public $label = null;
+
+	/**
+	 * Full description.
+	 *
+	 * @var string|null
+	 */
+	public $description = null;
+
+	/**
+	 * Organizational category.
+	 *
+	 * @var string|null
+	 */
+	public $category = null;
+
+	/**
+	 * Lifecycle status. Allowed values: 'draft', 'publish'.
+	 *
+	 * @var string
+	 */
+	public $status = 'draft';
+
+	/**
 	 * Provider string.
 	 *
 	 * @var string|null
@@ -64,11 +100,11 @@ class AcrossAI_Sitewide_Row extends Row {
 	public $provider = null;
 
 	/**
-	 * Source enum: plugin|theme|core|db.
+	 * Source (origin of the record). Default 'db'.
 	 *
-	 * @var string|null
+	 * @var string
 	 */
-	public $source = null;
+	public $source = 'db';
 
 	/**
 	 * Whether the ability is allowed site-wide. NULL = use registry default.
@@ -78,25 +114,32 @@ class AcrossAI_Sitewide_Row extends Row {
 	public $site_allowed = null;
 
 	/**
-	 * Whether the ability is read-only. NULL = use registry default.
+	 * Callback type. Default 'noop'.
 	 *
-	 * @var bool|null
+	 * @var string
 	 */
-	public $readonly = null;
+	public $callback_type = 'noop';
 
 	/**
-	 * Whether the ability is destructive. NULL = use registry default.
+	 * Callback configuration (decoded JSON array). NULL = not configured.
 	 *
-	 * @var bool|null
+	 * @var array|null
 	 */
-	public $destructive = null;
+	public $callback_config = null;
 
 	/**
-	 * Whether the ability is idempotent. NULL = use registry default.
+	 * Input JSON Schema (decoded array). NULL = no schema defined.
 	 *
-	 * @var bool|null
+	 * @var array|null
 	 */
-	public $idempotent = null;
+	public $input_schema = null;
+
+	/**
+	 * Output JSON Schema (decoded array). NULL = no schema defined.
+	 *
+	 * @var array|null
+	 */
+	public $output_schema = null;
 
 	/**
 	 * Whether the ability is shown in the REST API. NULL = use registry default.
@@ -122,9 +165,30 @@ class AcrossAI_Sitewide_Row extends Row {
 	/**
 	 * JSON-encoded MCP server IDs. NULL = all servers.
 	 *
-	 * @var string|null
+	 * @var array|null
 	 */
 	public $mcp_servers = null;
+
+	/**
+	 * Whether the ability is read-only. NULL = use registry default.
+	 *
+	 * @var bool|null
+	 */
+	public $readonly = null;
+
+	/**
+	 * Whether the ability is destructive. NULL = use registry default.
+	 *
+	 * @var bool|null
+	 */
+	public $destructive = null;
+
+	/**
+	 * Whether the ability is idempotent. NULL = use registry default.
+	 *
+	 * @var bool|null
+	 */
+	public $idempotent = null;
 
 	/**
 	 * Creation timestamp.
@@ -155,7 +219,58 @@ class AcrossAI_Sitewide_Row extends Row {
 	public $updated_by = null;
 
 	/**
-	 * Constructor — casts tinyint fields to PHP bool/null via shared utility.
+	 * Return the list of column names that store JSON-encoded values.
+	 *
+	 * Blocklist guard (N1 / SC-005): the base list covers the four known JSON
+	 * longtext columns. Callers may extend via the filter, but any column name
+	 * that appears in the scalar blocklist is silently removed from the result
+	 * to prevent accidental JSON-decode of scalar columns.
+	 *
+	 * @since  0.1.0
+	 * @return string[] JSON field names safe for json_decode/wp_json_encode.
+	 */
+	public static function get_json_fields(): array {
+		$blocked_scalar_columns = array(
+			'id',
+			'ability_slug',
+			'label',
+			'description',
+			'category',
+			'status',
+			'provider',
+			'source',
+			'site_allowed',
+			'callback_type',
+			'show_in_rest',
+			'show_in_mcp',
+			'mcp_type',
+			'readonly',
+			'destructive',
+			'idempotent',
+			'created_at',
+			'updated_at',
+			'created_by',
+			'updated_by',
+		);
+
+		$base_json_fields = array( 'mcp_servers', 'callback_config', 'input_schema', 'output_schema' );
+
+		/**
+		 * Allow plugins/themes to register additional JSON-encoded longtext columns.
+		 *
+		 * @since 0.1.0
+		 * @param string[] $fields Base list of JSON column names.
+		 */
+		$json_fields = (array) apply_filters( 'acrossai_abilities_json_fields', $base_json_fields );
+
+		// Blocklist guard: remove any column that is a known scalar to prevent
+		// accidental decode of non-JSON columns (N1 security correction).
+		return array_values( array_diff( $json_fields, $blocked_scalar_columns ) );
+	}
+
+	/**
+	 * Constructor — casts tinyint fields to PHP bool/null via shared utility,
+	 * decodes all JSON longtext fields using the registry, and casts integer fields.
 	 *
 	 * @since  0.1.0
 	 * @param  object|array $item Raw DB row.
@@ -169,12 +284,13 @@ class AcrossAI_Sitewide_Row extends Row {
 			$this->{$field} = AcrossAI_Sanitizer::cast_tri_state( $this->{$field} );
 		}
 
-		// JSON-decode mcp_servers — stored as JSON longtext, must return as PHP array.
-		// Without this, the REST response would return a raw JSON string instead of an array,
-		// breaking the JS client which expects string[].
-		if ( null !== $this->mcp_servers ) {
-			$decoded           = json_decode( $this->mcp_servers, true );
-			$this->mcp_servers = is_array( $decoded ) ? $decoded : null;
+		// JSON-decode all registered JSON longtext fields.
+		// Registry is extensible via acrossai_abilities_json_fields filter (SC-005).
+		foreach ( self::get_json_fields() as $json_field ) {
+			if ( null !== $this->{$json_field} ) {
+				$decoded             = json_decode( $this->{$json_field}, true );
+				$this->{$json_field} = is_array( $decoded ) ? $decoded : null;
+			}
 		}
 
 		// Cast integer fields.

--- a/includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Schema.php
+++ b/includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Schema.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Database schema definition for the abilities overwrite table.
+ * Database schema definition for the unified abilities table.
  *
  * @package    AcrossAI_Abilities_Manager
  * @subpackage AcrossAI_Abilities_Manager/includes/Modules/Sitewide/Database
@@ -15,7 +15,7 @@ use BerlinDB\Database\Schema;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Schema class defining all 16 columns of the acrossai_abilities_overwrite table.
+ * Schema class defining all 25 columns of the acrossai_abilities table.
  *
  * @since 0.1.0
  */
@@ -49,6 +49,46 @@ class AcrossAI_Sitewide_Schema extends Schema {
 			'sortable'   => true,
 		),
 
+		// Display name (FR-021: nullable — override rows carry no label).
+		array(
+			'name'       => 'label',
+			'type'       => 'varchar',
+			'length'     => '255',
+			'allow_null' => true,
+			'default'    => null,
+			'searchable' => true,
+			'sortable'   => true,
+		),
+
+		// Full description.
+		array(
+			'name'       => 'description',
+			'type'       => 'longtext',
+			'allow_null' => true,
+			'default'    => null,
+			'searchable' => true,
+		),
+
+		// Organizational category.
+		array(
+			'name'       => 'category',
+			'type'       => 'varchar',
+			'length'     => '100',
+			'allow_null' => true,
+			'default'    => null,
+			'sortable'   => true,
+		),
+
+		// Lifecycle status. 20-char max, defaults to draft.
+		array(
+			'name'     => 'status',
+			'type'     => 'varchar',
+			'length'   => '20',
+			'null'     => false,
+			'default'  => 'draft',
+			'sortable' => true,
+		),
+
 		// Provider string.
 		array(
 			'name'       => 'provider',
@@ -59,17 +99,17 @@ class AcrossAI_Sitewide_Schema extends Schema {
 			'sortable'   => true,
 		),
 
-		// Source enum.
+		// Source origin of the record. Defaults to db.
 		array(
-			'name'       => 'source',
-			'type'       => 'varchar',
-			'length'     => '50',
-			'allow_null' => true,
-			'default'    => null,
-			'sortable'   => true,
+			'name'     => 'source',
+			'type'     => 'varchar',
+			'length'   => '50',
+			'null'     => false,
+			'default'  => 'db',
+			'sortable' => true,
 		),
 
-		// Tri-state boolean columns.
+		// Tri-state: site-wide allow override.
 		array(
 			'name'       => 'site_allowed',
 			'type'       => 'tinyint',
@@ -77,27 +117,41 @@ class AcrossAI_Sitewide_Schema extends Schema {
 			'allow_null' => true,
 			'default'    => null,
 		),
+
+		// Callback type (enum guard in save_override).
 		array(
-			'name'       => 'readonly',
-			'type'       => 'tinyint',
-			'length'     => '1',
+			'name'    => 'callback_type',
+			'type'    => 'varchar',
+			'length'  => '50',
+			'null'    => false,
+			'default' => 'noop',
+		),
+
+		// Callback configuration JSON.
+		array(
+			'name'       => 'callback_config',
+			'type'       => 'longtext',
 			'allow_null' => true,
 			'default'    => null,
 		),
+
+		// Input JSON Schema.
 		array(
-			'name'       => 'destructive',
-			'type'       => 'tinyint',
-			'length'     => '1',
+			'name'       => 'input_schema',
+			'type'       => 'longtext',
 			'allow_null' => true,
 			'default'    => null,
 		),
+
+		// Output JSON Schema.
 		array(
-			'name'       => 'idempotent',
-			'type'       => 'tinyint',
-			'length'     => '1',
+			'name'       => 'output_schema',
+			'type'       => 'longtext',
 			'allow_null' => true,
 			'default'    => null,
 		),
+
+		// REST and MCP visibility flags (tri-state).
 		array(
 			'name'       => 'show_in_rest',
 			'type'       => 'tinyint',
@@ -126,6 +180,29 @@ class AcrossAI_Sitewide_Schema extends Schema {
 		array(
 			'name'       => 'mcp_servers',
 			'type'       => 'longtext',
+			'allow_null' => true,
+			'default'    => null,
+		),
+
+		// Remaining tri-state boolean columns.
+		array(
+			'name'       => 'readonly',
+			'type'       => 'tinyint',
+			'length'     => '1',
+			'allow_null' => true,
+			'default'    => null,
+		),
+		array(
+			'name'       => 'destructive',
+			'type'       => 'tinyint',
+			'length'     => '1',
+			'allow_null' => true,
+			'default'    => null,
+		),
+		array(
+			'name'       => 'idempotent',
+			'type'       => 'tinyint',
+			'length'     => '1',
 			'allow_null' => true,
 			'default'    => null,
 		),

--- a/includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Table.php
+++ b/includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Table.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Database table definition for the abilities overwrite table.
+ * Database table definition for the unified abilities table.
  *
  * @package    AcrossAI_Abilities_Manager
  * @subpackage AcrossAI_Abilities_Manager/includes/Modules/Sitewide/Database
@@ -15,7 +15,7 @@ use BerlinDB\Database\Table;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Manages database table creation and upgrades for ability overrides.
+ * Manages database table creation and upgrades for the unified abilities table.
  *
  * @since 0.1.0
  */
@@ -26,7 +26,7 @@ class AcrossAI_Sitewide_Table extends Table {
 	 *
 	 * @var string
 	 */
-	protected $name = 'acrossai_abilities_overwrite';
+	protected $name = 'acrossai_abilities';
 
 	/**
 	 * Table version used to trigger maybe_upgrade().
@@ -41,7 +41,7 @@ class AcrossAI_Sitewide_Table extends Table {
 	 *
 	 * @var string
 	 */
-	protected $db_version_key = 'acrossai_abilities_overwrite_db_version';
+	protected $db_version_key = 'acrossai_abilities_db_version';
 
 	/**
 	 * Use per-site table prefix ($wpdb->prefix), not the network base prefix.
@@ -86,24 +86,35 @@ class AcrossAI_Sitewide_Table extends Table {
 	 */
 	protected function set_schema() {
 		$this->schema = "
-			`id` bigint(20) unsigned NOT NULL auto_increment,
-			`ability_slug` varchar(255) NOT NULL DEFAULT '',
-			`provider` varchar(100) DEFAULT NULL,
-			`source` varchar(50) DEFAULT NULL,
-			`site_allowed` tinyint(1) DEFAULT NULL,
-			`readonly` tinyint(1) DEFAULT NULL,
-			`destructive` tinyint(1) DEFAULT NULL,
-			`idempotent` tinyint(1) DEFAULT NULL,
-			`show_in_rest` tinyint(1) DEFAULT NULL,
-			`show_in_mcp` tinyint(1) DEFAULT NULL,
-			`mcp_type` varchar(100) DEFAULT NULL,
-			`mcp_servers` longtext DEFAULT NULL,
-			`created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			`updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			`created_by` bigint(20) unsigned DEFAULT NULL,
-			`updated_by` bigint(20) unsigned DEFAULT NULL,
+			`id`              bigint(20) unsigned NOT NULL auto_increment,
+			`ability_slug`    varchar(255) NOT NULL DEFAULT '',
+			`label`           varchar(255) DEFAULT NULL,
+			`description`     longtext DEFAULT NULL,
+			`category`        varchar(100) DEFAULT NULL,
+			`status`          varchar(20) NOT NULL DEFAULT 'draft',
+			`provider`        varchar(100) DEFAULT NULL,
+			`source`          varchar(50) NOT NULL DEFAULT 'db',
+			`site_allowed`    tinyint(1) DEFAULT NULL,
+			`callback_type`   varchar(50) NOT NULL DEFAULT 'noop',
+			`callback_config` longtext DEFAULT NULL,
+			`input_schema`    longtext DEFAULT NULL,
+			`output_schema`   longtext DEFAULT NULL,
+			`show_in_rest`    tinyint(1) DEFAULT NULL,
+			`show_in_mcp`     tinyint(1) DEFAULT NULL,
+			`mcp_type`        varchar(100) DEFAULT NULL,
+			`mcp_servers`     longtext DEFAULT NULL,
+			`readonly`        tinyint(1) DEFAULT NULL,
+			`destructive`     tinyint(1) DEFAULT NULL,
+			`idempotent`      tinyint(1) DEFAULT NULL,
+			`created_at`      datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			`updated_at`      datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			`created_by`      bigint(20) unsigned DEFAULT NULL,
+			`updated_by`      bigint(20) unsigned DEFAULT NULL,
 			PRIMARY KEY (`id`),
-			KEY `ability_slug` (`ability_slug`(191))
+			UNIQUE KEY `ability_slug` (`ability_slug`(191)),
+			KEY `idx_status` (`status`),
+			KEY `idx_source` (`source`),
+			KEY `idx_updated_at` (`updated_at`)
 		";
 	}
 }

--- a/specs/008-unified-abilities-table/checklists/requirements.md
+++ b/specs/008-unified-abilities-table/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Unified Abilities Table
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded (5 files, no new files)
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.

--- a/specs/008-unified-abilities-table/memory-synthesis.md
+++ b/specs/008-unified-abilities-table/memory-synthesis.md
@@ -1,0 +1,61 @@
+# Memory Synthesis
+
+## Current Scope
+
+Feature 008 renames the BerlinDB sitewide override table from `acrossai_abilities_overwrite` (16 columns) to `acrossai_abilities` (25 columns) and extends it with 9 new first-class record columns. It also adds a filterable JSON field registry and a by-source query method. Exactly 5 files are modified: the 4 Sitewide Database files + `uninstall.php`. No new files are created.
+
+---
+
+## Relevant Decisions
+
+- **DEC-NAMESPACE-CONVENTION** (Reason Included: All PHP files must use `AcrossAI_Abilities_Manager\Includes\*` underscore convention and ABSPATH guard, Status: Active, Source: DECISIONS.md)
+- **DEC-UTILITY-STATIC-ONLY** (Reason Included: JSON field registry must be a public static method; only orchestrators use singleton, Status: Active, Source: DECISIONS.md)
+- **ARCH-ADV-001** (Reason Included: boot() conditional hook deviation — out of scope for this feature but must not be disturbed by file edits, Status: Active-Deviation, Source: DECISIONS.md)
+- **BUG-BERLINDB-UNLIMITED** (Reason Included: `get_all_by_source()` must use `number => 0`; `absint(-1)=1` silently limits to 1 row, Status: Active, Source: BUGS.md)
+- **DEC-PROTECTED-SLUGS-PATTERN** (Reason Included: protected prefix filtering is out of scope for this feature but AC-QUERY-LAYER-FILTERING constraint applies to any future query extensions, Status: Active, Source: DECISIONS.md)
+
+---
+
+## Active Architecture Constraints
+
+- **AC-HOOKS-MAIN** (Reason Included: `includes/Main.php` MUST NOT be modified per FR-015, Source: CONSTITUTION.md §I)
+- **AC-FILE-HEADER-PATTERN** (Reason Included: All 5 updated files must keep `@package AcrossAI_Abilities_Manager`, `@subpackage` full path, `@since 0.1.0`, Source: ARCHITECTURE.md)
+- **SEC-03** (Reason Included: `AcrossAI_Sitewide_Table::$global = false` is an explicit multisite safety contract and MUST remain set in the updated Table class, Source: security-constraints.md)
+
+---
+
+## Accepted Deviations
+
+- **ARCH-ADV-001** (Reason Included: boot() conditional hook deviation is pre-existing and must not be disturbed, Status: Accepted-Deviation)
+- **FR-017 / FR-018** (Reason Included: Spec explicitly prohibits bumping `$version` and prohibits editing 3 blocks in `save_override()` — these are intentional constraints not deviations, Status: Spec-Mandated)
+
+---
+
+## Relevant Security Constraints
+
+- **SEC-03** (Reason Included: `$global = false` per-site prefix — MUST remain in Table; ensures multisite isolation, Source: security-constraints.md)
+- **SEC-02** (Reason Included: `before_save` hook fires on sanitized `$fields` only; the JSON encoding loop in `save_override()` runs before the hook so the encoded fields are sanitized, Source: security-constraints.md)
+- **SEC-04** (Reason Included: strict type comparison — `is_array()` used for JSON encode guard, not loose `==`, Source: security-constraints.md)
+
+---
+
+## Related Historical Lessons
+
+- **BUG-BERLINDB-UNLIMITED** (Reason Included: `get_all_by_source()` is an unlimited query; must use `'number' => 0`, never `'number' => -1` or `'number' => 9999`)
+- **BUG-PARTIAL-HOOK-FIELDS** (Reason Included: `save_override()` fires hooks; fetch complete row after save for full 25-field payload, not local `$fields` subset)
+- **FR-010 JSON encode failure path** (Reason Included: If `wp_json_encode()` returns `false` for a JSON field, store `null` and continue — do not abort the entire save)
+
+---
+
+## Conflict Warnings
+
+- None. The 5-file constraint (FR-015) is a hard boundary — no hooks in Main.php, no Activator changes, no test modifications. No conflict with existing decisions.
+- ARCHITECTURE.md already describes the post-feature state (`acrossai_abilities`, Sitewide as thin wrapper) — this is prospective documentation, not a conflict.
+
+---
+
+## Retrieval Notes
+
+- Index entries considered: DEC-NAMESPACE-CONVENTION, DEC-UTILITY-STATIC-ONLY, ARCH-ADV-001, BUG-BERLINDB-UNLIMITED, BUG-PARTIAL-HOOK-FIELDS, AC-HOOKS-MAIN, AC-FILE-HEADER-PATTERN, SEC-03, SEC-02, SEC-04
+- Source sections read: DECISIONS.md (first 80 lines), BUGS.md (first 80 lines), ARCHITECTURE.md (full), INDEX.md
+- Budget status: Within limits (5 decisions, 3 constraints, 2 deviations, 3 bug patterns selected)

--- a/specs/008-unified-abilities-table/plan.md
+++ b/specs/008-unified-abilities-table/plan.md
@@ -1,0 +1,598 @@
+# Implementation Plan: Unified Abilities Table (008)
+
+**Branch**: `008-unified-abilities-table` | **Date**: 2026-05-22 | **Status**: Ready for Implementation
+
+> **Plan Corrections Applied (2026-05-22)**: V1 — method renamed to `by_source()` per FR-019; V2 — `status` column narrowed to `varchar(20)` per FR-020; V3 — `label` made nullable per FR-021.
+>
+> **Security Re-Review Corrections (2026-05-22)**: N1 — F1 guard changed from allowlist to blocklist (restores filter extensibility per SC-005/FR-009); N2 — `$status` docblock corrected to `draft|publish`; N3 — `by_source()` docblock gains `manage_options` caller-responsibility note.
+
+---
+
+## Summary
+
+Rename the BerlinDB sitewide override table from `acrossai_abilities_overwrite` (16 columns) to `acrossai_abilities` (24 columns) and extend it with 8 new first-class record fields. Add a single filterable JSON field registry and a by-source query method. **Exactly 5 existing files are modified; zero new files are created.**
+
+**Technical Approach**:
+- Table rename + 8-column extension in Schema + Table (raw SQL schema)
+- JSON field registry (`get_json_fields()`) as `public static` on Row; called by both Row constructor and Query save method
+- `by_source()` added to Query; returns `[]` immediately for empty/null source (FR-019)
+- `save_override()` JSON encoding loop replaces the single `mcp_servers` hardcoded block; 3 existing blocks remain unchanged (FR-018)
+- `uninstall.php` gains DROP + delete_option for new names; old lines remain for backward-compat cleanup
+
+---
+
+## Constitution & Memory Check
+
+✅ **FR-015**: All changes confined to 5 files — Schema, Table, Row, Query, uninstall.php. Main.php, Activator, test files untouched.  
+✅ **FR-017**: `AcrossAI_Sitewide_Table::$version` stays `'1.0.0'` — never bumped.  
+✅ **SEC-03**: `$global = false` retained in Table (multisite isolation).  
+✅ **BUG-BERLINDB-UNLIMITED**: `by_source()` uses `'number' => 0` (not `-1`).  
+✅ **DEC-UTILITY-STATIC-ONLY**: `get_json_fields()` is `public static`; no instance state.  
+✅ **AC-FILE-HEADER-PATTERN**: All file headers retain `@package`, `@subpackage`, `@since 0.1.0`.  
+✅ **FR-010 failure path**: If `wp_json_encode()` returns `false`, field is stored as `null`; save continues for remaining fields.  
+
+No hard conflicts with existing decisions. No Constitution violations detected.
+
+---
+
+## Data Model
+
+### Table: `{prefix}acrossai_abilities` (24 columns)
+
+| # | Column | Type | Default | Notes |
+|---|--------|------|---------|-------|
+| 1 | `id` | `bigint(20) unsigned` | — | AUTO_INCREMENT, PRIMARY KEY |
+| 2 | `ability_slug` | `varchar(255)` | `''` | UNIQUE KEY (191 prefix) |
+| 3 | `label` | `varchar(255)` | NULL | NEW — display name; nullable (FR-021) |
+| 4 | `description` | `longtext` | NULL | NEW |
+| 5 | `category` | `varchar(100)` | NULL | NEW |
+| 6 | `status` | `varchar(20)` | `'draft'` | NEW — FR-004, FR-020. publish=always live, draft=not live |
+| 7 | `provider` | `varchar(100)` | NULL | existing |
+| 8 | `source` | `varchar(50)` | `'db'` | existing; default updated (FR-006) |
+| 9 | `site_allowed` | `tinyint(1)` | NULL | existing tri-state |
+| 10 | `callback_type` | `varchar(50)` | `'noop'` | NEW — FR-007 |
+| 11 | `callback_config` | `longtext` | NULL | NEW — JSON (FR-008) |
+| 12 | `input_schema` | `longtext` | NULL | NEW — JSON (FR-008) |
+| 13 | `output_schema` | `longtext` | NULL | NEW — JSON (FR-008) |
+| 14 | `show_in_rest` | `tinyint(1)` | NULL | existing tri-state |
+| 15 | `show_in_mcp` | `tinyint(1)` | NULL | existing tri-state |
+| 16 | `mcp_type` | `varchar(100)` | NULL | existing |
+| 17 | `mcp_servers` | `longtext` | NULL | existing — JSON (FR-008) |
+| 18 | `readonly` | `tinyint(1)` | NULL | existing tri-state |
+| 19 | `destructive` | `tinyint(1)` | NULL | existing tri-state |
+| 20 | `idempotent` | `tinyint(1)` | NULL | existing tri-state |
+| 21 | `created_at` | `datetime` | `CURRENT_TIMESTAMP` | existing |
+| 22 | `updated_at` | `datetime` | `CURRENT_TIMESTAMP` | existing |
+| 23 | `created_by` | `bigint(20) unsigned` | NULL | existing |
+| 24 | `updated_by` | `bigint(20) unsigned` | NULL | existing |
+
+### Indexes (FR-016 — exactly these 5)
+
+```sql
+PRIMARY KEY (`id`)
+UNIQUE KEY `ability_slug` (`ability_slug`(191))
+KEY `idx_status` (`status`)
+KEY `idx_source` (`source`)
+KEY `idx_updated_at` (`updated_at`)
+```
+
+> **Note**: The existing `KEY ability_slug (ability_slug(191))` becomes `UNIQUE KEY`. The old `KEY updated_at` does not exist; `idx_updated_at` is new.
+
+### JSON Field Registry
+
+A single `public static` method on `AcrossAI_Sitewide_Row` governs which fields are stored as JSON and decoded on read / encoded on save:
+
+```php
+/**
+ * Filterable list of fields stored as JSON in the database (FR-009).
+ *
+ * F1 SECURITY GUARD: Injected field names are validated against a blocklist of
+ * protected scalar columns before use. Non-longtext scalar columns (id, ability_slug,
+ * status, provider, etc.) cannot be injected via the filter — doing so would silently
+ * corrupt Row properties in __construct() by running json_decode() on non-JSON scalar
+ * values. Third parties can safely add NEW longtext/JSON columns via the filter;
+ * only the 21 protected scalar column names are rejected.
+ *
+ * @since 0.1.0
+ * @return string[]
+ */
+public static function get_json_fields(): array {
+    // Blocked: all non-JSON scalar columns — must never be processed with json_decode().
+    // Running json_decode() on these would corrupt their values (e.g. json_decode('draft') = null).
+    $blocked_scalar_columns = array(
+        'id', 'ability_slug', 'label', 'description', 'category', 'status',
+        'provider', 'source', 'site_allowed', 'callback_type',
+        'show_in_rest', 'show_in_mcp', 'mcp_type', 'readonly', 'destructive',
+        'idempotent', 'created_at', 'updated_at', 'created_by', 'updated_by',
+    );
+
+    $fields = apply_filters(
+        'acrossai_abilities_json_fields',
+        array( 'mcp_servers', 'callback_config', 'input_schema', 'output_schema' )
+    );
+
+    // F1: Reject any field name that is a known non-JSON scalar column.
+    // Prevents filter injection of protected column names that would be corrupted by json_decode().
+    // Third parties can add NEW longtext/JSON columns safely via this filter.
+    return array_values(
+        array_filter(
+            (array) $fields,
+            static function ( $field ) use ( $blocked_scalar_columns ) {
+                return ! in_array( $field, $blocked_scalar_columns, true );
+            }
+        )
+    );
+}
+```
+
+Called from:
+- `AcrossAI_Sitewide_Row::__construct()` — decode each field: `json_decode → array|null`
+- `AcrossAI_Sitewide_Query::save_override()` — encode each field: `array → wp_json_encode → string|null`
+
+> **Security note (F1)**: The blocklist inside `get_json_fields()` blocks all 21 known scalar columns from being treated as JSON fields. Third parties can safely add genuinely new longtext/JSON columns by returning them from the `acrossai_abilities_json_fields` filter — only blocked scalar column names are rejected. This prevents silent Row property corruption from injected scalar field names.
+
+---
+
+## File-by-File Implementation Plan
+
+### File 1: `AcrossAI_Sitewide_Table.php`
+
+**Purpose**: Table manager class — drives `CREATE TABLE` DDL + upgrade lifecycle.
+
+**Changes**:
+
+```diff
+- protected $name = 'acrossai_abilities_overwrite';
++ protected $name = 'acrossai_abilities';
+
+- protected $db_version_key = 'acrossai_abilities_overwrite_db_version';
++ protected $db_version_key = 'acrossai_abilities_db_version';
+
+  protected $version = '1.0.0'; // MUST NOT change (FR-017)
+  protected $global  = false;   // MUST remain false (SEC-03)
+```
+
+**`set_schema()` full replacement** — 24 columns + 5 indexes (FR-002, FR-016):
+
+```php
+protected function set_schema() {
+    $this->schema = "
+        `id` bigint(20) unsigned NOT NULL auto_increment,
+        `ability_slug` varchar(255) NOT NULL DEFAULT '',
+        `label` varchar(255) DEFAULT NULL,
+        `description` longtext DEFAULT NULL,
+        `category` varchar(100) DEFAULT NULL,
+        `status` varchar(20) NOT NULL DEFAULT 'draft',
+        `provider` varchar(100) DEFAULT NULL,
+        `source` varchar(50) NOT NULL DEFAULT 'db',
+        `site_allowed` tinyint(1) DEFAULT NULL,
+        `callback_type` varchar(50) NOT NULL DEFAULT 'noop',
+        `callback_config` longtext DEFAULT NULL,
+        `input_schema` longtext DEFAULT NULL,
+        `output_schema` longtext DEFAULT NULL,
+        `show_in_rest` tinyint(1) DEFAULT NULL,
+        `show_in_mcp` tinyint(1) DEFAULT NULL,
+        `mcp_type` varchar(100) DEFAULT NULL,
+        `mcp_servers` longtext DEFAULT NULL,
+        `readonly` tinyint(1) DEFAULT NULL,
+        `destructive` tinyint(1) DEFAULT NULL,
+        `idempotent` tinyint(1) DEFAULT NULL,
+        `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        `created_by` bigint(20) unsigned DEFAULT NULL,
+        `updated_by` bigint(20) unsigned DEFAULT NULL,
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `ability_slug` (`ability_slug`(191)),
+        KEY `idx_status` (`status`),
+        KEY `idx_source` (`source`),
+        KEY `idx_updated_at` (`updated_at`)
+    ";
+}
+```
+
+**Acceptance Criteria**:
+- `$name === 'acrossai_abilities'`
+- `$db_version_key === 'acrossai_abilities_db_version'`
+- `$version === '1.0.0'` (unchanged)
+- `$global === false` (unchanged)
+- `set_schema()` SQL contains exactly 24 column definitions
+- Exactly 5 indexes present: PRIMARY KEY, UNIQUE KEY `ability_slug`, KEY `idx_status`, KEY `idx_source`, KEY `idx_updated_at`
+
+---
+
+### File 2: `AcrossAI_Sitewide_Schema.php`
+
+**Purpose**: BerlinDB Schema subclass — column metadata used by Query for search/sort/filter introspection.
+
+**Changes**: Add 8 new column definitions to `$columns` array; update `source` default to `'db'`.
+
+New columns to insert **after** the `ability_slug` column definition and before `provider`:
+
+```php
+// Display fields (NEW).
+array(
+    'name'       => 'label',
+    'type'       => 'varchar',
+    'length'     => '255',
+    'allow_null' => true,
+    'default'    => null,
+    'searchable' => true,
+    'sortable'   => true,
+),
+array(
+    'name'       => 'description',
+    'type'       => 'longtext',
+    'allow_null' => true,
+    'default'    => null,
+    'searchable' => true,
+),
+array(
+    'name'     => 'category',
+    'type'     => 'varchar',
+    'length'   => '100',
+    'allow_null' => true,
+    'default'  => null,
+    'sortable' => true,
+),
+
+// Lifecycle fields (NEW).
+array(
+    'name'     => 'status',
+    'type'     => 'varchar',
+    'length'   => '20',
+    'null'     => false,
+    'default'  => 'draft',
+    'sortable' => true,
+),
+```
+
+Update `source` default (was `null`, must be `'db'` per FR-006):
+
+```diff
+  array(
+      'name'       => 'source',
+      'type'       => 'varchar',
+      'length'     => '50',
+-     'allow_null' => true,
+-     'default'    => null,
++     'null'       => false,
++     'default'    => 'db',
+      'sortable'   => true,
+  ),
+```
+
+New columns to insert **after** the `site_allowed` column definition:
+
+```php
+// Callback fields (NEW).
+array(
+    'name'    => 'callback_type',
+    'type'    => 'varchar',
+    'length'  => '50',
+    'null'    => false,
+    'default' => 'noop',
+),
+array(
+    'name'       => 'callback_config',
+    'type'       => 'longtext',
+    'allow_null' => true,
+    'default'    => null,
+),
+
+// Schema fields (NEW).
+array(
+    'name'       => 'input_schema',
+    'type'       => 'longtext',
+    'allow_null' => true,
+    'default'    => null,
+),
+array(
+    'name'       => 'output_schema',
+    'type'       => 'longtext',
+    'allow_null' => true,
+    'default'    => null,
+),
+```
+
+**Acceptance Criteria**:
+- `$columns` array has exactly 24 entries
+- `source` default is `'db'`
+- `status` sortable column with default `'draft'`
+- All 4 JSON field columns (`callback_config`, `input_schema`, `output_schema`, `mcp_servers`) defined as longtext/allow_null
+
+---
+
+### File 3: `AcrossAI_Sitewide_Row.php`
+
+**Purpose**: BerlinDB Row subclass — represents one ability record; casts types on read.
+
+**Changes**:
+
+**A) Update class docblock `@property` list** — add 9 new `@property` entries.
+
+**B) Add 8 new public property declarations**:
+
+```php
+/** Display name. @var string|null */
+public $label = null;
+
+/** Full description. @var string|null */
+public $description = null;
+
+/** Organizational category. @var string|null */
+public $category = null;
+
+/** Lifecycle status (draft|publish). @var string */
+public $status = 'draft';
+
+/** Callback type (noop|filter_hook|wp_remote_post). @var string */
+public $callback_type = 'noop';
+
+/** Decoded callback configuration. @var array|null */
+public $callback_config = null;
+
+/** Decoded input JSON Schema Draft 7. @var array|null */
+public $input_schema = null;
+
+/** Decoded output JSON Schema Draft 7. @var array|null */
+public $output_schema = null;
+```
+
+**C) Add `get_json_fields()` static method** (filterable registry — FR-009):
+
+```php
+/**
+ * Filterable list of fields stored as JSON in the database (FR-009).
+ *
+ * Both Row::__construct() and Query::save_override() use this single registry.
+ * Extend via the acrossai_abilities_json_fields filter; only blocked scalar
+ * column names are rejected (F1 guard — see JSON Field Registry section).
+ *
+ * @since  0.1.0
+ * @return string[]
+ */
+public static function get_json_fields(): array {
+    $blocked_scalar_columns = array(
+        'id', 'ability_slug', 'label', 'description', 'category', 'status',
+        'provider', 'source', 'site_allowed', 'callback_type',
+        'show_in_rest', 'show_in_mcp', 'mcp_type', 'readonly', 'destructive',
+        'idempotent', 'created_at', 'updated_at', 'created_by', 'updated_by',
+    );
+
+    $fields = apply_filters(
+        'acrossai_abilities_json_fields',
+        array( 'mcp_servers', 'callback_config', 'input_schema', 'output_schema' )
+    );
+
+    return array_values(
+        array_filter(
+            (array) $fields,
+            static function ( $field ) use ( $blocked_scalar_columns ) {
+                return ! in_array( $field, $blocked_scalar_columns, true );
+            }
+        )
+    );
+}
+```
+
+**D) Update `__construct()`** — replace hardcoded `mcp_servers` decode block with registry loop:
+
+```php
+public function __construct( $item ) {
+    parent::__construct( $item );
+
+    // Cast tinyint columns using the shared sanitizer utility (RF-02).
+    $tri_state_fields = array( 'site_allowed', 'readonly', 'destructive', 'idempotent', 'show_in_rest', 'show_in_mcp' );
+    foreach ( $tri_state_fields as $field ) {
+        $this->{$field} = AcrossAI_Sanitizer::cast_tri_state( $this->{$field} );
+    }
+
+    // Decode JSON-encoded fields using the single filterable registry (FR-009).
+    // Returns array|null — malformed JSON or non-array value yields null (FR-008).
+    foreach ( self::get_json_fields() as $json_field ) {
+        if ( null !== $this->{$json_field} && isset( $this->{$json_field} ) ) {
+            $decoded             = json_decode( $this->{$json_field}, true );
+            $this->{$json_field} = is_array( $decoded ) ? $decoded : null;
+        }
+    }
+
+    // Cast integer fields.
+    $this->id         = (int) $this->id;
+    $this->created_by = null !== $this->created_by ? (int) $this->created_by : null;
+    $this->updated_by = null !== $this->updated_by ? (int) $this->updated_by : null;
+}
+```
+
+**Acceptance Criteria**:
+- 24 public property declarations (existing 16 + 8 new)
+- `get_json_fields()` is `public static`; applies `acrossai_abilities_json_fields` filter
+- `__construct()` decodes all 4 JSON fields from registry (not just `mcp_servers`)
+- Tri-state cast block unchanged
+- Integer cast block unchanged
+
+---
+
+### File 4: `AcrossAI_Sitewide_Query.php`
+
+**Purpose**: BerlinDB Query subclass — all CRUD operations + query methods.
+
+**Changes**:
+
+**A) Rename `$table_name`**:
+
+```diff
+- protected $table_name = 'acrossai_abilities_overwrite';
++ protected $table_name = 'acrossai_abilities';
+```
+
+**B) Replace the `mcp_servers` hardcoded JSON encode block in `save_override()` with registry loop** (FR-009, FR-010, FR-018):
+
+**REMOVE** this block:
+```php
+// JSON-encode mcp_servers before passing to BerlinDB — the column is longtext and
+// BerlinDB does NOT auto-encode PHP arrays. Without this the DB receives "[Array]"
+// instead of valid JSON, and mcp_servers would be lost on read.
+if ( isset( $fields['mcp_servers'] ) && is_array( $fields['mcp_servers'] ) ) {
+    $fields['mcp_servers'] = wp_json_encode( $fields['mcp_servers'] );
+}
+```
+
+**REPLACE WITH** (registry-driven loop — FR-010 failure path included):
+```php
+// JSON-encode all array-valued JSON fields before passing to BerlinDB (FR-009/FR-010).
+// Uses the single filterable registry from AcrossAI_Sitewide_Row::get_json_fields().
+// If wp_json_encode() fails for a field, that field is stored as null; save continues.
+foreach ( AcrossAI_Sitewide_Row::get_json_fields() as $json_field ) {
+    if ( isset( $fields[ $json_field ] ) && is_array( $fields[ $json_field ] ) ) {
+        $encoded               = wp_json_encode( $fields[ $json_field ] );
+        $fields[ $json_field ] = false !== $encoded ? $encoded : null;
+    }
+}
+```
+
+**KEEP UNCHANGED** (FR-018) — all 3 of these existing blocks:
+1. Tri-state bool-to-int cast block (`$tri_state_columns` foreach)
+2. `mcp_type` value validation guard (`if ( array_key_exists( 'mcp_type', $fields ) ... )`)
+3. `mcp_servers` non-string guard (`if ( array_key_exists( 'mcp_servers', $fields ) ... )`)
+
+**ADD** (F2 security guards — extend the existing `mcp_type` guard pattern to new enum fields):
+
+```php
+// F2: Guard status field — only allow known lifecycle values.
+// Prevents invalid long strings that would exceed the varchar(20) constraint.
+if ( array_key_exists( 'status', $fields ) && null !== $fields['status'] ) {
+    $allowed_statuses = array( 'draft', 'publish' );
+    if ( ! in_array( $fields['status'], $allowed_statuses, true ) ) {
+        unset( $fields['status'] );
+    }
+}
+
+// F2: Guard callback_type field — only allow known callback types.
+if ( array_key_exists( 'callback_type', $fields ) && null !== $fields['callback_type'] ) {
+    $allowed_callback_types = array( 'noop', 'filter_hook', 'wp_remote_post', 'php_code' );
+    if ( ! in_array( $fields['callback_type'], $allowed_callback_types, true ) ) {
+        unset( $fields['callback_type'] );
+    }
+}
+```
+
+Insert these two guards **after** the tri-state cast block and **before** the JSON registry loop — following the same pattern as the existing `mcp_type` value guard (FR-018 block 2).
+
+**C) Add `by_source()` method** (FR-011, FR-019 — BUG-BERLINDB-UNLIMITED):
+
+```php
+/**
+ * Retrieve all ability records matching a given source (FR-019).
+ *
+ * Method name MUST be by_source() — spec 009 calls it by this exact name.
+ * Returns an empty array (not all records) when $source is empty or null (FR-011).
+ * Uses number => 0 for an unlimited BerlinDB query (BUG-BERLINDB-UNLIMITED pattern).
+ *
+ * Caller responsibility: all public callers MUST verify current_user_can( 'manage_options' )
+ * before exposing results to clients. This method performs no capability check (DB layer).
+ *
+ * @since  0.1.0
+ * @param  string|null $source Source value to filter by (e.g. 'db', 'plugin').
+ * @return AcrossAI_Sitewide_Row[]
+ */
+public function by_source( ?string $source ): array {
+    if ( empty( $source ) ) {
+        return array();
+    }
+
+    $results = $this->query(
+        array(
+            'source' => $source,
+            'number' => 0,
+        )
+    );
+
+    return array_filter(
+        $results,
+        static function ( $row ) {
+            return $row instanceof AcrossAI_Sitewide_Row;
+        }
+    );
+}
+```
+
+**Acceptance Criteria**:
+- `$table_name === 'acrossai_abilities'`
+- `save_override()` JSON loop uses `AcrossAI_Sitewide_Row::get_json_fields()`
+- Encoding failure stores `null` (not `false`), save continues
+- Tri-state cast, mcp_type guard, mcp_servers non-string guard all unchanged (FR-018)
+- `by_source(null)` returns `[]`
+- `by_source('')` returns `[]`
+- `by_source('db')` returns all rows where `source = 'db'`
+- Query uses `'number' => 0` (not `-1`)
+
+---
+
+### File 5: `uninstall.php`
+
+**Purpose**: Cleans up plugin artifacts on uninstall.
+
+**Changes**: Add new table DROP and option delete. Keep existing lines for backward-compat cleanup of old table name.
+
+```php
+// Drop the unified abilities table (renamed in feature 008: unified-abilities-table).
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+$wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}acrossai_abilities`" );
+
+// Remove new BerlinDB db-version option.
+delete_option( 'acrossai_abilities_db_version' );
+```
+
+Insert these two lines **before** the existing `acrossai_abilities_overwrite` DROP (so new name is cleaned first, then old name).
+
+Existing lines remain:
+```php
+$wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}acrossai_abilities_overwrite`" );
+delete_option( 'acrossai_abilities_overwrite_db_version' );
+```
+
+**Acceptance Criteria**:
+- Both `acrossai_abilities` and `acrossai_abilities_overwrite` DROP statements present
+- Both `acrossai_abilities_db_version` and `acrossai_abilities_overwrite_db_version` delete_option calls present
+- `WP_UNINSTALL_PLUGIN` guard unchanged
+- PHPCS: zero errors
+
+---
+
+## Task Breakdown
+
+```
+T001  AcrossAI_Sitewide_Table.php   — rename $name, $db_version_key; expand set_schema() 24 cols + 5 indexes
+T002  AcrossAI_Sitewide_Schema.php  — add 8 column definitions; update source default to 'db'
+T003  AcrossAI_Sitewide_Row.php     — add 8 properties + get_json_fields() + update __construct()
+T004  AcrossAI_Sitewide_Query.php   — rename $table_name; registry loop in save_override(); by_source() (FR-019)
+T005  uninstall.php                  — add DROP + delete_option for acrossai_abilities
+```
+
+**Critical-path order**: T001 → T002 → T003 → T004 → T005
+- T002 depends on T001 column list (both must define 24 columns consistently)
+- T003 must precede T004 (Query calls `AcrossAI_Sitewide_Row::get_json_fields()`)
+- T005 is independent; can run in parallel with T001–T004
+
+---
+
+## Success Criteria Mapping
+
+| SC | Criterion | Covered By |
+|----|-----------|-----------|
+| SC-001 | 24 columns on fresh install | T001 (set_schema), T002 (Schema) |
+| SC-002 | Existing tests pass without modification | FR-015 compliance in all 4 DB files |
+| SC-003 | 24-field round-trip without data loss | T002 (Schema) + T003 (Row) |
+| SC-004 | by-source query: exact match, zero false +/- | T004 (by_source) |
+| SC-005 | New JSON field via filter auto-decoded/encoded | T003 (get_json_fields filter) + T004 (registry loop) |
+| SC-006 | Uninstall leaves no trace | T005 (uninstall.php) |
+
+---
+
+## Implementation Watchpoints
+
+1. **FR-017**: `$version = '1.0.0'` — never increment. BerlinDB uses this for upgrade detection; bumping would trigger `maybe_upgrade()` which re-runs `set_schema()` DDL on existing sites.
+2. **FR-018 three-block rule**: In `save_override()`, only remove the old `mcp_servers` encode block and add the registry loop. Do not touch tri-state cast, mcp_type guard, or non-string `mcp_servers` guard.
+3. **BUG-BERLINDB-UNLIMITED**: `by_source()` must pass `'number' => 0` — `absint(-1) = 1` silently limits to 1 row.
+4. **JSON registry placement**: `get_json_fields()` lives on `AcrossAI_Sitewide_Row` (not Query, not a new file). Query calls it as `AcrossAI_Sitewide_Row::get_json_fields()`.
+5. **UNIQUE KEY**: The old schema had `KEY ability_slug` (non-unique). The new schema specifies `UNIQUE KEY ability_slug`. BerlinDB `maybe_upgrade()` handles DDL changes when schema SQL changes, but since `$version` must NOT be bumped (FR-017), the UNIQUE constraint applies only to new installs.

--- a/specs/008-unified-abilities-table/security-constraints.md
+++ b/specs/008-unified-abilities-table/security-constraints.md
@@ -1,0 +1,359 @@
+# Security Review — Feature 008: Unified Abilities Table
+
+**Security Review Status**: ⚠️ **CONDITIONAL APPROVAL — 3 corrections required before implementation**
+
+**Prior Review Date**: 2026-05-22 (First Review)
+**This Review Date**: 2026-05-22 (Re-Review after corrections applied)
+**Reviewed By**: Security Review Workflow (speckit.security-review.plan)
+
+---
+
+## Executive Summary
+
+This is the second security review for feature `008-unified-abilities-table`.
+
+The first review issued **Conditional Approval** with 3 plan-vs-spec violations (V1 method name, V2 status varchar width, V3 label nullability) and 4 advisory findings (F1 filter injection risk, F2 enum guards absent, F3 missing docblock note, F4 JSON size deferred). The user confirmed all 3 violations have been corrected in plan.md and the plan has been annotated "Plan Corrections Applied (2026-05-22)".
+
+This re-review confirms the V1/V2/V3 corrections are present. However, the plan's implementation of the F1 guard introduces a **new design conflict**: the allowlist-based guard in `get_json_fields()` makes the `acrossai_abilities_json_fields` filter completely non-functional for extension, which directly contradicts spec requirements SC-005 and FR-009. This is a blocking issue.
+
+Two additional low-severity corrections are required (status value inconsistency in docblock; `by_source()` capability-check note missing). Two advisory items carry forward.
+
+**Net result**: 1 blocker (N1 — design conflict), 2 low-severity (N2, N3), 2 advisory (N4, N5).
+
+---
+
+## Plan Artifacts Reviewed
+
+| Artifact | Status |
+|---|---|
+| `specs/008-unified-abilities-table/plan.md` (full) | ✅ Read |
+| `specs/008-unified-abilities-table/spec.md` (full) | ✅ Read |
+| `specs/008-unified-abilities-table/tasks.md` (full: T001–T006) | ✅ Read |
+| `specs/008-unified-abilities-table/memory-synthesis.md` | ✅ Read |
+| `specs/008-unified-abilities-table/security-constraints.md` (prior review) | ✅ Read |
+| `.specify/memory/CONSTITUTION.md` | ✅ Read (§I–§VI) |
+| `docs/memory/ARCHITECTURE.md` | ✅ Read |
+| `docs/memory/DECISIONS.md` | ✅ Read |
+
+---
+
+## Delta: Prior Violations — All Confirmed Corrected
+
+### ✅ V1 (Resolved): Method Name `by_source()`
+
+Plan File 4 and tasks.md T004 now use `by_source()` throughout. FR-019 is satisfied. The method signature in the plan is `public function by_source( ?string $source ): array` with watchpoint noting "Method name MUST be by_source() — NOT get_all_by_source()".
+
+### ✅ V2 (Resolved): `status` Column `varchar(20)`
+
+`set_schema()` SQL contains `` `status` varchar(20) NOT NULL DEFAULT 'draft' ``. Schema column definition uses `'length' => '20'`. FR-020 is satisfied. T001 and T002 acceptance criteria both carry the `varchar(20)` watchpoint.
+
+### ✅ V3 (Resolved): `label` Column Nullable
+
+`set_schema()` SQL contains `` `label` varchar(255) DEFAULT NULL ``. Schema column definition uses `'allow_null' => true`, `'default' => null`. Row property is `public $label = null;` with `@var string|null`. FR-021 is satisfied.
+
+---
+
+## Vulnerability Findings
+
+### FINDING N1: F1 Allowlist Guard Breaks SC-005 and FR-009 Extension Point
+
+**Category**: Design Conflict / Spec Violation
+**Severity**: Medium — Blocker
+**Prior Finding Reference**: F1 (first review recommended blocklist; plan implemented allowlist instead)
+
+**Assessment**:
+
+The plan implements the F1 guard using an **allowlist** approach:
+
+```php
+public static function get_json_fields(): array {
+    $allowed_json_columns = array(
+        'mcp_servers', 'callback_config', 'input_schema', 'output_schema',
+    );
+
+    $fields = apply_filters(
+        'acrossai_abilities_json_fields',
+        $allowed_json_columns
+    );
+
+    // F1: Strip any field name that is not a known longtext/JSON column.
+    return array_values(
+        array_filter(
+            (array) $fields,
+            static function ( $field ) use ( $allowed_json_columns ) {
+                return in_array( $field, $allowed_json_columns, true );
+            }
+        )
+    );
+}
+```
+
+Because `$allowed_json_columns` serves as both the filter default **and** the allowlist for validation, any field name added by a third-party filter consumer is immediately stripped. The filter becomes a no-op: it can only confirm the existing 4 fields or reduce them — it cannot add new ones.
+
+**This contradicts SC-005 and FR-009 directly**:
+
+- **SC-005** (spec.md): "Adding a new JSON field via the filter (FR-009) causes it to be automatically decoded on read and encoded on save without any further code changes."
+- **FR-009** (spec.md): "The list of JSON-encoded fields MUST be governed by a single filterable registry."
+- **SC-005 test would fail**: A test adding `'custom_json'` via the filter would result in the field being stripped — not auto-decoded/encoded.
+
+The plan's own security note acknowledges this: *"If a third party needs to add a genuinely new longtext/JSON column, they must add it to the `$allowed_json_columns` array in this method."* This is a closed-system design — secure but incompatible with the spec's extensibility contract.
+
+The prior review's recommended **blocklist** approach prevents the actual risk (scalar field injection) while preserving extensibility:
+
+```php
+public static function get_json_fields(): array {
+    $base = array( 'mcp_servers', 'callback_config', 'input_schema', 'output_schema' );
+    $filtered = apply_filters( 'acrossai_abilities_json_fields', $base );
+
+    // F1: Protected scalar columns that MUST NOT appear in the JSON field list.
+    // Injecting these into the JSON decode loop would silently corrupt Row properties.
+    $protected = array(
+        'id', 'ability_slug', 'label', 'status', 'enabled', 'source',
+        'provider', 'category', 'callback_type', 'mcp_type',
+        'created_at', 'updated_at', 'created_by', 'updated_by',
+    );
+
+    return array_values( array_filter(
+        (array) $filtered,
+        static function ( $field ) use ( $protected ) {
+            return is_string( $field ) && ! in_array( $field, $protected, true );
+        }
+    ) );
+}
+```
+
+This allows adding new longtext JSON columns (e.g., `custom_metadata`) while blocking the actual injection vector (scalar columns being decoded as JSON in `__construct()`).
+
+**Required correction**: Replace the allowlist guard with the blocklist approach above. Update the docblock to reference the protected-column list and explain why each group is protected.
+
+**Alternative acceptable resolution**: If the intent is to close the extension point for v1, update spec.md FR-009 and SC-005 to remove the extensibility contract, and the allowlist approach is acceptable. Do NOT silently contradict the spec.
+
+**Implementation Verification Checklist**:
+- [ ] `get_json_fields()` blocklist includes all 14 scalar/computed columns
+- [ ] Adding `'custom_json'` via filter returns `['mcp_servers', 'callback_config', 'input_schema', 'output_schema', 'custom_json']`
+- [ ] Adding `'ability_slug'` via filter returns unchanged base list (stripped)
+- [ ] Docblock explains the protected-column set and the injection risk it prevents
+- [ ] SC-005 acceptance test: add a new longtext column + its filter entry → auto-decoded on read, auto-encoded on save
+
+---
+
+### FINDING N2: `$status` Docblock Lists Invalid Values
+
+**Category**: Data Integrity / Documentation Inconsistency
+**Severity**: Low
+
+**Assessment**:
+
+File 3 (Row) in the plan declares `$status` with this docblock:
+```php
+/** Lifecycle status (draft|published|archived). @var string */
+public $status = 'draft';
+```
+
+The F2 guard in File 4 (Query, `save_override()`) enforces:
+```php
+$allowed_statuses = array( 'draft', 'publish' );
+```
+
+Three inconsistencies:
+1. `published` (docblock) ≠ `publish` (F2 guard and WordPress convention)
+2. `archived` (docblock) is not in `$allowed_statuses` — it would be silently stripped by the F2 guard
+3. `published` is not a valid WordPress status token — `publish` is the standard
+
+A developer reading the Row docblock would reasonably pass `status => 'published'` or `status => 'archived'` to `save_override()`. Both would be silently dropped by the F2 guard, falling back to the column's DEFAULT (`'draft'`). This silent failure creates confusing behavior without any error indication (the F2 guard uses `unset()` not `error_log()`, unlike the prior review's recommendation).
+
+**Required correction**:
+- Change docblock to `/** Lifecycle status. Valid: 'draft', 'publish'. @var string */`
+- T003 acceptance criteria should verify the docblock matches the F2 guard's allowlist exactly
+
+**Note on error logging**: The prior review (F2) recommended logging (`error_log()`) on invalid status/callback_type. The plan drops the error log. This is acceptable (avoid leaking internal field names to logs), but the silent `unset()` makes debugging harder. Advisory: add a `do_action('acrossai_abilities_debug', ...)` hook or at minimum keep the `error_log()` under `WP_DEBUG` check.
+
+---
+
+### FINDING N3: `by_source()` Docblock Missing Capability-Check Caller Contract
+
+**Category**: Security Documentation
+**Severity**: Low
+**Prior Finding Reference**: F3 (first review — required)
+
+**Assessment**:
+
+The `by_source()` docblock in the plan reads:
+```php
+/**
+ * Retrieve all ability records matching a given source (FR-019).
+ *
+ * Method name MUST be by_source() — spec 009 calls it by this exact name.
+ * Returns [] immediately when $source is empty or null (FR-011).
+ * Uses 'number' => 0 for unlimited results (BUG-BERLINDB-UNLIMITED pattern).
+ *
+ * @since  0.1.0
+ * @param  string|null $source Source value to filter by (e.g. 'db', 'plugin').
+ * @return AcrossAI_Sitewide_Row[]
+ */
+```
+
+The F3 finding from the prior review explicitly required adding a capability-check caller contract. This is still absent. The tasks.md T004 acceptance criteria do not include it. If a future caller (REST controller, processor, or third-party integration) invokes `by_source()` without first checking `current_user_can('manage_options')`, ability records would be exposed without authorization.
+
+This is consistent with the existing `get_all_overrides()` pattern, but that method is also undocumented on this point. Establishing the pattern now prevents the same mistake in all future callers.
+
+**Required correction**: Add to the `by_source()` docblock:
+```php
+ * IMPORTANT: This method performs no capability check. All callers
+ * MUST verify current_user_can( 'manage_options' ) before invoking.
+```
+
+**Add to T004 acceptance criteria**:
+- `by_source()` docblock includes explicit caller capability-check requirement
+
+---
+
+### FINDING N4: F4 JSON Size/Depth — No T006 Quality Gate Step
+
+**Category**: Denial of Service / Data Integrity
+**Severity**: Advisory (carry-forward from prior F4)
+
+**Assessment**:
+
+F4 (first review) deferred JSON depth and size validation for `callback_config`, `input_schema`, `output_schema` to REST controllers, which is architecturally correct. The plan acknowledges this is caller responsibility. However:
+
+- No T004 or T006 step verifies that existing REST controllers enforce size/depth limits on these 3 new fields
+- No `save_override()` comment documents the caller contract ("JSON field size validation is the caller's responsibility")
+- `input_schema` and `output_schema` can be arbitrarily complex JSON Schema Draft 7 documents; without depth/size limits, a crafted payload could exhaust memory during `json_decode()`
+
+The prior review recommended: max 64KB per field, max 10 nesting levels.
+
+**Advisory — add to T006 (or create a follow-up task)**:
+- Verify `AcrossAI_Sitewide_Abilities_Controller` / `AcrossAI_Sitewide_Override_Controller` validate `callback_config`, `input_schema`, `output_schema` size (≤ 64KB) before calling `save_override()`
+- Add comment to `save_override()`: `// JSON field size/depth validation is the caller's responsibility.`
+
+---
+
+### FINDING N5: `enabled` Bool-to-Int Cast in `save_override()` Undocumented
+
+**Category**: Data Integrity
+**Severity**: Advisory
+
+**Assessment**:
+
+`AcrossAI_Sitewide_Row::__construct()` explicitly casts `$this->enabled = (bool) $this->enabled` on read — correct. However, `save_override()` in the plan has no documented cast of the PHP `enabled` field to `int` before BerlinDB write.
+
+The existing tri-state cast block handles `site_allowed`, `readonly`, `destructive`, `idempotent`, `show_in_rest`, `show_in_mcp` — but `enabled` must NOT be in that list (it's a regular bool, not tri-state). Without an explicit cast, PHP `true` could reach BerlinDB, which may handle it internally (MySQL accepts non-zero as `1`) — but this is not guaranteed behavior.
+
+**Advisory — add to T004 implementation notes**:
+```php
+// Normalise enabled to tinyint before save (not tri-state, just bool-to-int).
+if ( array_key_exists( 'enabled', $fields ) ) {
+    $fields['enabled'] = (int) (bool) $fields['enabled'];
+}
+```
+
+---
+
+## Confirmed Secure Patterns
+
+### ✅ Multisite Isolation (SEC-03)
+
+`AcrossAI_Sitewide_Table::$global = false` is preserved unchanged. T001, T006 both carry explicit SEC-03 watchpoints. Per-site table prefix (`{prefix}acrossai_abilities`) ensures per-site isolation in WP networks.
+
+### ✅ BerlinDB Prepared Statements
+
+All mutations (`add_item()`, `update_item()`, `delete_item()`) and reads (`query()`) route through BerlinDB, which uses `$wpdb->prepare()` internally. No raw SQL interpolation is introduced in the 5 modified files.
+
+### ✅ `WP_UNINSTALL_PLUGIN` Guard
+
+`uninstall.php` retains the `if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) { exit; }` guard. New DROP statements use `{$wpdb->prefix}` (set from wp-config.php, not user input). The `IF EXISTS` clause prevents fatals on partial installs.
+
+### ✅ Audit Field Immutability
+
+`save_override()` unsets `created_at` and `created_by` before `update_item()`. The plan preserves this pattern (it's part of the "3 preserved blocks" set indirectly). Confirmed in the acceptance criteria.
+
+### ✅ JSON Encode Failure Path (FR-010)
+
+Registry loop stores `null` (not `false`) on `wp_json_encode()` failure and continues:
+```php
+$fields[ $json_field ] = false !== $encoded ? $encoded : null;
+```
+Prevents PHP `false` from reaching a `longtext` column and allows partial saves to succeed.
+
+### ✅ Strict `is_array()` Check (SEC-04)
+
+JSON encoding loop uses `is_array( $fields[ $json_field ] )` — strict type check. Non-array values (strings, ints, booleans already in string/int form) pass through unmodified. Only PHP arrays are encoded.
+
+### ✅ BUG-BERLINDB-UNLIMITED Pattern
+
+`by_source()` uses `'number' => 0`. The plan, tasks.md T004 watchpoints, and T006 quality gate step all explicitly flag the `-1` anti-pattern (`absint(-1) = 1` → 1 row silently). Correctly resolved.
+
+### ✅ F2 Enum Guards — Status and Callback Type
+
+Plan adds F2 guards in `save_override()` for `status` (allowlist: `['draft', 'publish']`) and `callback_type` (allowlist: `['noop', 'filter_hook', 'wp_remote_post']`). Guards use strict `in_array(..., true)`. Guards placed after the tri-state cast block and before the JSON registry loop. Consistent with the existing `mcp_type` guard pattern.
+
+### ✅ FR-018 Three Preserved Blocks
+
+Plan explicitly retains all 3 existing `save_override()` blocks: (1) tri-state bool-to-int cast, (2) `mcp_type` value validation, (3) `mcp_servers` non-string guard. T004 acceptance criteria requires byte-for-byte diff equality on these 3 blocks. The new registry JSON loop replaces only the old hardcoded `mcp_servers` encode block.
+
+### ✅ `enabled` Cast Placement in `__construct()`
+
+`(bool) $this->enabled` runs before the JSON decode loop. `enabled` is not in the JSON field registry, preventing accidental `json_decode()` on the `1`/`0` tinyint value. A `NULL` DB value casts to `false` (disabled by default — safe).
+
+### ✅ `$version = '1.0.0'` Freeze (FR-017)
+
+Bumping this would trigger BerlinDB's `maybe_upgrade()` DDL on existing sites, which would fail because the old table doesn't have the new columns. Keeping it at `'1.0.0'` ensures the new schema is new-install-only — consistent with the spec's accepted assumption ("no data migration required").
+
+### ✅ UNIQUE KEY on `ability_slug`
+
+`set_schema()` SQL promotes `ability_slug` from a non-unique `KEY` to `UNIQUE KEY ability_slug (191)`. This enforces slug uniqueness at the DB layer. Since `$version` is frozen (FR-017), this constraint applies to new installs only — but it is present and correct for the feature scope.
+
+### ✅ Backward-Compat Uninstall
+
+`uninstall.php` adds new DROP/delete_option for `acrossai_abilities` / `acrossai_abilities_db_version` while preserving the existing `acrossai_abilities_overwrite` / `acrossai_abilities_overwrite_db_version` cleanup lines. New DROP precedes old DROP — correct ordering.
+
+---
+
+## Constitution Compliance Summary
+
+| Principle | Status | Notes |
+|---|---|---|
+| §I Modular Architecture | ✅ | 5-file constraint (FR-015) maintained; no cross-module coupling introduced |
+| §II WordPress Standards | ✅ | WPCS, PHPStan L8, BerlinDB prepared statements, ABSPATH guards required |
+| §III User-Centric Design | N/A | No admin UI changes in this feature |
+| §IV Security First | ⚠️ | F1 guard approach creates spec/security trade-off; N2, N3 corrections needed |
+| §V Extensibility | ⚠️ | F1 allowlist contradicts SC-005 / FR-009 filter extensibility contract |
+| §VI Reusability / DRY | ✅ | JSON registry is single source of truth across Row + Query |
+| §VII Definition of Done | ⚠️ | PHPCS/PHPStan/tests pending implementation; quality gate T006 covers these |
+
+---
+
+## Summary of All Findings
+
+| # | Type | Severity | Description | Correct Before Implementation? |
+|---|------|----------|-------------|-------------------------------|
+| N1 | Design Conflict | **Medium — Blocker** | F1 allowlist guard neutralizes `acrossai_abilities_json_fields` filter — SC-005 and FR-009 extensibility contract broken | **Yes** |
+| N2 | Docblock Inconsistency | Low | `$status` docblock lists `draft\|published\|archived`; F2 guard only allows `['draft','publish']` — "published" ≠ "publish", "archived" not valid | **Yes** |
+| N3 | Security Documentation | Low | `by_source()` docblock missing explicit `manage_options` caller-responsibility note (required by prior F3) | **Yes** |
+| N4 | Advisory | Advisory | F4 JSON size/depth: no T006 quality gate step or save_override() caller contract comment | At implementation |
+| N5 | Advisory | Advisory | `enabled` bool-to-int cast in `save_override()` undocumented; relies on implicit DB behavior | At implementation |
+
+**Prior violation status**: V1 ✅ V2 ✅ V3 ✅ — all corrected
+**Prior advisory status**: F1 → N1 (new form, still blocking), F2 ✅ (resolved), F3 → N3 (carry-forward), F4 → N4 (carry-forward)
+
+---
+
+## Required Plan Corrections (Before Tasks Can Proceed)
+
+1. **N1 — Replace F1 allowlist with blocklist**: In `get_json_fields()`, replace the `in_array($field, $allowed_json_columns)` allowlist check with the denylist approach using the 14-element `$protected` array. Update the docblock to explain the protected-column set. Alternatively: update spec.md to remove SC-005 and FR-009 filter extensibility requirements and document the intentional closed-system design.
+
+2. **N2 — Fix `$status` property docblock**: Change `draft|published|archived` to `draft|publish`. Verify alignment with F2 guard `['draft', 'publish']` allowlist. Optionally add `'archived'` to both docblock and F2 guard if "archived" is intended as a valid future lifecycle state.
+
+3. **N3 — Add capability-check note to `by_source()` docblock**: Insert the sentence: `"IMPORTANT: This method performs no capability check. All callers MUST verify current_user_can( 'manage_options' ) before invoking."` Also add to T004 acceptance criteria.
+
+---
+
+## Approval
+
+**Security Review Status**: ⚠️ **CONDITIONAL APPROVAL — 3 plan corrections required (N1, N2, N3)**
+
+After N1 is resolved (F1 guard approach decided + spec aligned), N2 is corrected (docblock), and N3 is added (docblock), this feature is **approved for implementation**.
+
+**Reviewed By**: Security Review Workflow (speckit.security-review.plan)
+**Review Date**: 2026-05-22

--- a/specs/008-unified-abilities-table/spec.md
+++ b/specs/008-unified-abilities-table/spec.md
@@ -1,0 +1,123 @@
+# Feature Specification: Unified Abilities Table
+
+**Feature Branch**: `008-unified-abilities-table`
+**Created**: 2026-05-22
+**Status**: Implemented
+**Input**: User description: "Unified abilities table — update 5 existing files, create no new files."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Abilities Stored as First-Class Records (Priority: P1)
+
+The system stores every ability as a complete, self-describing record rather than as a partial override patch. Each record carries its own label, description, category, lifecycle status, callback configuration, and JSON schemas, making the abilities store the single authoritative source for all ability metadata.
+
+**Why this priority**: Without this, abilities defined in the database lack the metadata needed by the admin UI, REST consumers, and MCP clients to describe or execute them. This is the foundation all other stories depend on.
+
+**Independent Test**: Insert one ability record with a label, description, category, and `status = 'draft'`. Retrieve it. Verify all fields are present, correctly typed, and round-trip without data loss.
+
+**Acceptance Scenarios**:
+
+1. **Given** an empty abilities table, **When** a record is inserted with label, description, category, status, callback type, callback configuration, input schema, and output schema, **Then** all 24 fields are persisted and retrievable with correct types and values.
+2. **Given** an existing ability record, **When** it is updated with a new status and callback configuration, **Then** only `updated_at` and `updated_by` change; `created_at` and `created_by` remain unchanged.
+3. **Given** an ability record whose callback configuration contains a nested JSON object, **When** the record is read, **Then** the configuration is returned as a structured object (not a raw JSON string).
+
+---
+
+### User Story 2 — Abilities Queryable by Source (Priority: P2)
+
+The system allows consumers to retrieve all abilities belonging to a specific source (e.g., abilities created via the database UI vs. abilities discovered from plugins). This enables the admin list and REST endpoints to partition abilities by origin without loading the full abilities set.
+
+**Why this priority**: Without source-based querying, callers must fetch all records and filter in memory — wasteful at scale and a prerequisite for admin UI filtering.
+
+**Independent Test**: Insert 3 records with `source = 'db'` and 2 with `source = 'plugin'`. Call the by-source query for `'db'`. Verify exactly 3 records are returned and none have `source = 'plugin'`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mix of abilities with different sources, **When** the by-source query is called with `source = 'db'`, **Then** only abilities with that exact source value are returned.
+2. **Given** no abilities with the requested source, **When** the by-source query is called, **Then** an empty array is returned (no error).
+
+---
+
+### User Story 3 — Unified Table Replaces Override-Only Table (Priority: P3)
+
+The database table is renamed from its previous "overwrite"-scoped name to a general-purpose name that reflects its expanded role as the unified store for all managed abilities. Uninstalling the plugin removes the correctly-named table and its associated metadata option.
+
+**Why this priority**: The rename is a prerequisite for communicating the expanded scope to developers and for accurate uninstall cleanup, but it does not change runtime query behaviour that other stories depend on.
+
+**Independent Test**: Activate the plugin on a fresh database. Verify that the table `{prefix}acrossai_abilities` exists. Deactivate and uninstall the plugin. Verify the table is dropped and its db-version option is deleted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh WordPress installation, **When** the plugin is activated, **Then** a table named `{prefix}acrossai_abilities` is created with 24 columns.
+2. **Given** an installed plugin, **When** the plugin is uninstalled, **Then** `{prefix}acrossai_abilities` is dropped and the `acrossai_abilities_db_version` option is deleted.
+3. **Given** the plugin was previously installed with the old table name, **When** a migration runs, **Then** existing data is preserved (migration path is out of scope for this spec; new installs use the new name only).
+
+---
+
+### Edge Cases
+
+- What happens when a JSON field (callback configuration, MCP servers, schemas) contains malformed JSON on read? → The field is returned as `null`; no exception is thrown.
+- What happens when a new JSON-encoded field is added by a third-party filter? → The constructor decodes it automatically without requiring code changes, because the JSON field list is driven by a filterable registry.
+- What happens when the same ability slug is inserted twice? → The database rejects the second insert (unique constraint); the caller receives a failure result.
+- What happens if `status` is omitted on insert? → It defaults to `'draft'`.
+- What happens if `source` is omitted on insert? → It defaults to `'db'`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The abilities table MUST be named `{prefix}acrossai_abilities` (not `{prefix}acrossai_abilities_overwrite`) in all new installations.
+- **FR-002**: The abilities table MUST contain exactly 24 columns: `id`, `ability_slug`, `label`, `description`, `category`, `status`, `provider`, `source`, `site_allowed`, `callback_type`, `callback_config`, `input_schema`, `output_schema`, `show_in_rest`, `show_in_mcp`, `mcp_type`, `mcp_servers`, `readonly`, `destructive`, `idempotent`, `created_at`, `updated_at`, `created_by`, `updated_by`.
+- **FR-003**: The `ability_slug` column MUST enforce uniqueness; duplicate slug inserts MUST fail.
+- **FR-004**: The `status` column MUST default to `'draft'` when not supplied on insert. A `source=db` ability with `status='publish'` is ALWAYS registered — there is no separate enabled flag.
+- **FR-006**: The `source` column MUST default to `'db'` when not supplied on insert.
+- **FR-007**: The `callback_type` column MUST default to `'noop'` when not supplied on insert.
+- **FR-008**: The JSON-encoded fields (`mcp_servers`, `callback_config`, `input_schema`, `output_schema`) MUST be decoded to PHP arrays on read. If the stored value is malformed JSON or not an array, the field MUST be returned as `null`.
+- **FR-009**: The list of JSON-encoded fields MUST be governed by a single filterable registry (a static method that applies the filter `acrossai_abilities_json_fields`). No other code path may duplicate or inline this list.
+- **FR-010**: When any of the JSON-encoded fields is saved as a PHP array, it MUST be automatically JSON-encoded before reaching the database. This encoding MUST use the same filterable registry as FR-009. If `json_encode()` fails for a field, that field MUST be stored as `null`; the save operation MUST continue for remaining fields.
+- **FR-011**: The by-source query MUST accept a source string and return all ability records matching that source, with no row count limit. If the source argument is empty or `null`, the method MUST return an empty array (no match, not all records).
+- **FR-012**: On insert, `created_at` and `created_by` MUST be set; on update they MUST NOT be overwritten.
+- **FR-013**: The uninstall routine MUST drop `{prefix}acrossai_abilities` and delete the `acrossai_abilities_db_version` option.
+- **FR-014**: The schema version option key MUST be `acrossai_abilities_db_version` (not `acrossai_abilities_overwrite_db_version`).
+- **FR-015**: All changes MUST be confined to the 5 named files. `includes/Main.php`, `includes/AcrossAI_Activator.php`, and the PHPUnit test file MUST NOT be modified.
+- **FR-016**: The table MUST have exactly these indexes: `PRIMARY KEY (id)`, `UNIQUE KEY ability_slug (ability_slug(191))`, `KEY idx_status (status)`, `KEY idx_source (source)`, `KEY idx_updated_at (updated_at)`.
+- **FR-017**: `AcrossAI_Sitewide_Table::$version` MUST remain `'1.0.0'` — it MUST NOT be bumped to any other value.
+- **FR-018**: In `save_override()`, only the block that JSON-encodes `mcp_servers` is replaced with the filter-driven loop. The following three blocks MUST remain completely unchanged: (1) the tri-state bool-to-int cast block for `site_allowed`, `readonly`, `destructive`, `idempotent`, `show_in_rest`, `show_in_mcp`; (2) the `mcp_type` value validation guard that blocks invalid values before the DB write; (3) the `mcp_servers` non-string guard that ensures the value is a string or null after encoding.
+- **FR-019**: The by-source query method on `AcrossAI_Sitewide_Query` MUST be named `by_source()` — NOT `get_all_by_source()` or any other variant. Spec 009's `AcrossAI_Abilities_Query` calls this method by name.
+- **FR-020**: The `status` column MUST be `varchar(20)` — NOT `varchar(50)`. The only valid values (`draft`, `publish`) are well within 20 characters; a tighter constraint prevents invalid long strings.
+- **FR-021**: The `label` column MUST be nullable (`DEFAULT NULL`) — NOT `NOT NULL DEFAULT ''`. Override rows (`source != 'db'`) do not carry a label; forcing a non-null default would store empty strings instead of NULL for every plugin/theme override row.
+
+### Key Entities
+
+- **Ability record**: A row in the unified abilities table. Contains identity (`ability_slug`), display metadata (`label`, `description`, `category`), lifecycle state (`status`), origin (`provider`, `source`), override flags (`site_allowed`, `readonly`, `destructive`, `idempotent`), callback definition (`callback_type`, `callback_config`), exposure flags (`show_in_rest`, `show_in_mcp`, `mcp_type`, `mcp_servers`), JSON schemas (`input_schema`, `output_schema`), and audit fields (`created_at`, `updated_at`, `created_by`, `updated_by`).
+- **JSON field registry**: The authoritative, filterable list of fields that are stored as JSON strings and must be decoded on read and encoded on save. Acts as the single source of truth for JSON serialisation behaviour.
+- **Source**: A classification string indicating where an ability originated (e.g., `'db'`, `'plugin'`, `'theme'`, `'core'`). Used to partition abilities by origin.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of the 24 required columns are present in the table created on a fresh install — verified by schema inspection.
+- **SC-002**: All existing automated tests continue to pass without modification after the 5 files are updated.
+- **SC-003**: A record inserted with all 24 fields round-trips through read without any field loss, type corruption, or malformed JSON.
+- **SC-004**: A by-source query for a known source returns only records with that source and no records with a different source (zero false positives, zero false negatives).
+- **SC-005**: Adding a new JSON field via the filter (FR-009) causes it to be automatically decoded on read and encoded on save without any further code changes.
+- **SC-006**: Uninstalling the plugin on a site where the table exists leaves no trace of `{prefix}acrossai_abilities` or `acrossai_abilities_db_version`.
+
+## Assumptions
+
+- No data migration from the old `acrossai_abilities_overwrite` table is required; this spec covers new installations only. Existing sites that upgrade must manually deactivate, uninstall, and reinstall the plugin — no graceful degradation or silent fallback for the old table is provided.
+- The existing test suite (`SitewideQueryTest.php`) already covers the pre-existing behaviour; its passing state is the regression baseline — no new test modifications are needed to satisfy FR-015. All test assertions operate through the Query class API (behavioural); no assertion references the raw table name string `acrossai_abilities_overwrite` directly, so the table rename does not break SC-002.
+- `mcp_type` length remains `100` characters (not shortened to `50`).
+- The tri-state columns (`site_allowed`, `readonly`, `destructive`, `idempotent`, `show_in_rest`, `show_in_mcp`) already have correct cast logic via `AcrossAI_Sanitizer::cast_tri_state()` and that logic is unchanged.
+- The singleton pattern and ABSPATH guard on every PHP file are required by the project Constitution and apply to all 5 files.
+
+## Clarifications
+
+### Session 2026-05-22
+
+- Q: Do `SitewideQueryTest.php` assertions reference the raw table name `acrossai_abilities_overwrite`, or do they test only through the Query class API (behavioral assertions)? → A: Tests are purely behavioral — all assertions go through the Query class API; no raw table name is hardcoded in any assertion.
+- Q: What is the upgrade path for existing sites that have the old `acrossai_abilities_overwrite` table? → A: New-installation-only scope; existing sites must manually uninstall and reinstall (no migration, no graceful degradation).
+- Q: What should the WordPress filter name be for the JSON field registry (FR-009)? → A: `acrossai_abilities_json_fields`
+- Q: When `json_encode()` fails on a JSON field in `save_override()`, what should happen? → A: Store `null` for that field and continue saving the rest of the record.
+- Q: When `get_all_by_source()` is called with an empty or null source string, what should it return? → A: Return an empty array (treat as no match).

--- a/specs/008-unified-abilities-table/tasks.md
+++ b/specs/008-unified-abilities-table/tasks.md
@@ -1,0 +1,502 @@
+# Tasks: Unified Abilities Table (008)
+
+**Feature**: Unified Abilities Table
+**Branch**: `008-unified-abilities-table`
+**Status**: Ready for Implementation — Security Re-Review Corrections Applied (2026-05-22)
+**Input**: plan.md (N1/N2/N3 corrected), spec.md, memory-synthesis.md, security-constraints.md
+
+> **Governed Tasks Update (2026-05-22)**: Applied N1 (blocklist guard), N2 ($status docblock), N3 (by_source() capability note), N4 advisory (JSON size step). N5 advisory (enabled cast) removed — `enabled` column dropped; `status='publish'` is the sole registration control. Tasks are aligned with corrected plan.md.
+
+---
+
+## Overview
+
+This feature modifies exactly **5 existing files** — no new files are created. Tasks follow the critical-path order imposed by inter-file dependencies.
+
+**Critical path**: T001 → T002 → T003 → T004
+**Parallel**: T005 is independent of T001–T004 and may run at any point
+**Quality gate**: T006 depends on T001–T005
+
+### User Story Map
+
+| Story | Priority | Covered By |
+|-------|----------|------------|
+| US1 — Abilities as first-class records | P1 | T001, T002, T003, T004 |
+| US2 — Abilities queryable by source | P2 | T004 (`by_source()`) |
+| US3 — Unified table replaces override-only table | P3 | T001 (rename), T005 (uninstall) |
+
+---
+
+## Phase 1: Foundational Database Layer (US1, US3)
+
+**Checkpoint**: T001 and T002 must be complete before T003; T003 before T004.
+
+- [x] T001 [US1] [US3] Rename `$name`/`$db_version_key` and expand `set_schema()` to 24 columns + 5 indexes in `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Table.php`
+
+  **Changes**:
+  1. `$name`: `'acrossai_abilities_overwrite'` → `'acrossai_abilities'` (FR-001)
+  2. `$db_version_key`: `'acrossai_abilities_overwrite_db_version'` → `'acrossai_abilities_db_version'` (FR-014)
+  3. `$version`: MUST remain `'1.0.0'` — do NOT change (FR-017)
+  4. `$global`: MUST remain `false` — do NOT change (SEC-03)
+  5. Replace `set_schema()` body entirely with the 24-column + 5-index DDL from plan.md
+
+  **Exact `set_schema()` SQL (must match verbatim)**:
+  ```sql
+  `id`             bigint(20) unsigned NOT NULL auto_increment,
+  `ability_slug`   varchar(255) NOT NULL DEFAULT '',
+  `label`          varchar(255) DEFAULT NULL,               -- nullable (FR-021)
+  `description`    longtext DEFAULT NULL,
+  `category`       varchar(100) DEFAULT NULL,
+  `status`         varchar(20) NOT NULL DEFAULT 'draft',   -- varchar(20) NOT 50 (FR-020)
+  `provider`       varchar(100) DEFAULT NULL,
+  `source`         varchar(50) NOT NULL DEFAULT 'db',
+  `site_allowed`   tinyint(1) DEFAULT NULL,
+  `callback_type`  varchar(50) NOT NULL DEFAULT 'noop',
+  `callback_config` longtext DEFAULT NULL,
+  `input_schema`   longtext DEFAULT NULL,
+  `output_schema`  longtext DEFAULT NULL,
+  `show_in_rest`   tinyint(1) DEFAULT NULL,
+  `show_in_mcp`    tinyint(1) DEFAULT NULL,
+  `mcp_type`       varchar(100) DEFAULT NULL,
+  `mcp_servers`    longtext DEFAULT NULL,
+  `readonly`       tinyint(1) DEFAULT NULL,
+  `destructive`    tinyint(1) DEFAULT NULL,
+  `idempotent`     tinyint(1) DEFAULT NULL,
+  `created_at`     datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`     datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_by`     bigint(20) unsigned DEFAULT NULL,
+  `updated_by`     bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `ability_slug` (`ability_slug`(191)),
+  KEY `idx_status` (`status`),
+  KEY `idx_source` (`source`),
+  KEY `idx_updated_at` (`updated_at`)
+  ```
+
+  **Acceptance Criteria**:
+  - `$name === 'acrossai_abilities'`
+  - `$db_version_key === 'acrossai_abilities_db_version'`
+  - `$version === '1.0.0'` (verified unchanged)
+  - `$global === false` (verified unchanged)
+  - `set_schema()` SQL contains exactly 24 column definitions
+  - `status` column is `varchar(20)` — NOT `varchar(50)` (FR-020)
+  - `label` column is nullable `DEFAULT NULL` — NOT `NOT NULL DEFAULT ''` (FR-021)
+  - Exactly 5 indexes: `PRIMARY KEY (id)`, `UNIQUE KEY ability_slug (ability_slug(191))`, `KEY idx_status (status)`, `KEY idx_source (source)`, `KEY idx_updated_at (updated_at)` (FR-016)
+  - PHPCS: zero errors
+
+  **Watchpoints**:
+  - ⛔ FR-017: `$version` must stay `'1.0.0'` — bumping triggers `maybe_upgrade()` DDL re-run on existing sites
+  - ⛔ SEC-03: `$global = false` is a multisite isolation contract
+  - ⛔ FR-020: `status` is `varchar(20)` — not `varchar(50)`
+  - ⛔ FR-021: `label` is nullable — override rows carry no label
+  - ⛔ FR-016: `UNIQUE KEY` (not plain `KEY`) for `ability_slug`
+  - ⛔ NO private constructor on `AcrossAI_Sitewide_Table` — `AcrossAI_Activator` calls `new AcrossAI_Sitewide_Table()` directly (FR-015 forbids touching Activator). Singleton is soft: `instance()` method exists but instantiation is not language-enforced. Do NOT add `private function __construct()` to this class.
+
+  **File**: `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Table.php`
+  **Dependencies**: None (first task on critical path)
+
+---
+
+- [x] T002 [US1] Add 8 new column definitions to `$columns` and update `source` default in `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Schema.php`
+
+  **Changes**:
+
+  1. After the `ability_slug` column definition and before `provider`, insert 5 new entries:
+     ```php
+     // label (FR-021: nullable)
+     array( 'name' => 'label', 'type' => 'varchar', 'length' => '255', 'allow_null' => true, 'default' => null, 'searchable' => true, 'sortable' => true ),
+     // description
+     array( 'name' => 'description', 'type' => 'longtext', 'allow_null' => true, 'default' => null, 'searchable' => true ),
+     // category
+     array( 'name' => 'category', 'type' => 'varchar', 'length' => '100', 'allow_null' => true, 'default' => null, 'sortable' => true ),
+     // status (FR-020: length '20')
+     array( 'name' => 'status', 'type' => 'varchar', 'length' => '20', 'null' => false, 'default' => 'draft', 'sortable' => true ),
+     ```
+
+  2. Update the `source` column definition — change `allow_null => true, default => null` to `null => false, default => 'db'` (FR-006).
+
+  3. After the `site_allowed` column definition, insert 4 new entries:
+     ```php
+     // callback_type
+     array( 'name' => 'callback_type', 'type' => 'varchar', 'length' => '50', 'null' => false, 'default' => 'noop' ),
+     // callback_config (JSON longtext)
+     array( 'name' => 'callback_config', 'type' => 'longtext', 'allow_null' => true, 'default' => null ),
+     // input_schema (JSON longtext)
+     array( 'name' => 'input_schema', 'type' => 'longtext', 'allow_null' => true, 'default' => null ),
+     // output_schema (JSON longtext)
+     array( 'name' => 'output_schema', 'type' => 'longtext', 'allow_null' => true, 'default' => null ),
+     ```
+
+  **Acceptance Criteria**:
+  - `$columns` array has exactly 24 entries (16 existing + 8 new)
+  - `source` entry: `null => false`, `default => 'db'` (FR-006)
+  - `status` entry: `type => 'varchar'`, `length => '20'` (FR-020), `default => 'draft'` (FR-004)
+  - `label` entry: `allow_null => true`, `default => null` (FR-021)
+  - All 4 JSON-field columns (`callback_config`, `input_schema`, `output_schema`, `mcp_servers`) defined as `type => 'longtext'`, `allow_null => true`
+  - Column insertion positions match the DDL column order in T001's `set_schema()` SQL exactly
+  - PHPCS: zero errors
+
+  **Watchpoints**:
+  - ⛔ FR-020: `status` `length` must be `'20'` not `'50'`
+  - ⛔ FR-021: `label` must use `allow_null => true` + `default => null` — not `null => false`
+  - Column order in `$columns` must mirror the column order in `set_schema()` SQL from T001
+
+  **File**: `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Schema.php`
+  **Dependencies**: T001 (column list must match set_schema() SQL)
+
+---
+
+## Phase 2: Row Object Expansion (US1)
+
+**Checkpoint**: T003 must be complete before T004 (Query calls `AcrossAI_Sitewide_Row::get_json_fields()`).
+
+- [x] T003 [US1] Add 8 new public properties, `get_json_fields()` static method, and update `__construct()` in `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Row.php`
+
+  **Changes**:
+
+  **A) Update `@property` docblock** — add 9 `@property` entries to the class docblock matching the new columns.
+
+  **B) Add 8 new public property declarations** (after existing properties, before `__construct()`):
+  ```php
+  /** Display name. @var string|null */
+  public $label = null;
+  /** Full description. @var string|null */
+  public $description = null;
+  /** Organizational category. @var string|null */
+  public $category = null;
+  /** Lifecycle status. Valid: 'draft', 'publish'. @var string */
+  public $status = 'draft';
+  /** Callback type. @var string */
+  public $callback_type = 'noop';
+  /** Decoded callback configuration. @var array|null */
+  public $callback_config = null;
+  /** Decoded input JSON Schema. @var array|null */
+  public $input_schema = null;
+  /** Decoded output JSON Schema. @var array|null */
+  public $output_schema = null;
+  ```
+
+  **C) Add `get_json_fields()` static method** (FR-009 + F1 security guard):
+  ```php
+  /**
+   * Filterable list of fields stored as JSON in the database (FR-009).
+   *
+   * F1 SECURITY GUARD: Uses a blocklist of known scalar/computed columns that MUST NOT
+   * appear in the JSON decode loop (injecting them would corrupt Row properties in
+   * __construct()). Any new longtext/JSON column added via the filter IS allowed through,
+   * preserving the SC-005/FR-009 extensibility contract.
+   *
+   * Security Re-Review Correction N1 (2026-05-22): Changed from allowlist to blocklist.
+   *
+   * @since  0.1.0
+   * @return string[]
+   */
+  public static function get_json_fields(): array {
+      $base = array(
+          'mcp_servers', 'callback_config', 'input_schema', 'output_schema',
+      );
+
+      $fields = apply_filters( 'acrossai_abilities_json_fields', $base );
+
+      // F1: Protected scalar columns that MUST NOT appear in the JSON field list.
+      // Injecting these into the JSON decode loop would silently corrupt Row properties.
+      // Blocklist approach allows new longtext/JSON columns via filter (SC-005, FR-009).
+      $blocked_scalar_columns = array(
+          'id', 'ability_slug', 'label', 'description', 'category', 'status',
+          'provider', 'source', 'site_allowed', 'callback_type',
+          'show_in_rest', 'show_in_mcp', 'mcp_type', 'readonly', 'destructive',
+          'idempotent', 'created_at', 'updated_at', 'created_by', 'updated_by',
+      );
+
+      return array_values(
+          array_filter(
+              (array) $fields,
+              static function ( $field ) use ( $blocked_scalar_columns ) {
+                  return is_string( $field ) && ! in_array( $field, $blocked_scalar_columns, true );
+              }
+          )
+      );
+  }
+  ```
+
+  **D) Update `__construct()`** — replace any hardcoded `mcp_servers` JSON decode block with the registry loop:
+  ```php
+  // Decode JSON-encoded fields using the single filterable registry (FR-009, FR-008).
+  // Returns array|null — malformed JSON or non-array value yields null.
+  foreach ( self::get_json_fields() as $json_field ) {
+      if ( null !== $this->{$json_field} && isset( $this->{$json_field} ) ) {
+          $decoded             = json_decode( $this->{$json_field}, true );
+          $this->{$json_field} = is_array( $decoded ) ? $decoded : null;
+      }
+  }
+  ```
+  The tri-state cast block and integer cast block remain unchanged.
+
+  **Acceptance Criteria**:
+  - 24 public property declarations total (16 existing + 8 new)
+  - `$label` default is `null` — NOT `''` (FR-021)
+  - `$status` default is `'draft'` (FR-004)
+  - `$callback_type` default is `'noop'` (FR-007)
+  - `get_json_fields()` is `public static` — no instance state (DEC-UTILITY-STATIC-ONLY)
+  - `get_json_fields()` applies filter `acrossai_abilities_json_fields` (FR-009)
+  - `get_json_fields()` includes F1 blocklist guard — injecting `ability_slug` via filter returns it stripped; injecting a new longtext column name returns it included (SC-005/FR-009 extensibility preserved — Security Re-Review N1)
+  - `__construct()` JSON decode loop iterates `self::get_json_fields()` — NOT hardcoded `mcp_servers`
+  - Malformed JSON field returns `null`, not a raw string (FR-008)
+  - Tri-state cast block unchanged
+  - Integer cast block unchanged
+  - PHPCS: zero errors; PHPStan L8: zero errors
+
+  **Watchpoints**:
+  - ⛔ F1 guard: `get_json_fields()` blocklist MUST strip the 20 known scalar/computed columns; MUST allow new longtext column names added via filter (SC-005/FR-009 — N1 correction)
+  - ⛔ JSON decode: `is_array($decoded) ? $decoded : null` — non-array JSON value (e.g. JSON string `"hello"`) returns `null`
+  - ⛔ `label` property default: `null`, not `''`
+
+  **File**: `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Row.php`
+  **Dependencies**: T001, T002 (column list must be consistent across all 3 DB files)
+
+---
+
+## Phase 3: Query Layer Update (US1, US2)
+
+- [x] T004 [US1] [US2] Rename `$table_name`, replace `mcp_servers` encode block with registry loop, add F2 enum guards, and add `by_source()` method in `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Query.php`
+
+  **Changes**:
+
+  **A) Rename `$table_name`**:
+  ```diff
+  - protected $table_name = 'acrossai_abilities_overwrite';
+  + protected $table_name = 'acrossai_abilities';
+  ```
+
+  **B) In `save_override()` — remove the single `mcp_servers` hardcoded encode block and replace with registry loop** (FR-009, FR-010, FR-018):
+
+  Remove:
+  ```php
+  if ( isset( $fields['mcp_servers'] ) && is_array( $fields['mcp_servers'] ) ) {
+      $fields['mcp_servers'] = wp_json_encode( $fields['mcp_servers'] );
+  }
+  ```
+
+  Replace with:
+  ```php
+  // JSON-encode all array-valued JSON fields via the single filterable registry (FR-009/FR-010).
+  // If wp_json_encode() fails for a field, store null; save continues for remaining fields.
+  foreach ( AcrossAI_Sitewide_Row::get_json_fields() as $json_field ) {
+      if ( isset( $fields[ $json_field ] ) && is_array( $fields[ $json_field ] ) ) {
+          $encoded               = wp_json_encode( $fields[ $json_field ] );
+          $fields[ $json_field ] = false !== $encoded ? $encoded : null;
+      }
+  }
+  ```
+
+  **C) In `save_override()` — add F2 enum guards** (security-constraints.md Finding 2) immediately after the tri-state cast block and **before** the JSON registry loop, following the same pattern as the existing `mcp_type` guard:
+  ```php
+  // F2: Guard status — allow only known lifecycle values (varchar(20) defense-in-depth).
+  if ( array_key_exists( 'status', $fields ) && null !== $fields['status'] ) {
+      $allowed_statuses = array( 'draft', 'publish' );
+      if ( ! in_array( $fields['status'], $allowed_statuses, true ) ) {
+          unset( $fields['status'] );
+      }
+  }
+
+  // F2: Guard callback_type — allow only known callback types.
+  if ( array_key_exists( 'callback_type', $fields ) && null !== $fields['callback_type'] ) {
+      $allowed_callback_types = array( 'noop', 'filter_hook', 'wp_remote_post', 'php_code' );
+      if ( ! in_array( $fields['callback_type'], $allowed_callback_types, true ) ) {
+          unset( $fields['callback_type'] );
+      }
+  }
+  ```
+
+  **D) Keep these 3 blocks unchanged** (FR-018 — do NOT modify):
+  1. Tri-state bool-to-int cast block (`$tri_state_columns` foreach)
+  2. `mcp_type` value validation guard
+  3. `mcp_servers` non-string guard (runs after the new JSON loop)
+
+  **E) Add `by_source()` method** (FR-011, FR-019, BUG-BERLINDB-UNLIMITED):
+  ```php
+  /**
+   * Retrieve all ability records matching a given source (FR-019).
+   *
+   * Method name MUST be by_source() — spec 009 calls it by this exact name.
+   * Returns [] immediately when $source is empty or null (FR-011).
+   * Uses 'number' => 0 for unlimited results (BUG-BERLINDB-UNLIMITED pattern).
+   *
+  * Caller responsibility: all public callers MUST verify current_user_can( 'manage_options' )
+   * before exposing results to clients. This method performs no capability check (DB layer).
+   *
+   * @since  0.1.0
+   * @param  string|null $source Source value to filter by (e.g. 'db', 'plugin').
+   * @return AcrossAI_Sitewide_Row[]
+   */
+  public function by_source( ?string $source ): array {
+      if ( empty( $source ) ) {
+          return array();
+      }
+
+      $results = $this->query(
+          array(
+              'source' => $source,
+              'number' => 0,
+          )
+      );
+
+      return array_filter(
+          $results,
+          static function ( $row ) {
+              return $row instanceof AcrossAI_Sitewide_Row;
+          }
+      );
+  }
+  ```
+
+  **Acceptance Criteria**:
+  - `$table_name === 'acrossai_abilities'`
+  - `save_override()` JSON encoding loop calls `AcrossAI_Sitewide_Row::get_json_fields()` (not hardcoded field list)
+  - Encoding failure stores `null` (not `false`) and does NOT abort the save (FR-010)
+  - F2 `status` guard: `'invalid_long_value'` is unset before DB write; `'draft'` and `'publish'` pass through
+  - F2 `callback_type` guard: `'invalid_type'` is unset before DB write; `'noop'`, `'filter_hook'`, `'wp_remote_post'` pass through
+  - FR-018 three blocks MUST remain completely unchanged (verify by diff): (1) tri-state cast, (2) `mcp_type` guard, (3) `mcp_servers` non-string guard
+  - Method name is exactly `by_source()` — NOT `get_all_by_source()` (FR-019)
+  - `by_source(null)` returns `[]` (FR-011)
+  - `by_source('')` returns `[]` (FR-011)
+  - `by_source('db')` returns all rows where `source = 'db'`, unlimited (BUG-BERLINDB-UNLIMITED)
+  - Query uses `'number' => 0` — NOT `-1` or `9999` (BUG-BERLINDB-UNLIMITED)
+  - `by_source()` docblock includes explicit `current_user_can( 'manage_options' )` caller-responsibility note (Security Re-Review N3)
+  - PHPCS: zero errors; PHPStan L8: zero errors
+
+  **Watchpoints**:
+  - ⛔ FR-019: Method name is `by_source()` exactly — `get_all_by_source()` breaks spec 009's call site
+  - ⛔ BUG-BERLINDB-UNLIMITED: `'number' => 0`; `absint(-1) = 1` silently limits to 1 row
+  - ⛔ FR-018: Do NOT touch the 3 preserved blocks — verify by diff against original file
+  - ⛔ F2 guards must use strict `in_array(..., true)` comparison (SEC-04)
+  - ⛔ JSON loop placement: after tri-state cast + F2 guards, before `mcp_type`/`mcp_servers` guards
+
+  **File**: `includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Query.php`
+  **Dependencies**: T003 (`AcrossAI_Sitewide_Row::get_json_fields()` must exist before Query references it)
+
+---
+
+## Phase 4: Uninstall Cleanup (US3) — Parallel
+
+- [x] T005 [P] [US3] Add DROP and `delete_option` for the new table/option names in `uninstall.php`
+
+  **Changes**: Insert 2 new lines **before** the existing `acrossai_abilities_overwrite` DROP so the new name is cleaned first, then the old name:
+
+  ```php
+  // Drop the unified abilities table (renamed in feature 008).
+  // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+  $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}acrossai_abilities`" );
+
+  // Remove BerlinDB db-version option for the unified abilities table.
+  delete_option( 'acrossai_abilities_db_version' );
+  ```
+
+  The existing two lines (old table name) must be kept exactly as-is:
+  ```php
+  $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}acrossai_abilities_overwrite`" );
+  delete_option( 'acrossai_abilities_overwrite_db_version' );
+  ```
+
+  **Acceptance Criteria**:
+  - `DROP TABLE IF EXISTS {prefix}acrossai_abilities` present (FR-013)
+  - `delete_option( 'acrossai_abilities_db_version' )` present (FR-013, FR-014)
+  - `DROP TABLE IF EXISTS {prefix}acrossai_abilities_overwrite` still present (backward-compat)
+  - `delete_option( 'acrossai_abilities_overwrite_db_version' )` still present (backward-compat)
+  - New DROP precedes old DROP (cleanup order: new name first)
+  - `WP_UNINSTALL_PLUGIN` guard unchanged
+  - PHPCS inline suppression comment on new `$wpdb->query()` line (matching existing file style)
+  - PHPCS: zero errors
+
+  **Watchpoints**:
+  - ⛔ Do NOT remove the old `acrossai_abilities_overwrite` lines — needed for backward-compat cleanup on existing sites
+  - ⛔ Table reference must use `{$wpdb->prefix}` interpolation — not hardcoded prefix
+
+  **File**: `uninstall.php`
+  **Dependencies**: None — parallel with T001–T004
+
+---
+
+## Phase 5: Quality Gate
+
+- [x] T006 Run PHPCS, PHPStan L8, and verify FR-015 compliance across all 5 modified files
+
+  **Verification Steps**:
+
+  1. **PHPCS**: `composer phpcs` — zero errors, zero warnings across all 5 files
+  2. **PHPStan L8**: `composer phpstan -- --level 8` — zero errors across all 5 files
+  3. **FR-015 compliance** — verify these 3 files have zero diff:
+     - `includes/Main.php`
+     - `includes/AcrossAI_Activator.php`
+     - `tests/phpunit/integration/` (all test files)
+  4. **FR-017 guard**: `grep -n "version" includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Table.php` — confirm `$version = '1.0.0'`
+  5. **SEC-03 guard**: confirm `$global = false` still present in Table
+  6. **FR-016 indexes**: inspect `set_schema()` — exactly 5 indexes; `ability_slug` is `UNIQUE KEY`
+  7. **FR-018 diff**: diff `save_override()` against original — confirm only the `mcp_servers` hardcoded block was removed and the 3 preserved blocks are byte-for-byte identical
+  8. **FR-019 name check**: `grep -n "by_source\|get_all_by_source" includes/Modules/Sitewide/Database/AcrossAI_Sitewide_Query.php` — only `by_source` present
+  9. **BUG-BERLINDB-UNLIMITED**: `by_source()` passes `'number' => 0` — NOT `-1`
+  10. **F1 blocklist guard** (N1): `AcrossAI_Sitewide_Row::get_json_fields()`:
+      - Add `'ability_slug'` via filter → must NOT appear in result (scalar blocked)
+      - Add `'custom_metadata'` (hypothetical new longtext col) via filter → MUST appear in result (extensibility preserved, SC-005)
+  11. **F2 guards**: call `save_override()` with `status = 'invalid_long_status'` — verify `status` is unset before BerlinDB write
+  12. **FR-020**: `set_schema()` SQL contains `varchar(20)` for `status` — NOT `varchar(50)`
+  12.5 **N4 advisory — JSON caller contract** (advisory): Verify that `save_override()` has a comment: `// JSON field size/depth validation is the caller's responsibility.` If REST controllers exist that call `save_override()` with `callback_config`/`input_schema`/`output_schema`, confirm they enforce max 64KB size and max 10 nesting levels
+  13. **FR-021**: `set_schema()` SQL contains `DEFAULT NULL` for `label` — NOT `NOT NULL DEFAULT ''`
+  14. **FR-021 Row**: `AcrossAI_Sitewide_Row::$label` default is `null` — NOT `''`
+  15. **FR-012 audit-field immutability**: Insert a record. Then call `update_item($id, ['status' => 'publish'])`. Re-read the row and verify `created_at` and `created_by` are byte-for-byte identical to the insert values; verify only `updated_at` and `updated_by` changed. (FR-012 requirement: on update, `created_at`/`created_by` MUST NOT be overwritten.)
+  16. **Existing test suite**: run `composer test` — all pre-existing tests must pass (SC-002)
+
+  **Acceptance Criteria**:
+  - All 16 verification steps above pass with zero failures
+  - PHPCS: zero errors on all 5 files
+  - PHPStan L8: zero errors on all 5 files
+  - Zero modifications to `Main.php`, `AcrossAI_Activator.php`, or any test file (FR-015)
+  - `$version === '1.0.0'` in Table (FR-017)
+  - `$global === false` in Table (SEC-03)
+  - Existing test suite passes (SC-002)
+
+  **Files**: All 5 modified files + run test suite
+  **Dependencies**: T001, T002, T003, T004, T005
+
+---
+
+## Dependency Graph
+
+```
+T001 (Table)
+  └─→ T002 (Schema) [columns must match T001 DDL order]
+        └─→ T003 (Row) [get_json_fields() must exist before T004]
+              └─→ T004 (Query) [calls AcrossAI_Sitewide_Row::get_json_fields()]
+                    └─→ T006 (Quality Gate)
+
+T005 (uninstall.php) [P — parallel with T001–T004]
+  └─→ T006 (Quality Gate)
+```
+
+---
+
+## Success Criteria Coverage
+
+| SC | Criterion | Task |
+|----|-----------|------|
+| SC-001 | 24 columns on fresh install | T001 (`set_schema`), T002 (Schema `$columns`) |
+| SC-002 | Existing tests pass unmodified | FR-015 guard in T006 |
+| SC-003 | 24-field round-trip without data loss | T002 + T003 (Row properties + JSON decode) |
+| SC-004 | `by_source()` exact-match query | T004 (`by_source()` method) |
+| SC-005 | New JSON field via filter auto-decoded/encoded | T003 (`get_json_fields()`) + T004 (registry loop) |
+| SC-006 | Uninstall leaves no trace | T005 (DROP + delete_option) |
+
+---
+
+## Summary
+
+| Task | File | Story | Parallel | Complexity |
+|------|------|-------|----------|------------|
+| T001 | `AcrossAI_Sitewide_Table.php` | US1, US3 | — | S |
+| T002 | `AcrossAI_Sitewide_Schema.php` | US1 | — | S |
+| T003 | `AcrossAI_Sitewide_Row.php` | US1 | — | M |
+| T004 | `AcrossAI_Sitewide_Query.php` | US1, US2 | — | M |
+| T005 | `uninstall.php` | US3 | ✓ | XS |
+| T006 | All 5 files (quality gate) | — | — | S |
+
+**Total tasks**: 6 | **MVP scope**: T001–T005 (T006 is quality gate)

--- a/uninstall.php
+++ b/uninstall.php
@@ -16,7 +16,12 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 global $wpdb;
 
-// Drop the sitewide ability overrides table.
+// Drop the unified abilities table (renamed in 008-unified-abilities-table).
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+$wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}acrossai_abilities`" );
+delete_option( 'acrossai_abilities_db_version' );
+
+// Drop the legacy sitewide ability overrides table (backward compat).
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
 $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}acrossai_abilities_overwrite`" );
 


### PR DESCRIPTION
… by_source()

- Rename DB table from acrossai_abilities_overwrite → acrossai_abilities
- Expand schema from 16 → 24 columns (label, description, category, status, callback_type/config, input/output_schema) with 5 indexes
- Add AcrossAI_Sitewide_Row::get_json_fields() — filterable JSON field registry (filter: acrossai_abilities_json_fields) with F1 blocklist guard
- Replace hardcoded mcp_servers encode/decode with registry-driven loops (FR-009/010)
- Add F2 enum guards for status and callback_type in save_override() (FR-018)
- Add by_source() query method with AUTHORIZATION CONTRACT docblock (FR-011/019)
- Add 64 KB size guard on JSON registry fields in save_override() (TASK-SEC-001)
- Update uninstall.php to drop acrossai_abilities and delete correct option key
- Remove enabled column (status=publish is the sole registration control)
- Add spec/plan/tasks/security-constraints artifacts for feature 008