### PR TITLE
Fix WordPress.org 0.0.2 activation error + release 0.0.3

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -15,18 +15,23 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer install --prefer-dist --no-progress
-          npm install
+          composer install --no-dev --prefer-dist --no-progress --optimize-autoloader
+          npm ci
 
       - name: Build plugin
         run: npm run build
 
+      - name: Verify build outputs
+        run: |
+          test -f vendor/autoload_packages.php || { echo "::error::vendor/autoload_packages.php missing"; exit 1; }
+          test -f build/js/abilities.js || { echo "::error::build/js/abilities.js missing"; exit 1; }
+
       - name: Create release zip
         run: |
           zip -r acrossai-abilities-manager.zip . \
-            -x "*.git*" "node_modules/*" "vendor/*" ".github/*" \
+            -x "*.git*" "node_modules/*" ".github/*" \
             "tests/*" "*.md" "*.json" "*.lock" "composer.json" \
-            "package.json" "wp.env.json" ".env*" "build/*"
+            "package.json" "wp.env.json" ".env*"
           mkdir -p releases
           mv acrossai-abilities-manager.zip releases/
 

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -9,6 +9,16 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.1'
+                  tools: composer:v2
+                  coverage: none
+            - name: Install Composer dependencies (production only)
+              run: composer install --no-dev --prefer-dist --optimize-autoloader --no-interaction
+            - name: Verify Composer autoloader was generated
+              run: test -f vendor/autoload_packages.php || { echo "::error::vendor/autoload_packages.php missing after composer install"; exit 1; }
             - name: Fix git safe directory
               run: git config --global --add safe.directory /github/workspace
             - name: WordPress Plugin Deploy

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.2
+Stable tag: 0.0.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -117,6 +117,9 @@ No data is sent to any external server without explicit user action.
 
 == Changelog ==
 
+= 0.0.3 =
+* **Fix: plugin now activates on installs from WordPress.org.** The 0.0.2 release ZIP shipped without the Composer autoloader (`vendor/autoload_packages.php`) because the WordPress.org deploy workflow did not run `composer install` before uploading. Users installing 0.0.2 from the WordPress.org plugin directory saw the plugin activation guard trigger: *"AcrossAI Abilities Manager cannot activate: the Composer autoloader is missing…"*. The 0.0.3 release ZIP includes the full production autoloader; no other code changes. If you already installed 0.0.2 and hit the activation error, delete the plugin folder and reinstall 0.0.3.
+
 = 0.0.2 =
 * **Composer dependency refresh** — `wpb-access-control` bumped to v2.0.0 (per-consumer database tables); `acrossai-co/main-menu` bumped to v0.0.10 (now bundles the Add-ons page and includes the JS-side rebrand-sync fix that restores Install / Activate / Deactivate button behavior). The standalone `acrossai-co/addons-page` package has been removed from direct dependencies; the same `AcrossAI_Addon\AddonsPage` class now ships from the `main-menu` package.
 * **Per-consumer access-control storage** — this plugin now owns its own `{prefix}abilities_access_control` database table, keeping its rules fully isolated from any other plugin embedding the same access-control library. The dedicated table is created automatically on plugin activation.
@@ -132,6 +135,9 @@ No data is sent to any external server without explicit user action.
 * MCP server listing via MCP Adapter integration.
 
 == Upgrade Notice ==
+
+= 0.0.3 =
+Fixes the 0.0.2 activation error on WordPress.org installs — the release ZIP now includes the Composer autoloader. No functional or user-facing changes vs 0.0.2. If you hit the "Composer autoloader is missing" error on 0.0.2, delete the plugin folder and reinstall 0.0.3.
 
 = 0.0.2 =
 IMPORTANT: (1) This release does NOT migrate Access Control rules from previous versions. If you had configured any Access Control rules on abilities, audit and reconfigure them after upgrading. Pre-existing rules remain in the database (in the orphaned `{prefix}wpb_access_control` table) but are no longer applied. (2) Ability execution logging has been removed — the Logs admin page is gone; ability-execution denials are no longer recorded by this plugin. Install a compatible logging plugin if you need this signal.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.2
+ * Version:           0.0.3
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.2' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.3' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Users installing **acrossai-abilities-manager 0.0.2** from https://wordpress.org/plugins/acrossai-abilities-manager/ get `wp_die()` on activation:

