### PR TITLE
Release 0.0.2

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.1
+Stable tag: 0.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -117,8 +117,8 @@ No data is sent to any external server without explicit user action.
 
 == Changelog ==
 
-= Unreleased =
-* **Composer dependency refresh** — `wpb-access-control` bumped to v2.0.0 (per-consumer database tables); `acrossai-co/main-menu` bumped to v0.0.8 (now bundles the Add-ons page). The standalone `acrossai-co/addons-page` package has been removed from direct dependencies; the same `AcrossAI_Addon\AddonsPage` class now ships from the `main-menu` package.
+= 0.0.2 =
+* **Composer dependency refresh** — `wpb-access-control` bumped to v2.0.0 (per-consumer database tables); `acrossai-co/main-menu` bumped to v0.0.10 (now bundles the Add-ons page and includes the JS-side rebrand-sync fix that restores Install / Activate / Deactivate button behavior). The standalone `acrossai-co/addons-page` package has been removed from direct dependencies; the same `AcrossAI_Addon\AddonsPage` class now ships from the `main-menu` package.
 * **Per-consumer access-control storage** — this plugin now owns its own `{prefix}abilities_access_control` database table, keeping its rules fully isolated from any other plugin embedding the same access-control library. The dedicated table is created automatically on plugin activation.
 * **Add-ons submenu URL changed** — the Add-ons page slug is now `acrossai-addons` (was `wpb-addons`). Any bookmarks or external links pointing at `wp-admin/admin.php?page=wpb-addons` should be updated to `wp-admin/admin.php?page=acrossai-addons`. The submenu location and behavior are otherwise unchanged.
 * **BREAKING — Access Control rules from earlier releases are NOT migrated.** If you previously configured Access Control rules on any ability, those rules were stored in the shared `{prefix}wpb_access_control` table and are **no longer read** by this release. After upgrading, please audit every ability's Access Control panel and reconfigure any rules that were previously in place. The legacy table is left on disk (in case you need to reference the prior configuration) and can be dropped manually by a database administrator if desired: `DROP TABLE {prefix}wpb_access_control;` and `DELETE FROM {prefix}options WHERE option_name = 'wpb_access_control_db_version';`.
@@ -133,7 +133,7 @@ No data is sent to any external server without explicit user action.
 
 == Upgrade Notice ==
 
-= Unreleased =
+= 0.0.2 =
 IMPORTANT: (1) This release does NOT migrate Access Control rules from previous versions. If you had configured any Access Control rules on abilities, audit and reconfigure them after upgrading. Pre-existing rules remain in the database (in the orphaned `{prefix}wpb_access_control` table) but are no longer applied. (2) Ability execution logging has been removed — the Logs admin page is gone; ability-execution denials are no longer recorded by this plugin. Install a compatible logging plugin if you need this signal.
 
 = 0.0.1 =

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.1
+ * Version:           0.0.2
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.1' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.2' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Bumps the plugin from **0.0.1** to **0.0.2**. Everything currently under `README.txt`'s `= Unreleased =` section moves into the `= 0.0.2 =` changelog and upgrade notice.

### Version touch-points updated
- `acrossai-abilities-manager.php:26` — Plugin header `Version: 0.0.2`
- `includes/Main.php:194` — `ACROSSAI_ABILITIES_MANAGER_VERSION` constant
- `README.txt:8` — `Stable tag: 0.0.2`
- `README.txt` — `= Unreleased =` → `= 0.0.2 =` in both Changelog and Upgrade Notice sections
- `README.txt` — stale `acrossai-co/main-menu v0.0.8` mention corrected to `v0.0.10` (the constraint that actually ships)

### What 0.0.2 contains
- **Composer refresh**: `wpb-access-control ^2.0.0` (per-consumer AC table) + `acrossai-co/main-menu ^0.0.10` (Add-ons page bundled + Add-ons button regression fix from #54) — pinned via [#54](https://github.com/acrossai-co/acrossai-abilities-manager/pull/54).
- **Feature 040**: Full Logger module decommission — includes the Constitution PATCH bump v1.4.7 → v1.4.8. Shipped via [#55](https://github.com/acrossai-co/acrossai-abilities-manager/pull/55).

### Dependency ordering
This PR is based on the tip of `040-remove-logs-module` (Feature 040 branch), so it currently shows the union of the Feature 040 diff + the version-bump diff. Once **#55 merges first**, this PR's diff collapses to the 3-file version bump only.

**Recommended merge order**:
1. Merge #55 (Feature 040) → base of this PR now equals main; diff collapses to 3 files
2. Merge this PR (Release 0.0.2)
3. Tag `0.0.2` on the merge commit and cut the GitHub release

### Test plan
- [ ] After #55 merges, confirm this PR's diff = 3 files only (`acrossai-abilities-manager.php`, `includes/Main.php`, `README.txt`)
- [ ] Fresh install → `wp plugin get acrossai-abilities-manager --field=version` returns `0.0.2`
- [ ] Fresh install → `wp eval 'echo ACROSSAI_ABILITIES_MANAGER_VERSION;'` prints `0.0.2`
- [ ] Plugins list in WP-Admin shows `Version: 0.0.2`
- [ ] README changelog + upgrade notice display correctly on wp.org preview (if applicable)

### Historical `@since 0.0.1` docblocks
Left intact — those mark original symbol introduction, not release scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)