### PR TITLE
Fix Add-ons page buttons: bump acrossai-co/main-menu to ^0.0.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"automattic/jetpack-autoloader": "^5.0",
 		"wpboilerplate/wpb-access-control": "^2.0.0",
 		"berlindb/core": "^3.0.0",
-		"acrossai-co/main-menu": "^0.0.8"
+		"acrossai-co/main-menu": "^0.0.10"
 	},
 	"keywords": [
 		"wordpress",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0840ceb393f6f27ce5e929d5128b3d18",
+    "content-hash": "7b00edfe44dbb5e4f968e5e51b22882e",
     "packages": [
         {
             "name": "acrossai-co/main-menu",
-            "version": "0.0.8",
+            "version": "0.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acrossai-co/main-menu.git",
-                "reference": "00bc54a54aa80fb76a7604a0b2db4404c5d9de16"
+                "reference": "5173abbfa8ae090d1c8e34920870b63cf3ed5d27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acrossai-co/main-menu/zipball/00bc54a54aa80fb76a7604a0b2db4404c5d9de16",
-                "reference": "00bc54a54aa80fb76a7604a0b2db4404c5d9de16",
+                "url": "https://api.github.com/repos/acrossai-co/main-menu/zipball/5173abbfa8ae090d1c8e34920870b63cf3ed5d27",
+                "reference": "5173abbfa8ae090d1c8e34920870b63cf3ed5d27",
                 "shasum": ""
             },
             "require": {
@@ -43,9 +43,9 @@
             "description": "AcrossAI Admin Dashboard — parent menu, shared Settings page (Settings API), manager submenu slots, and an Add-ons page with Freemius integration.",
             "support": {
                 "issues": "https://github.com/acrossai-co/main-menu/issues",
-                "source": "https://github.com/acrossai-co/main-menu/tree/0.0.8"
+                "source": "https://github.com/acrossai-co/main-menu/tree/0.0.10"
             },
-            "time": "2026-07-01T07:01:09+00:00"
+            "time": "2026-07-02T10:14:38+00:00"
         },
         {
             "name": "automattic/jetpack-autoloader",
@@ -957,8 +957,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c4cda3fb3d5fe1615d1b53edee13525600e39868",
-                "reference": "c4cda3fb3d5fe1615d1b53edee13525600e39868",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/735a6c1867ac816052ce586be841e617339accad",
+                "reference": "735a6c1867ac816052ce586be841e617339accad",
                 "shasum": ""
             },
             "require": {
@@ -1015,7 +1015,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-17T15:28:08+00:00"
+            "time": "2026-07-02T09:45:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
## Summary
- Bumps `acrossai-co/main-menu` from `^0.0.8` to `^0.0.10` to pick up the [upstream rebrand-sync fix](https://github.com/acrossai-co/main-menu/releases/tag/0.0.10).
- The Add-ons page (`?page=acrossai-addons`) Install / Activate / Deactivate buttons were rendering but firing zero AJAX requests on any 0.0.9 install, because the container's data attribute was renamed (`data-acrossai-addons-instance`) while the JS bundle still read the pre-rebrand key (`dataset.wpbAddonsInstance`). `window[global_name]` resolved to `undefined`, the click-handler binding block short-circuited, and the buttons became no-ops.
- Upstream 0.0.10 syncs both the JS source and the minified bundle to `dataset.acrossaiAddonsInstance` so both sides use the same key.

## Test plan
- [ ] `composer install` → verify `vendor/acrossai-co/main-menu` is at 0.0.10
- [ ] Open `wp-admin/admin.php?page=acrossai-addons` on a fresh install
- [ ] DevTools Console: `window['acrossaiAddonsPage_acrossai']` returns the config object (not `undefined`)
- [ ] DevTools Console: `document.querySelector('.acrossai-addons-page').dataset.acrossaiAddonsInstance === 'acrossai'`
- [ ] Click any Install / Activate / Deactivate button → DevTools Network shows a POST to `admin-ajax.php` with `action=acrossai_addons_install_free` / `_activate` / `_deactivate`
- [ ] Free add-on install → succeeds and button state transitions to "Activated"
- [ ] Constitution §II: `composer phpstan` + `composer phpcs` remain green (no code changes in this repo — vendor bump only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)