> AcrossAI Abilities Manager cannot activate: the Composer autoloader is missing. Run "composer install" inside the plugin directory and try again.

**The activation guard is correct** — `vendor/autoload_packages.php` is legitimately absent from the shipped ZIP. Root cause is entirely in CI/CD; no plugin code change needed.

## Root cause

`vendor/` is gitignored (`.gitignore:36` — `/vendor/`), but neither release workflow runs `composer install` before packaging:

**`.github/workflows/wordpress-plugin-deploy.yml`** (the acute bug — this is what users hit):
- Runs `actions/checkout@v4` → immediately `10up/action-wordpress-plugin-deploy@stable`.
- 10up's action reads `.distignore` (which correctly does NOT exclude `vendor/`) and syncs everything to WP.org SVN. But `vendor/` doesn't exist on the runner, so nothing about `vendor/` reaches SVN.

**`.github/workflows/build-zip.yml`** (latent bug — same class):
- Runs `composer install` (without `--no-dev`) → `npm install` → `npm run build`, then explicitly **excludes** `vendor/*` AND `build/*` from the ZIP with `-x`. Anyone downloading the artifact would hit the same activation error, and the admin UI would render without JS.

## Fix (3 commits)

1. **`ae534b1`** — `wordpress-plugin-deploy.yml`: add `shivammathur/setup-php@v2` + `composer install --no-dev --prefer-dist --optimize-autoloader --no-interaction` + a smoke-test step that fails loud if the autoloader was somehow not generated. Belt-and-braces against a future regression re-shipping a broken tag.
2. **`033b544`** — `build-zip.yml`: switch composer to `--no-dev --optimize-autoloader`, switch `npm install` → `npm ci`, remove `vendor/*` and `build/*` from ZIP exclusions, add a verify-build-outputs smoke test.
3. **`1f66886`** — Release 0.0.3. Three-file version bump (Plugin header, `ACROSSAI_ABILITIES_MANAGER_VERSION` constant, `Stable tag`) + README changelog `= 0.0.3 =` section. **No code changes** — this release is byte-for-byte identical PHP/JS/SCSS to 0.0.2, only the CI produces a different (working) ZIP this time.

## Local smoke test (already verified in this branch)

```
rm -rf vendor/
composer install --no-dev --prefer-dist --optimize-autoloader --no-interaction
test -f vendor/autoload_packages.php && echo "OK autoloader present"
```
→ `OK autoloader present` on this branch. Same command runs on the CI runner.

## Test plan

- [ ] CI: `phpstan.yml`, `phpcs.yml`, `phpunit.yml`, `phpcompat.yml` — all remain green (no production code changed)
- [ ] Merge PR
- [ ] Cut GitHub Release `0.0.3` on the merge commit — `wordpress-plugin-deploy.yml` fires with the fix applied
- [ ] Verify Actions log for the deploy: the new "Verify Composer autoloader was generated" step is green (`vendor/autoload_packages.php` exists)
- [ ] Verify on wp.org: [plugin page](https://wordpress.org/plugins/acrossai-abilities-manager/) advertises `0.0.3` as latest, Download → unzip → confirm `vendor/autoload_packages.php` is in the ZIP
- [ ] Fresh WP install → WP-Admin → Plugins → Add New → search "AcrossAI Abilities Manager" → Install & Activate → **NO wp_die()**; plugin activates cleanly
- [ ] `wp plugin get acrossai-abilities-manager --field=version` returns `0.0.3`
- [ ] Navigate to WP-Admin → AcrossAI → Abilities → list renders

## Repro (before this PR merges)

Any fresh WP install → wp-admin → Plugins → Add New → "AcrossAI Abilities Manager" → Activate → `wp_die("...Composer autoloader is missing...")`.

## Repro (after this PR merges + 0.0.3 publishes)

Same steps → plugin activates.

## Files changed

- `.github/workflows/wordpress-plugin-deploy.yml` (+10 −0)
- `.github/workflows/build-zip.yml` (+9 −4)
- `acrossai-abilities-manager.php` (+1 −1)
- `includes/Main.php` (+1 −1)
- `README.txt` (+7 −1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)