### PR TITLE
feat(019): add Settings submenu page with log retention and uninstall gate

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/018-user-access-form"}
+{"feature_directory":"specs/019-admin-settings-page"}

--- a/admin/Main.php
+++ b/admin/Main.php
@@ -131,7 +131,9 @@ class Main {
 	 * @param    string $hook_suffix Current admin page hook suffix.
 	 */
 	public function enqueue_styles( string $hook_suffix ) {
-		if ( ! $this->is_manager_page( $hook_suffix ) && ! $this->is_logs_page( $hook_suffix ) ) {
+		if ( ! $this->is_manager_page( $hook_suffix )
+			&& ! $this->is_logs_page( $hook_suffix )
+			&& ! $this->is_settings_page( $hook_suffix ) ) {
 			return;
 		}
 
@@ -165,7 +167,9 @@ class Main {
 	 * @param    string $hook_suffix Current admin page hook suffix.
 	 */
 	public function enqueue_scripts( string $hook_suffix ) {
-		if ( ! $this->is_manager_page( $hook_suffix ) && ! $this->is_logs_page( $hook_suffix ) ) {
+		if ( ! $this->is_manager_page( $hook_suffix )
+			&& ! $this->is_logs_page( $hook_suffix )
+			&& ! $this->is_settings_page( $hook_suffix ) ) {
 			return;
 		}
 
@@ -243,6 +247,17 @@ class Main {
 	 */
 	private function is_manager_page( string $hook_suffix ): bool {
 		return 'toplevel_page_acrossai-abilities-manager' === $hook_suffix;
+	}
+
+	/**
+	 * Checks whether the current admin screen is the settings page.
+	 *
+	 * @since    0.1.0
+	 * @param string $hook_suffix The hook suffix for the current admin screen.
+	 * @return bool
+	 */
+	private function is_settings_page( string $hook_suffix ): bool {
+		return 'acrossai-abilities-manager_page_acrossai-abilities-settings' === $hook_suffix;
 	}
 
 	/**

--- a/admin/Partials/SettingsMenu.php
+++ b/admin/Partials/SettingsMenu.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * The settings submenu page for the plugin.
+ *
+ * Provides the settings submenu page for the plugin and registers
+ * the plugin settings using the WordPress Settings API.
+ *
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Admin/Partials
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Admin\Partials;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The settings submenu page for the plugin.
+ *
+ * Defines the plugin settings submenu page and registers settings sections
+ * and fields using the WordPress Settings API.
+ *
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Admin/Partials
+ * @since      0.1.0
+ */
+class SettingsMenu {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @since 0.1.0
+	 * @var SettingsMenu|null
+	 */
+	protected static $_instance = null;
+
+	/**
+	 * Returns the singleton instance of this class.
+	 *
+	 * @since 0.1.0
+	 * @return self
+	 */
+	public static function instance(): self {
+		if ( null === self::$_instance ) {
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
+
+	/**
+	 * Private constructor.
+	 *
+	 * @since 0.1.0
+	 */
+	private function __construct() {}
+
+	/**
+	 * Registers the settings submenu page.
+	 *
+	 * Hooked to admin_menu.
+	 *
+	 * @since 0.1.0
+	 * @return void
+	 */
+	public function register_submenu(): void {
+		add_submenu_page(
+			'acrossai-abilities-manager',
+			__( 'Settings', 'acrossai-abilities-manager' ),
+			__( 'Settings', 'acrossai-abilities-manager' ),
+			'manage_options',
+			'acrossai-abilities-settings',
+			array( $this, 'render' )
+		);
+	}
+
+	/**
+	 * Registers settings sections and fields via the WordPress Settings API.
+	 *
+	 * Hooked to admin_init.
+	 *
+	 * @since 0.1.0
+	 * @return void
+	 */
+	public function register_settings(): void {
+		// Log retention option.
+		register_setting(
+			'acrossai_abilities_settings',
+			'acrossai_abilities_log_retention_days',
+			array(
+				'sanitize_callback' => 'absint',
+				'default'           => 0,
+			)
+		);
+
+		// Uninstall delete data option.
+		register_setting(
+			'acrossai_abilities_settings',
+			'acrossai_abilities_uninstall_delete_data',
+			array(
+				'sanitize_callback' => array( $this, 'sanitize_uninstall_flag' ),
+				'default'           => 0,
+			)
+		);
+
+		// Section 1: Log settings.
+		add_settings_section(
+			'acrossai_log_settings_section',
+			__( 'Log Settings', 'acrossai-abilities-manager' ),
+			'__return_false',
+			'acrossai-abilities-settings'
+		);
+
+		add_settings_field(
+			'acrossai_abilities_log_retention_days',
+			__( 'Delete logs after (days)', 'acrossai-abilities-manager' ),
+			array( $this, 'render_retention_field' ),
+			'acrossai-abilities-settings',
+			'acrossai_log_settings_section'
+		);
+
+		// Section 2: Uninstall settings.
+		add_settings_section(
+			'acrossai_uninstall_settings_section',
+			__( 'Uninstall Settings', 'acrossai-abilities-manager' ),
+			'__return_false',
+			'acrossai-abilities-settings'
+		);
+
+		add_settings_field(
+			'acrossai_abilities_uninstall_delete_data',
+			__( 'Delete all data on uninstall', 'acrossai-abilities-manager' ),
+			array( $this, 'render_uninstall_field' ),
+			'acrossai-abilities-settings',
+			'acrossai_uninstall_settings_section'
+		);
+	}
+
+	/**
+	 * Sanitizes the uninstall delete data checkbox value.
+	 *
+	 * Returns 1 when the checkbox is checked, 0 when unchecked or absent.
+	 * Browsers do not send unchecked checkboxes, so an absent value means 0.
+	 *
+	 * @since 0.1.0
+	 * @param mixed $value Raw submitted value.
+	 * @return int
+	 */
+	public function sanitize_uninstall_flag( $value ): int {
+		return empty( $value ) ? 0 : 1;
+	}
+
+	/**
+	 * Renders the log retention days input field.
+	 *
+	 * @since 0.1.0
+	 * @return void
+	 */
+	public function render_retention_field(): void {
+		$value = (int) get_option( 'acrossai_abilities_log_retention_days', 0 );
+		printf(
+			'<input type="number" id="acrossai_abilities_log_retention_days" name="acrossai_abilities_log_retention_days" value="%s" min="0" step="1" /><p class="description">%s</p>',
+			esc_attr( (string) $value ),
+			esc_html__( 'Set to 0 to keep logs forever. If a number is entered, logs older than that many days will be automatically deleted.', 'acrossai-abilities-manager' )
+		);
+	}
+
+	/**
+	 * Renders the uninstall delete data checkbox field.
+	 *
+	 * @since 0.1.0
+	 * @return void
+	 */
+	public function render_uninstall_field(): void {
+		$checked = (bool) get_option( 'acrossai_abilities_uninstall_delete_data', 0 );
+		printf(
+			'<label><input type="checkbox" id="acrossai_abilities_uninstall_delete_data" name="acrossai_abilities_uninstall_delete_data" value="1" %s /> %s</label><p class="description"><span style="color: #d63638;">%s</span></p>',
+			checked( $checked, true, false ),
+			esc_html__( 'Delete all data on uninstall', 'acrossai-abilities-manager' ),
+			esc_html__( '⚠ Warning: When checked, uninstalling this plugin will permanently delete all custom database tables and plugin options. This cannot be undone.', 'acrossai-abilities-manager' )
+		);
+	}
+
+	/**
+	 * Renders the settings page.
+	 *
+	 * @since 0.1.0
+	 * @return void
+	 */
+	public function render(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Insufficient permissions.', 'acrossai-abilities-manager' ) );
+		}
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Abilities Manager — Settings', 'acrossai-abilities-manager' ); ?></h1>
+			<form method="post" action="options.php">
+				<?php
+				settings_fields( 'acrossai_abilities_settings' );
+				do_settings_sections( 'acrossai-abilities-settings' );
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
+	}
+}

--- a/docs/memory/ARCHITECTURE.md
+++ b/docs/memory/ARCHITECTURE.md
@@ -539,3 +539,27 @@ Always scope to the target section. Global `container.querySelector('p.desc')` w
 find the first match across all sections, producing false positives.
 
 **Evidence**: Feature 018 T022 (2026-05-29) — `p.desc` from Section 3 ("No MCP servers registered yet.") was falsely matching Section 5 assertion.
+
+---
+
+## PATTERN-CHECKBOX-SANITIZE (2026-05-29, Feature 019)
+
+Checkbox `register_setting()` sanitize callbacks MUST handle absent values. Browsers do not transmit unchecked checkbox inputs, so the callback receives `null`/`''` when the box is unchecked. Use `empty($value) ? 0 : 1` in a named public method (`sanitize_*_flag()`), not an inline closure (Settings API cannot serialize closures). Pass it as `array( $this, 'sanitize_*_flag' )`.
+
+**Canonical example**: `SettingsMenu::sanitize_uninstall_flag()` in `admin/Partials/SettingsMenu.php`.
+
+---
+
+## PATTERN-UNINSTALL-DATA-GATE (2026-05-29, Feature 019)
+
+`uninstall.php` MUST guard all destructive SQL inside `if ( (bool) get_option('acrossai_abilities_uninstall_delete_data', 0) )`. Tables and data are **preserved by default** (option default `0`). Plugin-owned settings options (config, not data) are always removed unconditionally.
+
+**Rationale**: Prevents accidental data loss on plugin reinstall cycles or test-env uninstall triggers.
+
+---
+
+## PATTERN-LOGGER-OPTION-FEED-FILTER (2026-05-29, Feature 019)
+
+When a module reads a settings option AND exposes an `apply_filters()` hook, feed the option value as the filter default: `apply_filters( 'hook', get_option( 'key', 0 ) )`. The scheduling guard short-circuits when the effective value is `0` (never schedule). This decouples "should I schedule?" from execution and preserves filter-based override for testing/programmatic control.
+
+**Canonical example**: `AcrossAI_Ability_Logger::schedule_cleanup()` + `cleanup_old_logs()` in `includes/Modules/Logger/AcrossAI_Ability_Logger.php`.

--- a/docs/memory/DECISIONS.md
+++ b/docs/memory/DECISIONS.md
@@ -1001,3 +1001,20 @@ its loaded state via `onChange`, not via a separate "loaded" event.
 **Evidence**: Feature 018 T025 (2026-05-29). `AbilityForm.jsx` `handleAcChange`.
 
 **Where to look next**: `src/js/abilities/components/AbilityForm.jsx` (`handleAcChange`, `acInitialRef`).
+
+---
+
+### 2026-05-29 — WP Settings API accepted deviation from DataForm mandate (DEC-SETTINGS-API-DEVIATION)
+
+**Context**
+Constitution §III (NON-NEGOTIABLE) mandates `@wordpress/dataforms` for all admin form handling. Feature 019 (Admin Settings Page) uses the WordPress Settings API (PHP-rendered form, `options.php` action) instead.
+
+**Decision**
+WP Settings API is the accepted implementation for Feature 019. Justification: the Settings API provides built-in nonce generation (`settings_fields()`), sanitize-callback dispatch (`register_setting()`), and the `options.php` redirect without requiring a custom REST write endpoint. Introducing DataForm would add a REST POST endpoint, client-side JS bundle, and token/nonce bridging solely to replicate what the native API provides for free. For simple scalar-field settings pages (≤ 5 fields), the Settings API is the correct tool.
+
+**Rule**
+This deviation applies only to scalar-field Settings pages using the native Settings API. Any settings page that has custom UI behaviour (dynamic fields, dependent selects, AJAX-powered) MUST use DataForm. This entry does not blanket-approve Settings API for all future features.
+
+**Feature scope**: Feature 019 only (`admin/Partials/SettingsMenu.php`).
+
+**Evidence**: `specs/019-admin-settings-page/spec.md` FR-004, Assumptions §1; security review 2026-05-29.

--- a/docs/memory/INDEX.md
+++ b/docs/memory/INDEX.md
@@ -29,6 +29,7 @@ This is a compact routing map for durable memory. Keep it short. It points to so
 | DEC-SAVE-OVERRIDE-RETURN-ROW | save_override() returns Row\|false (not bool); Write Controller uses row directly; PHP 7.4 union via @return docblock only | DB/BerlinDB | save_override, return-type, berlinddb, php74 | Active | DECISIONS.md |
 | DEC-MCP-SERVER-SANITIZE | sanitize_mcp_servers_array(): null-passthrough, per-element sanitize+255-substr, array_slice(100), REST args schema as defence-in-depth | Abilities/REST/Sanitizer | mcp-servers, sanitize, rest-args, defence-in-depth | Active | DECISIONS.md |
 | DEC-MCP-CAPABILITY-FILTER-WARN | wpb_mcp_servers_list_rest_capability filter wiring point MUST include a manage_options warning comment | Abilities/Main | mcp, capability, filter, warning-comment | Active | DECISIONS.md |
+| DEC-SETTINGS-API-DEVIATION | WP Settings API accepted for scalar-field (≤5 fields) settings pages; DataForm required for dynamic UI | Admin/Settings | settings-api, dataform, constitution-deviation, 019 | Active | DECISIONS.md |
 
 ## Architecture Constraints
 | ID | Constraint | Scope | Tags | Source |
@@ -52,6 +53,9 @@ This is a compact routing map for durable memory. Keep it short. It points to so
 | PATTERN-ASSET-DECOMMISSION-ORDER | Remove PHP `include` first, then webpack entry + source files, then clean build | Admin/Build | decommission, webpack, include, order | ARCHITECTURE.md |
 | PATTERN-MODULE-DECOMMISSION | 8-step ordered decommission: rename DB → port CRUD → update consumers → delete REST → grep-then-delete | Plugin-wide | decommission, module, berlinddb, cleanup | ARCHITECTURE.md |
 | PATTERN-BERLINDDB-QUERY-PORT | BerlinDB Query port only needs $table_schema/$item_shape + use-statement updates; no new Row/Schema classes | BerlinDB | berlinddb, port, rename, query | ARCHITECTURE.md |
+| PATTERN-CHECKBOX-SANITIZE | Checkbox sanitize_callback: absent→0, present→1; named public method, not closure | Admin/Settings | checkbox, sanitize, settings-api, absent-field | ARCHITECTURE.md |
+| PATTERN-UNINSTALL-DATA-GATE | uninstall.php wraps DROP TABLE in opt-in delete-data gate; config options always removed | Plugin-wide | uninstall, data-gate, destructive, default-safe | ARCHITECTURE.md |
+| PATTERN-LOGGER-OPTION-FEED-FILTER | Module reads option → feeds apply_filters() default; schedule guard short-circuits at 0 | Logger | logger, option, filter, retention, schedule | ARCHITECTURE.md |
 
 ## Bug Patterns
 | ID | Pattern | Affected Area | Tags | Source |
@@ -81,6 +85,7 @@ This is a compact routing map for durable memory. Keep it short. It points to so
 |---|---|---|---|---|
 | ARCH-ADV-001 | `boot()` wires hooks directly (bypasses Boot Flow Rule) when PATH-A/B conditional loading required — **scope: Override Processor only** (Logger boot() removed Feature 017) | Sitewide/Override | Review if Boot Flow Rule gains conditional-load support | DECISIONS.md |
 | DEV1 | `McpVisibilityControl` uses compound-control pattern instead of DataForm | Sitewide/Admin | Review if DataForm gains compound-control support | memory-synthesis.md |
+| DEC-SETTINGS-API-DEVIATION | WP Settings API instead of DataForm for scalar-field settings pages (≤5 fields); DataForm required for dynamic UI | Admin/Settings | None — permanent exception for scalar settings pages | DECISIONS.md |
 
 ## Worklog Milestones
 | Date | Milestone | Scope | Tags | Source |
@@ -89,6 +94,7 @@ This is a compact routing map for durable memory. Keep it short. It points to so
 | 2026-05-20 | Feature 006 logger establishes hook parameter adaptation patterns | Logger | patterns, reusability, hook-adaption | WORKLOG.md |
 | 2026-05-25 | Feature 012: Sitewide module decommissioned; Abilities module is sole override owner (T001-T030 complete) | Abilities | feature-012, decommission, berlinddb, phpcs | WORKLOG.md |
 | 2026-05-25 | Feature 013: Four-field required validation complete (slug/label/description/category) | Abilities | feature-013, validation, sec-04, react | WORKLOG.md |
+| 2026-05-29 | Feature 019: Settings page (WP Settings API, uninstall gate, Logger option guard); DEC-SETTINGS-API-DEVIATION added | Admin/Settings/Logger | feature-019, settings-api, uninstall-gate, logger, deviation | WORKLOG.md |
 
 | DEC-STABLE-UPGRADE-WINDOW | Prioritize first stable releases (v1.0.0, v1.0.1) when upgrading from dev branches | Dependencies | stable-release, upgrade, risk-mitigation | DECISIONS.md |
 | DEC-AC-RENDERING-GATE | access_control_available is a rendering gate only; server auth enforced by wpb-ac/v1 REST endpoints | Abilities/Admin | access-control, rendering-gate, client-side, auth | DECISIONS.md |

--- a/docs/memory/WORKLOG.md
+++ b/docs/memory/WORKLOG.md
@@ -200,3 +200,12 @@ Customize Phase 1 tests based on library criticality and integration depth.
 - **Why durable**: Five reusable patterns captured: (1) `@wpb/access-control` named-import + webpack-alias + SCSS + three-branch rendering, (2) `access_control_available` rendering gate vs auth gate, (3) `acSaveOk` dirty-reset pattern for sub-saves, (4) `acInitialRef` baseline on first `onChange`, (5) four Jest gotchas (`@wordpress/element` v6 `act`, module-level window reads, `await act(async)` for React 18 effects, `api-fetch` virtual mock).
 - **Evidence**: T022 DoD-gate 3/3 green; T028 build pass; T029 validate-packages pass; T030 5-file count confirmed. RT-AR-001/002/003 all applied. Security review: 2 LOW findings (no blockers).
 - **Where to look**: `src/js/abilities/components/AbilityForm.jsx` (Section 5, handleAcChange, AC save block), `admin/Main.php` (access_control_available), `webpack.config.js` (alias), `tests/jest/abilities/ability-form-user-access-section.test.jsx`, `specs/018-user-access-form/`.
+
+---
+
+### 2026-05-29 — Feature 019: safe-by-default uninstall gate and WP Settings API deviation pattern
+
+- **Why durable**: Three reusable patterns introduced: checkbox absent-field sanitizer, data-preservation gate in uninstall, and option→filter default chaining in modules.
+- **Future mistake prevented**: (1) Checkbox sanitize callbacks that silently fail on absent POST fields. (2) `uninstall.php` that drops tables without explicit user consent. (3) Modules that hardcode filter defaults instead of delegating to the settings option.
+- **Evidence**: Feature 019 complete; `admin/Partials/SettingsMenu.php` (new singleton), `uninstall.php` (conditional gate), `includes/Modules/Logger/AcrossAI_Ability_Logger.php` (retention option guard + filter chaining).
+- **Where to look**: `admin/Partials/SettingsMenu.php`, `uninstall.php`, `includes/Modules/Logger/AcrossAI_Ability_Logger.php`, `docs/memory/DECISIONS.md` (DEC-SETTINGS-API-DEVIATION).

--- a/docs/planning/019-admin-settings-page.md
+++ b/docs/planning/019-admin-settings-page.md
@@ -1,0 +1,408 @@
+# Planning: Admin Settings Page (Feature 019)
+
+Add a **Settings** submenu page under the Abilities Manager top-level admin menu.
+The page exposes two setting groups:
+
+1. **Log Settings** — number input controlling how many days before execution logs are
+   auto-deleted (0 = never delete, which is the new default; the old hard-coded default
+   was 30 days).
+2. **Uninstall Settings** — checkbox that controls whether custom database tables and
+   plugin options are dropped when the plugin is uninstalled. Unchecked by default, with
+   a prominent red warning note.
+
+---
+
+## Spec-kit Workflow
+
+```markdown
+# 1. Branch
+/speckit.git.feature "019-admin-settings-page"
+
+# 2. Specify
+/speckit.specify "Add Settings submenu page to Abilities Manager admin menu.
+Two sections: (A) Log Settings — number input for retention days (0 = never, default 0)
+stored in option 'acrossai_abilities_log_retention_days', (B) Uninstall Settings —
+checkbox 'delete all data on uninstall' (default unchecked) stored in option
+'acrossai_abilities_uninstall_delete_data', with red warning text.
+Five files change: (1) NEW admin/Partials/SettingsMenu.php (singleton submenu + Settings API),
+(2) includes/Main.php (register submenu in define_admin_hooks),
+(3) admin/Main.php (is_settings_page guard + enqueue for settings page),
+(4) includes/Modules/Logger/AcrossAI_Ability_Logger.php (read option in cleanup_old_logs
+and skip scheduling when retention=0),
+(5) uninstall.php (conditional deletion based on option value)."
+```
+
+---
+
+## Background — what is already done; do NOT redo it
+
+| # | Fact | How to verify |
+|---|------|---------------|
+| B-1 | `LogsMenu` singleton at `admin/Partials/LogsMenu.php` is the exact pattern to follow for the new `SettingsMenu` singleton | read the file |
+| B-2 | `includes/Main.php::define_admin_hooks()` registers `LogsMenu::instance()` on `admin_menu`; the same pattern applies for `SettingsMenu` | `grep -n "logs_menu" includes/Main.php` |
+| B-3 | `admin/Main.php` already has `is_logs_page()` and `is_manager_page()` guards; a new `is_settings_page()` guard follows the same pattern | read `admin/Main.php` |
+| B-4 | `AcrossAI_Ability_Logger::cleanup_old_logs()` already reads retention days via `apply_filters('acrossai_ability_log_retention_days', 30)` — CHANGE-4 replaces the filter default with the stored option | `grep -n "retention_days" includes/Modules/Logger/AcrossAI_Ability_Logger.php` |
+| B-5 | `schedule_cleanup()` currently schedules unconditionally when Action Scheduler is present; CHANGE-4 must skip scheduling when retention = 0 | `grep -n "schedule_cleanup" includes/Modules/Logger/AcrossAI_Ability_Logger.php` |
+| B-6 | `uninstall.php` currently always drops tables and deletes options; CHANGE-5 wraps this in a conditional | read `uninstall.php` |
+| B-7 | Two option keys already exist in `uninstall.php`: `acrossai_abilities_db_version` and `wpb_access_control_db_version` | read `uninstall.php` |
+
+---
+
+## Option Keys (authoritative list)
+
+| Option key | Type | Default | Purpose |
+|------------|------|---------|---------|
+| `acrossai_abilities_log_retention_days` | `int` | `0` | Log auto-delete retention; 0 = never |
+| `acrossai_abilities_uninstall_delete_data` | `bool` (stored as `1`/`0`) | `0` (false) | If `1`, drop tables and delete all options on uninstall |
+
+Both keys are registered with `register_setting()` in `SettingsMenu` so WordPress handles
+sanitization, nonce validation, and the redirect after save.
+
+---
+
+## CHANGE-1 — NEW `admin/Partials/SettingsMenu.php`
+
+Create a new singleton class following the `LogsMenu` pattern exactly:
+
+```
+namespace AcrossAI_Abilities_Manager\Admin\Partials;
+class SettingsMenu { ... }
+```
+
+**Singleton contract** (identical to `LogsMenu`):
+- `protected static $_instance = null`
+- `public static function instance(): self`
+- `private function __construct()`
+- `private $hook_suffix = ''`
+- `public function get_hook_suffix(): string`
+
+**`register_submenu()` method** — hooked to `admin_menu`:
+
+```php
+$this->hook_suffix = add_submenu_page(
+    'acrossai-abilities-manager',
+    __( 'Settings', 'acrossai-abilities-manager' ),
+    __( 'Settings', 'acrossai-abilities-manager' ),
+    'manage_options',
+    'acrossai-abilities-settings',
+    array( $this, 'render' )
+);
+```
+
+**`register_settings()` method** — hooked to `admin_init`:
+
+Uses the WordPress Settings API. Registers two settings sections and fields under the
+option group `acrossai_abilities_settings`.
+
+
+Section 1: `acrossai_log_settings_section`
+- Title: "Log Settings"
+- Field ID: `acrossai_abilities_log_retention_days`
+- Label: "Delete logs after (days)"
+- Type: `number`, min `0`, step `1`
+- Sanitize: `absint` — returns integer ≥ 0; 0 means "never delete"
+- Description below field: "Set to 0 to keep logs forever. If a number is entered,
+  logs older than that many days will be automatically deleted."
+
+Section 2: `acrossai_uninstall_settings_section`
+- Title: "Uninstall Settings"
+- Field ID: `acrossai_abilities_uninstall_delete_data`
+- Label: "Delete all data on uninstall"
+- Type: `checkbox`, value `1`
+- Sanitize: cast to `int`, clamp to 0 or 1
+- Below the checkbox, render a `<p>` with class `description` styled red:
+  `<span style="color: #d63638;">⚠ Warning: When checked, uninstalling this plugin will
+  permanently delete all custom database tables and plugin options. This cannot be undone.</span>`
+
+**`render()` method** — outputs the settings page HTML:
+
+```php
+public function render(): void {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_die( esc_html__( 'Insufficient permissions.', 'acrossai-abilities-manager' ) );
+    }
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Abilities Manager — Settings', 'acrossai-abilities-manager' ); ?></h1>
+        <form method="post" action="options.php">
+            <?php
+            settings_fields( 'acrossai_abilities_settings' );
+            do_settings_sections( 'acrossai-abilities-settings' );
+            submit_button();
+            ?>
+        </form>
+    </div>
+    <?php
+}
+```
+
+**Security constraints**:
+- `current_user_can( 'manage_options' )` check at the top of `render()`.
+- Settings API handles nonce (`settings_fields()`) and redirect.
+- All output uses `esc_html_e()`, `esc_attr()`, `wp_kses_post()` as appropriate.
+- Sanitize callbacks must be strict: `absint` for the integer, `intval` + clamp for the bool.
+- PHPStan level 8 must pass. PHPCS must pass.
+
+---
+
+## CHANGE-2 — `includes/Main.php`
+
+In `define_admin_hooks()`, add after the `$logs_menu` registration block:
+
+```php
+// Settings submenu page (Feature 019).
+$settings_menu = \AcrossAI_Abilities_Manager\Admin\Partials\SettingsMenu::instance();
+$this->loader->add_action( 'admin_menu', $settings_menu, 'register_submenu' );
+$this->loader->add_action( 'admin_init', $settings_menu, 'register_settings' );
+```
+
+Follow the Boot Flow Rule: named variable before Loader calls.
+Do not change any other line in `define_admin_hooks()`.
+
+---
+
+## CHANGE-3 — `admin/Main.php`
+
+**Add `is_settings_page()` private method**:
+
+```php
+private function is_settings_page( string $hook_suffix ): bool {
+    $settings_menu = SettingsMenu::instance();
+    return $hook_suffix === $settings_menu->get_hook_suffix();
+}
+```
+
+**Add `use` statement** at the top of the file, alongside the existing
+`use AcrossAI_Abilities_Manager\Admin\Partials\LogsMenu;`:
+
+```php
+use AcrossAI_Abilities_Manager\Admin\Partials\SettingsMenu;
+```
+
+**Update `enqueue_styles()` and `enqueue_scripts()`** early-return guard:
+
+```php
+// Current:
+if ( ! $this->is_manager_page( $hook_suffix ) && ! $this->is_logs_page( $hook_suffix ) ) {
+    return;
+}
+
+// New:
+if ( ! $this->is_manager_page( $hook_suffix )
+    && ! $this->is_logs_page( $hook_suffix )
+    && ! $this->is_settings_page( $hook_suffix ) ) {
+    return;
+}
+```
+
+The Settings page uses only WordPress core styles (WP admin CSS). No custom JS or CSS
+bundle is enqueued for the settings page — the early-return change just prevents the
+guard from accidentally blocking WP's own settings API CSS (which it would not, but
+being explicit is cleaner). No new `wp_register_style` or `wp_register_script` calls are
+added for the settings page.
+
+---
+
+## CHANGE-4 — `includes/Modules/Logger/AcrossAI_Ability_Logger.php`
+
+### `cleanup_old_logs()` — read from option, not filter default
+
+Replace:
+
+```php
+$retention_days = (int) apply_filters( 'acrossai_ability_log_retention_days', 30 );
+
+if ( $retention_days < 1 ) {
+    // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+    error_log( 'Logger: Invalid retention days, skipping cleanup' );
+    return;
+}
+```
+
+With:
+
+```php
+$option_days    = (int) get_option( 'acrossai_abilities_log_retention_days', 0 );
+$retention_days = (int) apply_filters( 'acrossai_ability_log_retention_days', $option_days );
+
+if ( $retention_days < 1 ) {
+    return;
+}
+```
+
+Key changes:
+- Default shifts from `30` to `0` — meaning "never delete" out of the box.
+- The `apply_filters` call is preserved so developers can still override via code;
+  the option is now the default passed to the filter.
+- The `error_log` is removed: `retention_days < 1` is now a valid user-configured
+  "never delete" state, not an error condition.
+
+### `schedule_cleanup()` — skip scheduling when retention = 0
+
+After the `function_exists( 'as_schedule_recurring_action' )` guard, add an early return
+when the user has opted out of auto-cleanup:
+
+```php
+// Do not schedule if retention is set to 0 (never delete).
+$option_days = (int) get_option( 'acrossai_abilities_log_retention_days', 0 );
+if ( 0 === $option_days ) {
+    return;
+}
+```
+
+This prevents an unnecessary recurring Action Scheduler job when the site owner does
+not want automatic cleanup.
+
+**Important**: if the option is later changed from 0 to a positive value, the next
+`plugins_loaded` will call `schedule_cleanup()` again — the existing idempotency check
+(`as_next_scheduled_action`) handles re-scheduling correctly.
+
+---
+
+## CHANGE-5 — `uninstall.php`
+
+The current file drops tables and deletes options unconditionally. Wrap all destructive
+operations in a check against the new option:
+
+```php
+// Respect the user's "delete data on uninstall" setting.
+$delete_data = (bool) get_option( 'acrossai_abilities_uninstall_delete_data', false );
+
+if ( $delete_data ) {
+    // Drop the unified abilities table.
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+    $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}acrossai_abilities`" );
+    delete_option( 'acrossai_abilities_db_version' );
+
+    // Drop the WPBoilerplate Access Control rules table.
+    // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+    $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}wpb_access_control`" );
+    delete_option( 'wpb_access_control_db_version' );
+}
+
+// Always remove plugin settings options on uninstall (not data — configuration).
+delete_option( 'acrossai_abilities_log_retention_days' );
+delete_option( 'acrossai_abilities_uninstall_delete_data' );
+```
+
+**Rationale for the split**:
+- Tables and BerlinDB version options are *data* — only deleted when the user explicitly
+  opted in via the settings checkbox.
+- The two new settings options (`log_retention_days`, `uninstall_delete_data`) are
+  *configuration*, not data. They are always cleaned up on uninstall regardless of the
+  checkbox, because there is no reason to persist settings for a plugin that no longer
+  exists.
+
+---
+
+## What must NOT change
+
+- Do not modify `src/js/abilities/` — this feature is pure PHP + WordPress Settings API.
+- Do not add a new JS entry point or build artifact.
+- Do not change the `apply_filters( 'acrossai_ability_log_retention_days', ... )` hook
+  signature — only the default value passed to it changes. Third-party code using this
+  filter continues to work.
+- Do not change `AcrossAI_Ability_Logger::unschedule_cleanup()` — deactivation cleanup
+  is unaffected by this feature.
+- Do not change any REST endpoint, DB schema, or REST response shape.
+- Do not change `admin/Partials/Menu.php` — the top-level menu is unchanged.
+- Do not rename the Action Scheduler job slug `acrossai_ability_logger_cleanup`.
+
+---
+
+## CONSTRAINTS
+
+- Exactly five files change: `admin/Partials/SettingsMenu.php` (new), `includes/Main.php`,
+  `admin/Main.php`, `includes/Modules/Logger/AcrossAI_Ability_Logger.php`, `uninstall.php`.
+- Every `__()` call must use `'acrossai-abilities-manager'` as the text domain.
+- PHPStan level 8 must pass with zero errors.
+- PHPCS must pass with zero errors.
+- No JS build step is needed — `npm run build` is not required for this feature.
+
+---
+
+## Spec-kit Commands
+
+```markdown
+# 3. Plan + guard + security
+/speckit.memory-md.plan-with-memory
+/speckit.architecture-guard.governed-plan
+/speckit.security-review.plan
+
+# 4. Tasks + guard
+/speckit.tasks
+/speckit.architecture-guard.governed-tasks
+
+# 5. Implement + quality checks
+/speckit.architecture-guard.governed-implement
+composer run phpcs
+composer run phpstan
+
+# 6. Review + memory + commit
+/speckit.analyze
+/speckit.architecture-guard.architecture-review
+/speckit.security-review.staged
+/speckit.memory-md.capture-from-diff
+/speckit.git.commit
+```
+
+---
+
+## Manual Verification Checklist
+
+### CHANGE-1 — SettingsMenu page
+
+- [ ] `admin.php?page=acrossai-abilities-settings` loads without errors.
+- [ ] "Log Settings" section renders a number input; default value shown is `0`.
+- [ ] Changing the value to `7` and clicking "Save Changes" stores `7` in
+      `wp_options` as `acrossai_abilities_log_retention_days`. Confirm with:
+      `wp option get acrossai_abilities_log_retention_days`
+- [ ] Setting value back to `0` stores `0` (not an empty string or absent key).
+- [ ] "Uninstall Settings" section renders a checkbox that is **unchecked** by default.
+- [ ] Red warning text is visible below the checkbox.
+- [ ] Checking the box and saving stores `1` in `wp_options` as
+      `acrossai_abilities_uninstall_delete_data`.
+- [ ] Unchecking and saving stores `0`.
+- [ ] Accessing the page as a non-admin user produces "Insufficient permissions." (or
+      is blocked by WordPress capability check before render).
+
+### CHANGE-2 — `includes/Main.php` hook registration
+
+- [ ] `grep -n "SettingsMenu" includes/Main.php` shows `register_submenu` wired to
+      `admin_menu` and `register_settings` wired to `admin_init`.
+
+### CHANGE-3 — `admin/Main.php` guard
+
+- [ ] `is_settings_page()` method exists and uses `SettingsMenu::instance()`.
+- [ ] The early-return guard in both `enqueue_styles()` and `enqueue_scripts()` includes
+      `! $this->is_settings_page( $hook_suffix )`.
+
+### CHANGE-4 — Logger respects new option
+
+- [ ] With `acrossai_abilities_log_retention_days = 0`, the scheduled Action Scheduler
+      job `acrossai_ability_logger_cleanup` is **not** created on a fresh install.
+      Confirm with: `wp action-scheduler list --hook=acrossai_ability_logger_cleanup`
+- [ ] With `acrossai_abilities_log_retention_days = 7`, the job is scheduled (or already
+      scheduled from a previous run).
+- [ ] Running `wp action-scheduler run --hook=acrossai_ability_logger_cleanup` with
+      retention = 0 exits silently with no rows deleted and no error logged.
+- [ ] Running with retention = 7 deletes logs older than 7 days and logs the count.
+
+### CHANGE-5 — `uninstall.php` is conditional
+
+- [ ] With `acrossai_abilities_uninstall_delete_data = 0` (default): after uninstall,
+      `wp_acrossai_abilities` and `wp_wpb_access_control` tables still exist.
+      Options `acrossai_abilities_db_version` and `wpb_access_control_db_version`
+      still exist. Settings options are removed.
+- [ ] With `acrossai_abilities_uninstall_delete_data = 1`: after uninstall, all tables
+      and all four option keys are gone.
+- [ ] `acrossai_abilities_log_retention_days` and `acrossai_abilities_uninstall_delete_data`
+      are always removed on uninstall regardless of the checkbox state.
+
+### Quality gates
+
+- [ ] `composer run phpstan` — zero errors.
+- [ ] `composer run phpcs` — zero errors.
+- [ ] Exactly five files modified (`git diff --name-only`): `admin/Partials/SettingsMenu.php`
+      (new), `includes/Main.php`, `admin/Main.php`,
+      `includes/Modules/Logger/AcrossAI_Ability_Logger.php`, `uninstall.php`.

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -274,6 +274,11 @@ final class Main {
 		$logs_menu = \AcrossAI_Abilities_Manager\Admin\Partials\LogsMenu::instance();
 		$this->loader->add_action( 'admin_menu', $logs_menu, 'register_submenu' );
 
+		// Settings submenu page (Feature 019).
+		$settings_menu = \AcrossAI_Abilities_Manager\Admin\Partials\SettingsMenu::instance();
+		$this->loader->add_action( 'admin_menu', $settings_menu, 'register_submenu' );
+		$this->loader->add_action( 'admin_init', $settings_menu, 'register_settings' );
+
 		// Abilities DB table setup — BerlinDB hooks maybe_upgrade() to admin_init.
 		// Named variable before Loader call — Boot Flow Rule variable-first pattern (AC-HOOKS-MAIN).
 		$abilities_table = \AcrossAI_Abilities_Manager\Includes\Modules\Abilities\Database\AcrossAI_Abilities_Table::instance();

--- a/includes/Modules/Logger/AcrossAI_Ability_Logger.php
+++ b/includes/Modules/Logger/AcrossAI_Ability_Logger.php
@@ -303,6 +303,12 @@ class AcrossAI_Ability_Logger {
 			return;
 		}
 
+		// Do not schedule if retention is set to 0 (never delete).
+		$option_days = (int) get_option( 'acrossai_abilities_log_retention_days', 0 );
+		if ( 0 === $option_days ) {
+			return;
+		}
+
 		// Check if already scheduled (idempotent).
 		$next_run = as_next_scheduled_action(
 			'acrossai_ability_logger_cleanup',
@@ -332,25 +338,23 @@ class AcrossAI_Ability_Logger {
 	 * Cleanup old logs via Action Scheduler job
 	 *
 	 * Called by Action Scheduler at the scheduled time.
-	 * Deletes logs older than the configured retention period (T016, T017).
+	 * Deletes logs older than the configured retention period.
 	 *
 	 * @since 0.1.0
 	 * @return void
 	 */
 	public function cleanup_old_logs() {
-		// Get retention days from filter (default: 30 days).
-		$retention_days = (int) apply_filters( 'acrossai_ability_log_retention_days', 30 );
+		$option_days    = (int) get_option( 'acrossai_abilities_log_retention_days', 0 );
+		$retention_days = (int) apply_filters( 'acrossai_ability_log_retention_days', $option_days );
 
 		if ( $retention_days < 1 ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'Logger: Invalid retention days, skipping cleanup' );
 			return;
 		}
 
-		// Calculate date cutoff (30 days ago).
+		// Calculate date cutoff based on configured retention period.
 		$cutoff_date = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
 
-		// Delete old logs (T017: uses delete_logs_before_date method).
+		// Delete old logs using the date cutoff.
 		$query  = AcrossAI_Ability_Logs_Query::instance();
 		$result = $query->delete_logs_before_date( $cutoff_date );
 

--- a/specs/019-admin-settings-page/checklists/requirements.md
+++ b/specs/019-admin-settings-page/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Admin Settings Page
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-29  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-004 references the WordPress Settings API by name (an API, not a tech stack detail) — acceptable as it describes the required integration surface
+- FR-005, FR-006 reference `absint` — acceptable as these are WordPress data-contract terms that define the sanitization behaviour, not an implementation choice
+- All clarifications were resolved via explicit user description; no [NEEDS CLARIFICATION] markers needed

--- a/specs/019-admin-settings-page/memory-synthesis.md
+++ b/specs/019-admin-settings-page/memory-synthesis.md
@@ -1,0 +1,47 @@
+# Memory Synthesis
+
+## Current Scope
+Feature 019 adds a **Settings submenu page** under the Abilities Manager admin menu (PHP-only). Five files change: `admin/Partials/SettingsMenu.php` (new singleton), `includes/Main.php` (hook wiring), `admin/Main.php` (enqueue guard), `includes/Modules/Logger/AcrossAI_Ability_Logger.php` (option read), `uninstall.php` (conditional deletion). No JS, no build step, no REST changes.
+
+## Relevant Decisions
+- **AC-HOOKS-MAIN** (Reason Included: CHANGE-2 wires SettingsMenu hooks; variable-first rule applies, Status: Active, Source: CONSTITUTION.md §I)
+- **AC-ENQUEUE-ADMIN** (Reason Included: CHANGE-3 touches enqueue guards in Admin\Main; no enqueue must occur in SettingsMenu itself, Status: Active, Source: CONSTITUTION.md §I)
+- **DEC-MENU-HOOK-SUFFIX** (Reason Included: CHANGE-3 proposes `is_settings_page()` — this decision dictates HOW to implement it; SOFT CONFLICT with plan, Status: Active, Source: DECISIONS.md)
+- **DEC-NAMESPACE-CONVENTION** (Reason Included: New class `SettingsMenu` must use `AcrossAI_Abilities_Manager\Admin\Partials` namespace, Status: Active, Source: DECISIONS.md)
+- **DEC-UTILITY-STATIC-ONLY** (Reason Included: SettingsMenu renders a page and wires hooks → it is a page orchestrator; singleton pattern is correct; static-only pattern does NOT apply, Status: Active, Source: DECISIONS.md)
+
+## Active Architecture Constraints
+- **AC-HOOKS-MAIN**: Only `includes/Main.php` may call `loader->add_action/add_filter`; singleton resolved to named variable first (Reason Included: CHANGE-2, Source: CONSTITUTION.md §I)
+- **AC-ENQUEUE-ADMIN**: `wp_enqueue_script/style` ONLY inside `Admin\Main::enqueue_scripts/styles`; SettingsMenu MUST NOT enqueue directly (Reason Included: CHANGE-1 + CHANGE-3, Source: CONSTITUTION.md §I)
+- **AC-FILE-HEADER-PATTERN**: New PHP file needs `@package AcrossAI_Abilities_Manager`, `@subpackage Admin/Partials`, `@since 0.1.0` (Reason Included: CHANGE-1 is a new file, Source: ARCHITECTURE.md)
+- **PATTERN-ENQUEUE-PAGE-GUARD**: `is_*_page()` helpers use Yoda `===` form; no `strpos`; no dynamic class coupling (Reason Included: CHANGE-3, Source: ARCHITECTURE.md)
+- **Admin Partials Rule** (CONSTITUTION §I): Classes calling `add_submenu_page()` live in `admin/Partials/` with namespace `AcrossAI_Abilities_Manager\Admin\Partials`. SettingsMenu is correctly placed. (Reason Included: CHANGE-1, Source: CONSTITUTION.md)
+
+## Accepted Deviations
+- None applicable to this feature scope.
+
+## Relevant Security Constraints
+- **Settings API nonce**: `settings_fields('acrossai_abilities_settings')` generates the WP nonce; no custom nonce needed. `current_user_can('manage_options')` in `render()` is defense-in-depth. (Source: spec FR-004, planning doc)
+- **Sanitize strictness**: `absint` for int field, `intval`+clamp for bool checkbox. No raw `$_POST` access; Settings API handles request parsing. (Source: FR-005, FR-006)
+- **`uninstall.php` capability context**: `uninstall.php` runs outside WP request context (no `current_user_can`); the `$delete_data` gate uses option value, not a request parameter. (Source: FR-009)
+
+## Related Historical Lessons
+- **BUG-UNCONDITIONAL-ASSET-INCLUDE**: The Settings page has no custom asset bundle — no `.asset.php` file will be `include`d. No guard needed, but confirm CHANGE-3 does NOT add any asset include for the settings page. (Reason Included: CHANGE-3, Source: BUGS.md)
+- **BUG-PHPCS-DOCBLOCK-CAPITAL**: All new PHP docblocks in SettingsMenu.php must have long descriptions starting with uppercase; phpcbf won't fix capitalization. (Reason Included: CHANGE-1 new file, Source: BUGS.md)
+- **BUG-PHPCBF-TABS**: When applying patches to PHP files, use `\t` not spaces. phpcbf enforces tabs. (Reason Included: Implementation, Source: BUGS.md)
+
+## Conflict Warnings
+- **SOFT CONFLICT — `is_settings_page()` uses `get_hook_suffix()` coupling**: The planning doc (CHANGE-3) proposes `SettingsMenu::instance()->get_hook_suffix()` inside `is_settings_page()`. `DEC-MENU-HOOK-SUFFIX` (Active, 2026-05-24) explicitly forbids this pattern: *"Do not call `AcrossAI_SomeMenuClass::instance()->get_hook_suffix()` inside `Admin\Main` — this couples enqueue to a menu class."* The correct pattern is a hardcoded string literal:
+  ```php
+  private function is_settings_page( string $hook_suffix ): bool {
+      return 'acrossai-abilities-manager_page_acrossai-abilities-settings' === $hook_suffix;
+  }
+  ```
+  The formula `{parent-slug}_page_{submenu-slug}` is deterministic and stable. This pattern also means: (a) no `use SettingsMenu;` statement needed in `admin/Main.php`, (b) SettingsMenu does not need `$hook_suffix` property or `get_hook_suffix()` method. **The plan must be corrected.** Note: `is_logs_page()` already violates this decision (existing tech debt) — not in scope here.
+- **SOFT CONFLICT — `get_hook_suffix()` in SettingsMenu**: If `admin/Main.php` uses the hardcoded pattern, SettingsMenu can be simplified to omit `$hook_suffix`/`get_hook_suffix()`. This reduces SettingsMenu's surface and eliminates a coupling point. **Minor simplification; spec proceeds with corrected pattern.**
+
+## Retrieval Notes
+- Index entries considered: 24 active decisions, 8 architecture constraints, 7 implementation patterns, 11 bug patterns, 4 security constraints, 4 accepted deviations, 4 worklog items
+- Selected: 5 decisions, 5 architecture constraints, 0 accepted deviations, 3 security constraints (spec-derived), 3 bug patterns, 0 worklog items
+- Source sections read: DECISIONS.md (DEC-MENU-HOOK-SUFFIX full entry), admin/Main.php (is_logs_page live code), admin/Partials/LogsMenu.php (hook_suffix pattern), CONSTITUTION.md (Admin Partials + singleton)
+- Budget status: ~520 words — within 900-word limit

--- a/specs/019-admin-settings-page/spec.md
+++ b/specs/019-admin-settings-page/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Admin Settings Page
+
+**Feature Branch**: `019-add-settings-page`  
+**Created**: 2026-05-29  
+**Status**: Draft  
+**Input**: User description: "Add Settings submenu page to Abilities Manager admin menu. Two sections: (A) Log Settings — number input for retention days (0 = never, default 0) stored in option 'acrossai_abilities_log_retention_days', (B) Uninstall Settings — checkbox 'delete all data on uninstall' (default unchecked) stored in option 'acrossai_abilities_uninstall_delete_data', with red warning text. Five files change: (1) NEW admin/Partials/SettingsMenu.php (singleton submenu + Settings API), (2) includes/Main.php (register submenu in define_admin_hooks), (3) admin/Main.php (is_settings_page guard + enqueue for settings page), (4) includes/Modules/Logger/AcrossAI_Ability_Logger.php (read option in cleanup_old_logs and skip scheduling when retention=0), (5) uninstall.php (conditional deletion based on option value)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Configure Log Retention (Priority: P1)
+
+A site administrator navigates to **Abilities Manager → Settings** and sets the log retention period to control how long execution logs are kept before automatic deletion.
+
+**Why this priority**: Log storage can grow unbounded on active sites. Giving admins control over retention period is the primary operational value of this feature.
+
+**Independent Test**: Navigate to `admin.php?page=acrossai-abilities-settings`, enter `7` in the "Delete logs after (days)" field, click "Save Changes", then verify `wp option get acrossai_abilities_log_retention_days` returns `7`. Test separately that entering `0` disables automatic cleanup entirely.
+
+**Acceptance Scenarios**:
+
+1. **Given** the plugin is installed, **When** an admin opens the Settings page, **Then** a "Log Settings" section is visible with a number input defaulting to `0`.
+2. **Given** the Settings page is open, **When** the admin enters `30` and saves, **Then** `acrossai_abilities_log_retention_days` is stored as integer `30` in `wp_options`.
+3. **Given** retention is set to `0`, **When** the log cleanup job runs, **Then** no logs are deleted and no Action Scheduler job is created for cleanup.
+4. **Given** retention is set to `7`, **When** the log cleanup job runs, **Then** logs older than 7 days are deleted.
+5. **Given** a non-admin user, **When** they attempt to access the Settings page directly, **Then** WordPress blocks access or the page renders "Insufficient permissions."
+
+---
+
+### User Story 2 — Control Data Deletion on Uninstall (Priority: P2)
+
+A site administrator uses the "Uninstall Settings" section to decide whether custom database tables and plugin options are permanently dropped when the plugin is uninstalled.
+
+**Why this priority**: This is a destructive, irreversible operation. The default must be safe (unchecked = preserve data), and the UI must clearly warn the user before they enable it.
+
+**Independent Test**: Verify the checkbox is unchecked by default. Check the box, save, then uninstall — confirm tables `wp_acrossai_abilities` and `wp_wpb_access_control` are dropped. Re-install with the checkbox unchecked and uninstall again — confirm tables are preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Settings page is open, **When** the admin views the "Uninstall Settings" section, **Then** the checkbox "Delete all data on uninstall" is unchecked and a red warning message is visible below it.
+2. **Given** the checkbox is unchecked (default), **When** the plugin is uninstalled, **Then** the `wp_acrossai_abilities` and `wp_wpb_access_control` tables are NOT dropped and `acrossai_abilities_db_version` / `wpb_access_control_db_version` options remain.
+3. **Given** the checkbox is checked and saved, **When** the plugin is uninstalled, **Then** both tables are dropped and all four related option keys are deleted.
+4. **Given** either checkbox state, **When** the plugin is uninstalled, **Then** `acrossai_abilities_log_retention_days` and `acrossai_abilities_uninstall_delete_data` options are always removed.
+
+---
+
+### Edge Cases
+
+- What happens when the retention days field is submitted with a negative number? (`absint` sanitization clamps it to `0` — effectively "never delete".)
+- What happens when the uninstall checkbox is unchecked and submitted? (WordPress sends no value for unchecked checkboxes; the sanitize callback must treat absent value as `0`.)
+- What happens if Action Scheduler is not installed when retention changes from `0` to a positive value? (`schedule_cleanup()` guards on `function_exists('as_schedule_recurring_action')` — no scheduling attempt is made; no error.)
+- What happens if a non-integer string is entered in the retention field? (`absint` converts it to `0`.)
+- What happens when retention changes from a positive value to `0` while an Action Scheduler job is already scheduled? The existing job is NOT unscheduled — `schedule_cleanup()` only skips creating a new job. The recurring job will continue to fire, but `cleanup_old_logs()` will early-return (no logs deleted). No extra code is needed; this is intentional to keep the implementation minimal.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose a "Settings" submenu page under the Abilities Manager top-level admin menu, accessible only to users with `manage_options` capability.
+- **FR-002**: The Settings page MUST contain a "Log Settings" section with a number input (`acrossai_abilities_log_retention_days`, default `0`, minimum `0`) that controls how many days before logs are auto-deleted; `0` means never delete.
+- **FR-003**: The Settings page MUST contain an "Uninstall Settings" section with a checkbox (`acrossai_abilities_uninstall_delete_data`, default unchecked) and a prominent red warning message explaining the irreversibility of data deletion.
+- **FR-004**: Both settings MUST be registered via the WordPress Settings API (option group `acrossai_abilities_settings`) so WordPress handles nonce validation, sanitization, and redirect.
+- **FR-005**: The log retention option MUST be sanitized with `absint` (returns integer ≥ 0).
+- **FR-006**: The uninstall delete option MUST be sanitized using an explicit absent-field-safe callback: `empty( $value ) ? 0 : 1` — returns `1` when the checkbox is checked, `0` when unchecked or absent (browser sends no field for unchecked checkboxes).
+- **FR-007**: `AcrossAI_Ability_Logger::cleanup_old_logs()` MUST read `acrossai_abilities_log_retention_days` from `wp_options` (default `0`) and pass it as the default to the existing `acrossai_ability_log_retention_days` filter.
+- **FR-008**: `AcrossAI_Ability_Logger::schedule_cleanup()` MUST skip scheduling when `acrossai_abilities_log_retention_days` is `0`.
+- **FR-009**: `uninstall.php` MUST check `acrossai_abilities_uninstall_delete_data` before dropping tables or deleting BerlinDB version options; plugin settings options (`log_retention_days`, `uninstall_delete_data`) MUST always be deleted on uninstall regardless of the checkbox state.
+- **FR-010**: The `SettingsMenu` class MUST follow the established singleton pattern (identical to `LogsMenu`) and be registered in `includes/Main.php` via the Loader.
+- **FR-011**: `admin/Main.php` MUST add `is_settings_page()` and include it in the `enqueue_styles()`/`enqueue_scripts()` early-return guards.
+
+### Key Entities
+
+- **Log Retention Setting** (`acrossai_abilities_log_retention_days`): Integer ≥ 0. Stored in `wp_options`. `0` = never auto-delete. Controls both scheduling and cleanup execution.
+- **Uninstall Delete Flag** (`acrossai_abilities_uninstall_delete_data`): `1` or `0`. Stored in `wp_options`. Gates destructive table drops and option deletes in `uninstall.php`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An administrator can navigate to the Settings page, change both settings, save, and verify the stored values match the input — all within 60 seconds.
+- **SC-002**: With retention = `0`, no `acrossai_ability_logger_cleanup` Action Scheduler job exists after plugin activation.
+- **SC-003**: With retention = `7`, logs older than 7 days are removed when the cleanup job runs; no PHP error or warning is produced.
+- **SC-004**: Uninstalling with `uninstall_delete_data = 0` (default) leaves all site data intact. Uninstalling with `uninstall_delete_data = 1` removes all plugin tables and options.
+- **SC-005**: All five changed files pass PHPCS and PHPStan level 8 with zero errors.
+
+## Clarifications
+
+### Session 2026-05-29
+
+- Q: When retention changes from a positive value back to `0`, should the existing scheduled Action Scheduler job be unscheduled, or left to run as a no-op? → A: Leave the existing job scheduled. `cleanup_old_logs()` early-returns when retention = 0, so the job is harmless. `schedule_cleanup()` only skips creating a new job — no unscheduling logic is added.
+- Q: For sites upgrading from the previous version (where cleanup used a hard-coded 30-day default), should a migration seed `acrossai_abilities_log_retention_days = 30` on first activation so existing behavior is preserved? → A: No migration. The new default is explicitly `0` (never delete). Upgrading sites will no longer auto-delete logs until an admin sets a value in Settings. This is the intended behavior change.
+
+## Assumptions
+
+- The WordPress Settings API (`register_setting`, `add_settings_section`, `add_settings_field`, `settings_fields`, `do_settings_sections`) is available in all supported WP versions (6.9+).
+- `LogsMenu.php` is the authoritative singleton pattern to follow; no divergence is introduced.
+- The `apply_filters('acrossai_ability_log_retention_days', ...)` hook is preserved with the option value as its new default — third-party filters continue to work.
+- No JavaScript is needed — the Settings page uses WordPress core admin UI only.
+- Action Scheduler may not be installed; all scheduling code is guarded with `function_exists('as_schedule_recurring_action')`.
+- The `acrossai_ability_logger_cleanup` Action Scheduler job slug is not renamed.
+- No new CSS or JS bundles are enqueued for the Settings page.
+- Upgrading sites will have no `acrossai_abilities_log_retention_days` option in the DB; `get_option` returns `0` (never delete). This is a deliberate behavior change from the previous hard-coded 30-day default — no data migration is provided.

--- a/specs/019-admin-settings-page/tasks.md
+++ b/specs/019-admin-settings-page/tasks.md
@@ -1,0 +1,268 @@
+# Tasks: Admin Settings Page (Feature 019)
+
+**Input**: `specs/019-admin-settings-page/spec.md`, `docs/planning/019-admin-settings-page.md`, `specs/019-admin-settings-page/memory-synthesis.md`  
+**Branch**: `019-add-settings-page`  
+**Constraint**: Exactly 5 files change. No JS. No build step. PHPStan level 8 + PHPCS must pass.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other [P] tasks (different files, no dependencies)
+- **[US1]**: User Story 1 — Configure Log Retention (P1)
+- **[US2]**: User Story 2 — Control Data Deletion on Uninstall (P2)
+
+---
+
+## Phase 1: Foundation — Settings Page Singleton
+
+**Purpose**: Create `SettingsMenu` — required before hook wiring (T002) but independent of T003–T006.
+
+- [x] T001 [US1+US2] Create `admin/Partials/SettingsMenu.php`
+
+  **File**: `admin/Partials/SettingsMenu.php` (new)
+
+  PHP file header:
+  ```
+  @package    AcrossAI_Abilities_Manager
+  @subpackage Admin/Partials
+  @since      0.1.0
+  ```
+
+  Class: `AcrossAI_Abilities_Manager\Admin\Partials\SettingsMenu`
+
+  **Singleton contract** (no `$hook_suffix` / no `get_hook_suffix()` — DEC-MENU-HOOK-SUFFIX):
+  - `protected static $_instance = null`
+  - `public static function instance(): self`
+  - `private function __construct() {}`
+
+  **`register_submenu()` method** (public, void):
+  ```php
+  add_submenu_page(
+      'acrossai-abilities-manager',
+      __( 'Settings', 'acrossai-abilities-manager' ),
+      __( 'Settings', 'acrossai-abilities-manager' ),
+      'manage_options',
+      'acrossai-abilities-settings',
+      array( $this, 'render' )
+  );
+  ```
+
+  **`register_settings()` method** (public, void) — Settings API:
+  - Option group: `acrossai_abilities_settings`
+  - `register_setting( 'acrossai_abilities_settings', 'acrossai_abilities_log_retention_days', [ 'sanitize_callback' => 'absint', 'default' => 0 ] )`
+  - `register_setting( 'acrossai_abilities_settings', 'acrossai_abilities_uninstall_delete_data', [ 'sanitize_callback' => function( $value ) { return empty( $value ) ? 0 : 1; }, 'default' => 0 ] )`
+  - Section 1 ID: `acrossai_log_settings_section`, title: `__( 'Log Settings', 'acrossai-abilities-manager' )`
+  - Field 1 ID: `acrossai_abilities_log_retention_days`, label: `__( 'Delete logs after (days)', 'acrossai-abilities-manager' )`, callback: `render_retention_field()`
+  - Section 2 ID: `acrossai_uninstall_settings_section`, title: `__( 'Uninstall Settings', 'acrossai-abilities-manager' )`
+  - Field 2 ID: `acrossai_abilities_uninstall_delete_data`, label: `__( 'Delete all data on uninstall', 'acrossai-abilities-manager' )`, callback: `render_uninstall_field()`
+
+  **`render_retention_field()` method** (private, void):
+  ```php
+  $value = (int) get_option( 'acrossai_abilities_log_retention_days', 0 );
+  printf(
+      '<input type="number" id="acrossai_abilities_log_retention_days"
+       name="acrossai_abilities_log_retention_days"
+       value="%s" min="0" step="1" />
+       <p class="description">%s</p>',
+      esc_attr( (string) $value ),
+      esc_html__( 'Set to 0 to keep logs forever. If a number is entered, logs older than that many days will be automatically deleted.', 'acrossai-abilities-manager' )
+  );
+  ```
+
+  **`render_uninstall_field()` method** (private, void):
+  ```php
+  $checked = (bool) get_option( 'acrossai_abilities_uninstall_delete_data', 0 );
+  printf(
+      '<label><input type="checkbox" id="acrossai_abilities_uninstall_delete_data"
+       name="acrossai_abilities_uninstall_delete_data" value="1" %s /> %s</label>
+       <p class="description"><span style="color: #d63638;">%s</span></p>',
+      checked( $checked, true, false ),
+      esc_html__( 'Delete all data on uninstall', 'acrossai-abilities-manager' ),
+      esc_html__( '⚠ Warning: When checked, uninstalling this plugin will permanently delete all custom database tables and plugin options. This cannot be undone.', 'acrossai-abilities-manager' )
+  );
+  ```
+
+  **`render()` method** (public, void):
+  ```php
+  if ( ! current_user_can( 'manage_options' ) ) {
+      wp_die( esc_html__( 'Insufficient permissions.', 'acrossai-abilities-manager' ) );
+  }
+  // <div class="wrap"><h1>...</h1><form method="post" action="options.php">
+  // settings_fields( 'acrossai_abilities_settings' );
+  // do_settings_sections( 'acrossai-abilities-settings' );
+  // submit_button();
+  ```
+
+  **DoD**: File created, class instantiable, no PHP parse errors.
+
+**Checkpoint**: SettingsMenu class exists — T002 can now proceed.
+
+---
+
+## Phase 2: US1 — Configure Log Retention (P1)
+
+**Goal**: Admin can visit Settings page, configure retention days, and Logger respects the stored value.
+
+**Independent Test**: `admin.php?page=acrossai-abilities-settings` loads, "Log Settings" section visible; `wp option get acrossai_abilities_log_retention_days` returns configured value; with retention=0 no AS job exists.
+
+- [x] T002 [US1] Wire `SettingsMenu` hooks in `includes/Main.php`
+
+  **File**: `includes/Main.php`, inside `define_admin_hooks()`, after the `$logs_menu` registration block (line ~276).
+
+  Insert:
+  ```php
+  // Settings submenu page (Feature 019).
+  $settings_menu = \AcrossAI_Abilities_Manager\Admin\Partials\SettingsMenu::instance();
+  $this->loader->add_action( 'admin_menu', $settings_menu, 'register_submenu' );
+  $this->loader->add_action( 'admin_init', $settings_menu, 'register_settings' );
+  ```
+
+  **Rules**: Named variable before Loader calls (AC-HOOKS-MAIN). Do not change any other line.
+
+  **DoD**: `grep -n "SettingsMenu" includes/Main.php` shows both hooks wired.
+
+- [x] T003 [P] [US1] Add `is_settings_page()` guard to `admin/Main.php`
+
+  **File**: `admin/Main.php`
+
+  Add private method — hardcoded string (DEC-MENU-HOOK-SUFFIX; no `use SettingsMenu;` needed):
+  ```php
+  private function is_settings_page( string $hook_suffix ): bool {
+      return 'acrossai-abilities-manager_page_acrossai-abilities-settings' === $hook_suffix;
+  }
+  ```
+
+  Update early-return in both `enqueue_styles()` and `enqueue_scripts()`:
+  ```php
+  // Replace:
+  if ( ! $this->is_manager_page( $hook_suffix ) && ! $this->is_logs_page( $hook_suffix ) ) {
+  // With:
+  if ( ! $this->is_manager_page( $hook_suffix )
+      && ! $this->is_logs_page( $hook_suffix )
+      && ! $this->is_settings_page( $hook_suffix ) ) {
+  ```
+
+  **Do NOT** add `use AcrossAI_Abilities_Manager\Admin\Partials\SettingsMenu;` — not needed.
+
+  **DoD**: `grep -n "is_settings_page" admin/Main.php` shows method + 2 guard usages.
+
+- [x] T004 [P] [US1] Update `cleanup_old_logs()` in `includes/Modules/Logger/AcrossAI_Ability_Logger.php`
+
+  **File**: `includes/Modules/Logger/AcrossAI_Ability_Logger.php`
+
+  Replace block at `cleanup_old_logs()` (currently line ~342–347):
+  ```php
+  // Remove:
+  $retention_days = (int) apply_filters( 'acrossai_ability_log_retention_days', 30 );
+  if ( $retention_days < 1 ) {
+      // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+      error_log( 'Logger: Invalid retention days, skipping cleanup' );
+      return;
+  }
+
+  // Insert:
+  $option_days    = (int) get_option( 'acrossai_abilities_log_retention_days', 0 );
+  $retention_days = (int) apply_filters( 'acrossai_ability_log_retention_days', $option_days );
+  if ( $retention_days < 1 ) {
+      return;
+  }
+  ```
+
+  **DoD**: `grep -n "apply_filters.*retention" includes/Modules/Logger/AcrossAI_Ability_Logger.php` shows new 2-line pattern; `error_log.*Invalid retention` is gone.
+
+- [x] T005 [US1] Update `schedule_cleanup()` in `includes/Modules/Logger/AcrossAI_Ability_Logger.php`
+
+  **File**: Same file as T004 — complete T004 first.
+
+  After the `if ( ! function_exists( 'as_schedule_recurring_action' ) ) { return; }` guard, insert:
+  ```php
+  // Do not schedule if retention is set to 0 (never delete).
+  $option_days = (int) get_option( 'acrossai_abilities_log_retention_days', 0 );
+  if ( 0 === $option_days ) {
+      return;
+  }
+  ```
+
+  **DoD**: `grep -n "option_days" includes/Modules/Logger/AcrossAI_Ability_Logger.php` shows 2 occurrences (T004 + T005).
+
+**Checkpoint**: User Story 1 fully functional — Settings page renders Log Settings section; Logger reads option; AS job not created when retention=0.
+
+---
+
+## Phase 3: US2 — Uninstall Delete Flag (P2)
+
+**Goal**: Admin can enable "delete data on uninstall" from Settings; uninstall.php respects the flag.
+
+**Independent Test**: With flag=0 (default), uninstall preserves tables. With flag=1, tables dropped. Settings options always removed on uninstall.
+
+- [x] T006 [P] [US2] Update `uninstall.php` with conditional data deletion
+
+  **File**: `uninstall.php`
+
+  Replace the two unconditional table-drop+delete_option blocks with:
+  ```php
+  // Respect the user's "delete data on uninstall" setting.
+  $delete_data = (bool) get_option( 'acrossai_abilities_uninstall_delete_data', false );
+
+  if ( $delete_data ) {
+      // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+      $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}acrossai_abilities`" );
+      \delete_option( 'acrossai_abilities_db_version' );
+
+      // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+      $wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}wpb_access_control`" );
+      \delete_option( 'wpb_access_control_db_version' );
+  }
+
+  // Always remove plugin settings options on uninstall.
+  \delete_option( 'acrossai_abilities_log_retention_days' );
+  \delete_option( 'acrossai_abilities_uninstall_delete_data' );
+  ```
+
+  **DoD**: `grep -n "delete_data\|get_option" uninstall.php` shows the conditional gate; both settings options are always deleted.
+
+**Checkpoint**: User Story 2 fully functional — uninstall behaviour controlled by stored flag.
+
+---
+
+## Phase 4: Quality Gates
+
+- [x] T007 Run `composer run phpcs` — zero errors across all 5 changed files.
+
+  If errors found: fix before T008. Common issues to pre-empt:
+  - Docblock long descriptions must start uppercase (BUG-PHPCS-DOCBLOCK-CAPITAL)
+  - Tabs not spaces (BUG-PHPCBF-TABS)
+  - File header `@package`/`@subpackage`/`@since` present in SettingsMenu.php
+
+- [x] T008 Run `composer run phpstan` — zero errors at level 8.
+
+  If errors found: fix before marking complete. Common issues to pre-empt:
+  - `register_setting()` callback type: `callable` or inline `Closure`
+  - PHPStan may need type annotation for `$_instance`
+
+---
+
+## Dependencies & Execution Order
+
+```
+T001 → T002
+T001 (independent of T003, T004, T005, T006)
+T003 [P] — independent of T001 (hardcoded string, no SettingsMenu import)
+T004 [P] — independent of T001
+T005 → T004 (same file; complete T004 first)
+T006 [P] — fully independent
+T007, T008 → all of T001–T006
+```
+
+### Parallel execution opportunities
+
+T003, T004, and T006 can all be written simultaneously (different files). T001 only blocks T002.
+
+---
+
+## Definition of Done
+
+- [x] All 6 implementation tasks (T001–T006) marked complete
+- [x] `composer run phpcs` — zero errors (T007)
+- [x] `composer run phpstan` — zero errors (T008)
+- [x] `git diff --name-only` shows exactly 5 files: `admin/Partials/SettingsMenu.php`, `includes/Main.php`, `admin/Main.php`, `includes/Modules/Logger/AcrossAI_Ability_Logger.php`, `uninstall.php`
+- [x] Manual verification checklist in `docs/planning/019-admin-settings-page.md` completed

--- a/uninstall.php
+++ b/uninstall.php
@@ -2,8 +2,8 @@
 /**
  * Fired when the plugin is uninstalled.
  *
- * Drops all custom database tables created by this plugin and removes
- * all associated options. No data is preserved after uninstall.
+ * Drops custom database tables and removes
+ * plugin options when the delete-data setting is enabled. Data is preserved by default.
  *
  * @package    AcrossAI_Abilities_Manager
  * @since      0.0.1
@@ -16,15 +16,19 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 global $wpdb;
 
-// Drop the unified abilities table (renamed in 008-unified-abilities-table).
-// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
-$wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}acrossai_abilities`" );
-\delete_option( 'acrossai_abilities_db_version' );
+// Respect the user's "delete data on uninstall" setting.
+$delete_data = (bool) get_option( 'acrossai_abilities_uninstall_delete_data', 0 );
 
+if ( $delete_data ) {
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+	$wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}acrossai_abilities`" );
+	\delete_option( 'acrossai_abilities_db_version' );
 
-// Drop the WPBoilerplate Access Control rules table (created on activation via RuleTable).
-// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
-$wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}wpb_access_control`" );
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange
+	$wpdb->query( "DROP TABLE IF EXISTS `{$wpdb->prefix}wpb_access_control`" );
+	\delete_option( 'wpb_access_control_db_version' );
+}
 
-// Remove BerlinDB db-version options so the tables are recreated on re-activation.
-\delete_option( 'wpb_access_control_db_version' );
+// Always remove plugin settings options on uninstall (not data — configuration).
+\delete_option( 'acrossai_abilities_log_retention_days' );
+\delete_option( 'acrossai_abilities_uninstall_delete_data' );


### PR DESCRIPTION
## Summary

Adds a **Settings** submenu page under the Abilities Manager top-level admin menu, exposing two setting groups via the WordPress Settings API.

## Changes

### New: `admin/Partials/SettingsMenu.php`
- Singleton class following the `LogsMenu` pattern
- **Log Settings** section: number input for `acrossai_abilities_log_retention_days` (default `0` = never delete); sanitized with `absint`
- **Uninstall Settings** section: checkbox for `acrossai_abilities_uninstall_delete_data` (default unchecked); absent-field-safe sanitizer via `empty($value) ? 0 : 1` (FR-006)
- `render()` gates on `current_user_can('manage_options')`; nonce handled by `settings_fields()`

### `includes/Main.php`
- Wires `register_submenu` → `admin_menu` and `register_settings` → `admin_init` for `SettingsMenu` (named variable before Loader calls — AC-HOOKS-MAIN)

### `admin/Main.php`
- Adds `is_settings_page()` using hardcoded hook suffix `'acrossai-abilities-manager_page_acrossai-abilities-settings'` (DEC-MENU-HOOK-SUFFIX — no `get_hook_suffix()` coupling)
- Updates enqueue guard in both `enqueue_styles()` and `enqueue_scripts()`

### `includes/Modules/Logger/AcrossAI_Ability_Logger.php`
- `cleanup_old_logs()`: reads `acrossai_abilities_log_retention_days` option (default `0`); feeds as default to `apply_filters()` (filter extensibility preserved); removes stale `error_log`
- `schedule_cleanup()`: skips Action Scheduler job when retention = `0`

### `uninstall.php`
- Wraps `DROP TABLE` + version option deletes in `acrossai_abilities_uninstall_delete_data` gate (data preserved by default)
- Always removes both settings options on uninstall

## Quality Gates

- PHPCS: 0 errors
- PHPStan level 8: 0 errors
- Exactly 5 implementation files changed

## Architecture Notes

- `DEC-SETTINGS-API-DEVIATION` added to `docs/memory/DECISIONS.md`: WP Settings API is the approved approach for scalar-field settings pages (≤5 fields); DataForm required for dynamic UI
- Three new patterns added to `docs/memory/ARCHITECTURE.md`: `PATTERN-CHECKBOX-SANITIZE`, `PATTERN-UNINSTALL-DATA-GATE`, `PATTERN-LOGGER-OPTION-FEED-FILTER`