### PR TITLE
Release 0.0.5 — refresh acrossai-co/main-menu to 0.0.11

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.4
+Stable tag: 0.0.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -117,6 +117,9 @@ No data is sent to any external server without explicit user action.
 
 == Changelog ==
 
+= 0.0.5 =
+* **Dependencies: `acrossai-co/main-menu` bumped to `0.0.11`.** Picks up the latest AcrossAI shared parent menu / dashboard / settings / add-ons page code from that package. No plugin-owned code changes in this release — the bump is the only functional delta vs 0.0.4.
+
 = 0.0.4 =
 * **BREAKING (add-on developers) — Library display fields moved from top-level `$args` into `$args['meta']['acrossai']`.** The three Library-only fields introduced by Features 033 and 037 — `sub_group`, `sub_group_label`, and `tab_group` — are no longer read from the top level of the `$args` array passed to `wp_register_ability()`. They must now be nested under `$args['meta']['acrossai']`, matching the existing `meta.mcp` (MCP integration) and `meta.annotations` (WP-core annotations) convention. This is a hard cut with no back-compat shim: any add-on that still passes the fields at the top level will silently render its Library card without a sub-group heading or custom tab placement. Migration: change `'sub_group' => 'x'` to `'meta' => [ 'acrossai' => [ 'sub_group' => 'x' ] ]` (same for `sub_group_label` and `tab_group`). Only affects add-ons that extend `Ability_Definition` and use these Library display fields; abilities without them are unaffected. No end-user data migration, no DB schema change, no REST API change.
 * **Plugin icon replaced with a vector (SVG) asset.** The WordPress.org plugin directory now serves `.wordpress-org/icon.svg` in place of the previous 128×128 / 256×256 JPG icons, so the icon renders sharp at any display density. Also removes the 772×250 and 1544×500 header banners from the directory listing — the plugin page will show the WordPress.org default header until banners are re-added. wp.org-assets-only change.
@@ -139,6 +142,9 @@ No data is sent to any external server without explicit user action.
 * MCP server listing via MCP Adapter integration.
 
 == Upgrade Notice ==
+
+= 0.0.5 =
+Dependency-only release: refreshes the bundled `acrossai-co/main-menu` package to `0.0.11`. No functional changes to this plugin. Safe upgrade.
 
 = 0.0.4 =
 IMPORTANT for add-on developers: Library display fields `sub_group`, `sub_group_label`, and `tab_group` must now be nested under `$args['meta']['acrossai']` when calling `wp_register_ability()`. The old top-level shape is silently dropped — cards will render without their sub-group heading or custom tab placement until you migrate. End users and site administrators are not affected; no data migration, no DB or REST changes. Also swaps the WordPress.org plugin icon to an SVG and drops the directory banners.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.4
+ * Version:           0.0.5
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"automattic/jetpack-autoloader": "^5.0",
 		"wpboilerplate/wpb-access-control": "^2.0.0",
 		"berlindb/core": "^3.0.0",
-		"acrossai-co/main-menu": "^0.0.10"
+		"acrossai-co/main-menu": "0.0.11"
 	},
 	"keywords": [
 		"wordpress",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b00edfe44dbb5e4f968e5e51b22882e",
+    "content-hash": "141ae05afcc2374c991cae34bf7b1faf",
     "packages": [
         {
             "name": "acrossai-co/main-menu",
-            "version": "0.0.10",
+            "version": "0.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acrossai-co/main-menu.git",
-                "reference": "5173abbfa8ae090d1c8e34920870b63cf3ed5d27"
+                "reference": "ed6d21b3760d7066b2ade409379868ba14bbc355"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acrossai-co/main-menu/zipball/5173abbfa8ae090d1c8e34920870b63cf3ed5d27",
-                "reference": "5173abbfa8ae090d1c8e34920870b63cf3ed5d27",
+                "url": "https://api.github.com/repos/acrossai-co/main-menu/zipball/ed6d21b3760d7066b2ade409379868ba14bbc355",
+                "reference": "ed6d21b3760d7066b2ade409379868ba14bbc355",
                 "shasum": ""
             },
             "require": {
@@ -43,9 +43,9 @@
             "description": "AcrossAI Admin Dashboard — parent menu, shared Settings page (Settings API), manager submenu slots, and an Add-ons page with Freemius integration.",
             "support": {
                 "issues": "https://github.com/acrossai-co/main-menu/issues",
-                "source": "https://github.com/acrossai-co/main-menu/tree/0.0.10"
+                "source": "https://github.com/acrossai-co/main-menu/tree/0.0.11"
             },
-            "time": "2026-07-02T10:14:38+00:00"
+            "time": "2026-07-04T01:01:24+00:00"
         },
         {
             "name": "automattic/jetpack-autoloader",

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.4' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.5' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Dependency-only release. Bumps `acrossai-co/main-menu` from `^0.0.10 → 0.0.11` to pick up the latest AcrossAI shared parent menu / dashboard / settings / add-ons page code. **No plugin-owned code changes vs 0.0.4.**

Constraint was also tightened from a caret to a pinned version (`0.0.11`) to match how the release was staged locally.

## Version touch-points (matches the 0.0.3 / 0.0.4 pattern)

- `acrossai-abilities-manager.php` Plugin header `Version: 0.0.5`
- `includes/Main.php` `ACROSSAI_ABILITIES_MANAGER_VERSION` → `'0.0.5'`
- `README.txt` `Stable tag: 0.0.5`
- `README.txt` new `= 0.0.5 =` Changelog + Upgrade Notice sections

## Post-merge tag

I did NOT push `0.0.5` from this branch — that would trigger the wp.org deploy workflow off a non-main commit. Once you merge, ping me and I'll tag `0.0.5` on the merge commit and publish the GitHub Release (bare-number scheme, same as `0.0.4`).

## Test plan

- [ ] CI green on the branch (composer install, PHPCS, PHPStan, PHPUnit, build-zip).
- [ ] After merge: tag `0.0.5` on the merge commit → publish GitHub Release → verify wp.org deploy runs and the release ZIP includes `vendor/autoload_packages.php` + the updated `vendor/acrossai-co/main-menu/` at `0.0.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)