### PR TITLE
Release 0.0.8 — Feature 053: Freemius removal + main-menu 0.0.14 → 0.0.23 + Library header row + self-filter

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.7
+Stable tag: 0.0.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -99,6 +99,12 @@ No data is sent to any external server without explicit user action.
 
 == Changelog ==
 
+= 0.0.8 =
+* **Freemius integration removed entirely.** The `freemius/wordpress-sdk` composer dependency is dropped (upstream `acrossai-co/main-menu` 0.0.21+ no longer requires it). The plugin no longer sends any data to Freemius, no longer shows a Connect / Login / Buy affordance on the Add-ons page, and the entire Freemius vendored SDK tree (~2,000 files) is removed from the installable ZIP. If you previously connected a Freemius account tied to this plugin, that connection is now inert; any `fs_*` or `freemius_*` rows in `wp_options` are no longer read by anything and can be safely deleted (e.g. `wp option list --search='fs_*'` then `wp option delete <name>` for each). This supersedes the 0.0.6 changelog entry about Freemius credentials — those credentials are no longer used. See PR [#69](https://github.com/acrossai-co/acrossai-abilities-manager/pull/69).
+* **Add-ons page — free-only, and this plugin excluded from its own listing.** The Add-ons page (`?page=acrossai-addons`) now lists only free companion plugins hosted on WordPress.org (Install / Activate / Deactivate via the standard WP plugin installer). This plugin no longer appears in its own Add-ons page — a small self-filter on the `acrossai_addons` hook removes it, since it's obviously already active when the page renders. Other AcrossAI companion plugins (MCP Manager, Model Manager, Turn Off AI Features) still list normally.
+* **Library page — title and Enable All / Disable All buttons on a single horizontal row.** The "Ability Library" page heading and the bulk-action buttons introduced in 0.0.7 (Feature 052) now share one line at the top of the page (title anchored left, buttons anchored right). Saves vertical space; matches administrator expectations for admin page layouts.
+* **Dependencies: `acrossai-co/main-menu` bumped from `0.0.14` to `0.0.23`.** Three-hop bump (0.0.21 → 0.0.22 → 0.0.23) accumulated during the release cycle. Consumer API surface (`SettingsPage`, `MenuRegistrar`, `AddonsPageRenderer`) preserved across each hop; no code changes required beyond removing the old `\AcrossAI_Addon\AddonsPage` instantiation (class deleted upstream in 0.0.21 — its responsibilities moved into `\AcrossAI_Main_Menu\MenuRegistrar` which is registered automatically when the shared `SettingsPage` bootstrap runs).
+
 = 0.0.7 =
 * **Library page — bulk Enable All / Disable All action buttons.** A new right-aligned header row above the tab strip on `?page=acrossai-abilities-library` renders two side-by-side buttons that toggle every ability category currently in view with a single click. Actions are scoped to the active tab: on the `All` tab they touch every registered category; on a specific tab (Core, Blocks, Themes, Users, Cache, File Manager, Cron, Database, Plugins) they only touch categories whose ability metadata declares that `tab_group`. Categories in other tabs pass through byte-for-byte unchanged. Each category's mode (All / Specific) and per-slug selections are preserved on both actions — a Disable All → Enable All cycle is a lossless round-trip. Persisted via the existing `POST /acrossai-abilities-library/v1/abilities/config` REST route (`manage_options` + nonce, unchanged). See PR [#68](https://github.com/acrossai-co/acrossai-abilities-manager/pull/68).
 * **URL-synced tabs on the Library page.** The active tab is now reflected in the browser URL as `?tab=<slug>`. Deep-linkable, bookmarkable, and browser back / forward navigation re-syncs the visible tab. Direct-navigation to `?page=acrossai-abilities-library&tab=themes` opens the Themes tab on first paint. Invalid tab values silently fall back to the default `All` view — no error, no console warning. The default `All` view keeps the canonical URL clean by removing the `tab` query arg entirely.
@@ -137,6 +143,9 @@ No data is sent to any external server without explicit user action.
 * MCP server listing via MCP Adapter integration.
 
 == Upgrade Notice ==
+
+= 0.0.8 =
+IMPORTANT: this release **removes the Freemius integration entirely** — the plugin no longer sends any data to Freemius and no longer offers a Connect / Login / Buy affordance on the Add-ons page. If you previously connected a Freemius account tied to this plugin, that connection is now inert; stale `fs_*` or `freemius_*` rows in `wp_options` are safe to delete manually. Also: the Add-ons page now shows only free WordPress.org companion plugins (and no longer lists this plugin itself); the Library page compacts its title + bulk-action buttons onto one horizontal row; and `acrossai-co/main-menu` bumps `0.0.14 → 0.0.23`. No breaking changes to REST endpoints, capability requirements, or database schema. Safe upgrade.
 
 = 0.0.7 =
 Adds Library page bulk Enable All / Disable All buttons scoped to the active tab, URL-synced tabs (`?tab=<slug>`) for deep-linkable views, and a readonly ability preview on disabled cards. No breaking changes; no database schema changes; no new REST endpoints; no new capability requirements. `mode` and per-slug selections are preserved through disable / enable cycles. Safe upgrade.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.7
+ * Version:           0.0.8
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.7' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.8' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Version bump `0.0.7 → 0.0.8` bundling the Feature 053 scope (merged via PR [#69](https://github.com/acrossai-co/acrossai-abilities-manager/pull/69)):

- **Freemius integration removed entirely** — dropped `freemius/wordpress-sdk 2.13.3` from `vendor/` (~2,000 files gone); deleted the `\AcrossAI_Addon\AddonsPage` instantiation block (class no longer exists in `main-menu 0.0.21+`); plugin no longer sends any data to Freemius or offers Connect / Login / Buy affordances. Any prior Freemius connection tied to this plugin is now inert.
- **Add-ons page — free-only, and this plugin excluded from its own listing** — the Add-ons page (`?page=acrossai-addons`) lists only free WordPress.org companion plugins. A small self-filter on the `acrossai_addons` hook removes this plugin's own entry (it's obviously already active when the page renders).
- **Library page header — title + Enable All / Disable All buttons on a single horizontal row** — the "Ability Library" page heading and the bulk-action buttons (added in 0.0.7 / Feature 052) now share one line at the top of the page, title anchored left, buttons anchored right.
- **Dependencies** — `acrossai-co/main-menu` bumped `0.0.14 → 0.0.23` (three-hop bump: 0.0.21 → 0.0.22 → 0.0.23 accumulated during the Feature 053 cycle). `automattic/jetpack-autoloader v5.0.20 → v5.0.21` (transitive).

**Files changed** (this PR — the release bump itself is 3 files):
- `acrossai-abilities-manager.php` — `Version: 0.0.7 → 0.0.8`
- `includes/Main.php` — `ACROSSAI_ABILITIES_MANAGER_VERSION 0.0.7 → 0.0.8`
- `README.txt` — `Stable tag: 0.0.8`, new `= 0.0.8 =` Changelog + Upgrade Notice entries

The `0.0.6` changelog entry mentioning Freemius credential rotation is explicitly superseded by the new `0.0.8` entry — those credentials are no longer used anywhere in the plugin.

**Not in this release**: nothing pending. All active feature branches (Feature 051 was reverted; Feature 052 shipped in 0.0.7; Feature 053 ships in this release) are accounted for.

## Test plan

- [x] `composer phpstan` — L8 zero errors
- [x] `composer phpcs -- acrossai-abilities-manager.php includes/Main.php` — zero errors
- [x] Version bumps consistent across all 3 files (grep verified)
- [ ] Manual: `wp plugin activate acrossai-abilities-manager` on a fresh wp-env with 0.0.7 previously installed — verify no activation errors, admin notices clean.
- [ ] Manual: visit `?page=acrossai-addons` — verify free-only listing, plugin's own card absent.
- [ ] Manual: visit `?page=acrossai-abilities-library` — verify title + Enable All / Disable All on one row.
- [ ] Manual: verify Feature 052 flows still work — bulk enable/disable per tab, URL-synced tabs, disabled-card UI.

## Notes for reviewer

- Content of Feature 053 already merged via PR #69 (commit `4a80a71`); this PR is version-bump-only.
- Follows the historical `release-N.N.N` branch pattern (PR #67 for Release 0.0.6, since 0.0.7 was an inline direct-to-main deviation which I want to avoid this cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)