### PR TITLE
Feature 041 — Backup/restore abilities + plugin/theme update

### DIFF
--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -105,6 +105,7 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Plugins\Plugin_Activate();
 		new Plugins\Plugin_Deactivate();
 		new Plugins\Plugin_Install();
+		new Plugins\Plugin_Update();
 		new Plugins\Plugin_List();
 		new Plugins\Update_Check();
 		new Settings\Permalink_Get();
@@ -120,6 +121,7 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Themes\Theme_Activate();
 		new Themes\Theme_Delete();
 		new Themes\Theme_Install();
+		new Themes\Theme_Update();
 		new Themes\Theme_List();
 		new Users\User_Get();
 		new Users\User_List();
@@ -155,6 +157,12 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new FileManager\Wp_Config_Edit();
 		new FileManager\Debug_Log_Read();
 		new FileManager\Debug_Log_Clear();
+		new FileManager\Zip_Create();
+		new FileManager\Zip_Upload();
+		new FileManager\Zip_Extract();
+		new FileManager\Zip_Download();
+		new FileManager\Zip_List();
+		new FileManager\Zip_Delete();
 		new Block\Pattern_List();
 		new Block\Pattern_Read();
 		new Block\Pattern_Create();
@@ -285,5 +293,9 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		Cron_Helpers::register_filter();
 		add_action( Media\Upload_Media::CHUNK_SWEEP_HOOK, array( Media\Upload_Media::class, 'sweep_chunk_sessions' ) );
 		Media\Upload_Media::register_sweep_cron();
+
+		// Feature 041: Zip_Upload chunk sweeper — same shape as Upload_Media.
+		add_action( FileManager\Zip_Upload::CHUNK_SWEEP_HOOK, array( FileManager\Zip_Upload::class, 'sweep_chunk_sessions' ) );
+		FileManager\Zip_Upload::register_sweep_cron();
 	}
 }

--- a/includes/Abilities/FileManager/Zip_Create.php
+++ b/includes/Abilities/FileManager/Zip_Create.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * Zip_Create ability (Feature 041).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\FileManager
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Backups_Storage;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Zip_Target_Resolver;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Zip a plugin, theme, uploads folder, mu-plugins folder, or arbitrary path
+ * inside ABSPATH and store the archive under
+ * wp-content/uploads/acrossai-backups/ with a random filename. Returns the
+ * download URL, ABSPATH-relative path, size, and SHA-256 so the caller can
+ * fetch the archive and hand it to a destination site.
+ */
+class Zip_Create extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/zip-create',
+			'args' => array(
+				'label'               => __( 'Create Zip Backup', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Zip a plugin, theme, uploads folder, mu-plugins folder, or an arbitrary path under ABSPATH. The archive is stored under wp-content/uploads/acrossai-backups/ with a random filename; the response returns the download URL, ABSPATH-relative path, size, and SHA-256.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-file-manager',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'target_type'    => array(
+							'type'        => 'string',
+							'enum'        => Zip_Target_Resolver::supported_types(),
+							'description' => __( 'What to back up: plugin, theme, uploads, mu-plugins, or an arbitrary path under ABSPATH.', 'acrossai-abilities-manager' ),
+						),
+						'target'         => array(
+							'type'        => 'string',
+							'description' => __( 'Plugin slug (e.g. "hello-dolly"), theme stylesheet (e.g. "twentytwentyfour"), or path relative to ABSPATH. Ignored for "uploads" and "mu-plugins".', 'acrossai-abilities-manager' ),
+						),
+						'include_hidden' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'When true, include dotfiles / hidden directories (e.g. .git) in the archive.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'required'             => array( 'target_type' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'   => array( 'type' => 'boolean' ),
+						'file_path' => array( 'type' => 'string' ),
+						'file_url'  => array( 'type' => 'string' ),
+						'size'      => array( 'type' => 'integer' ),
+						'sha256'    => array( 'type' => 'string' ),
+						'target'    => array( 'type' => 'string' ),
+						'message'   => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'file-manager',
+						'sub_group'       => 'backups',
+						'sub_group_label' => __( 'Backups', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		if ( ! class_exists( '\ZipArchive' ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'PHP ZipArchive extension is not available on this server.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$target_type    = (string) ( $input['target_type'] ?? '' );
+		$target         = (string) ( $input['target'] ?? '' );
+		$include_hidden = ! empty( $input['include_hidden'] );
+
+		$resolved = Zip_Target_Resolver::resolve_source( $target_type, $target );
+		if ( is_wp_error( $resolved ) ) {
+			return array(
+				'success' => false,
+				'message' => $resolved->get_error_message(),
+			);
+		}
+
+		$src_dir = rtrim( $resolved['abs_path'], '/' );
+
+		$backups_dir = Backups_Storage::backups_path();
+		if ( false === $backups_dir ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Could not create the backups directory under wp-content/uploads/acrossai-backups.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$filename = Backups_Storage::random_backup_filename( $target_type, $target );
+		$dest     = trailingslashit( $backups_dir ) . $filename;
+
+		/**
+		 * Filter the maximum backup archive size (bytes).
+		 *
+		 * The size of the source tree is estimated before writing the archive;
+		 * anything above the cap is rejected up front. Default: 512 MB.
+		 *
+		 * @param int $bytes Default 512 MB.
+		 */
+		$max_bytes = (int) apply_filters( 'acrossai_abilities_manager_zip_max_bytes', 512 * 1024 * 1024 );
+
+		$estimated_bytes = self::estimate_tree_size( $src_dir, $include_hidden );
+		if ( $estimated_bytes > $max_bytes ) {
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: 1: estimated bytes, 2: cap bytes */
+					__( 'Source tree is ~%1$d bytes which exceeds the configured backup cap of %2$d bytes.', 'acrossai-abilities-manager' ),
+					$estimated_bytes,
+					$max_bytes
+				),
+			);
+		}
+
+		$zip  = new \ZipArchive();
+		$open = $zip->open( $dest, \ZipArchive::CREATE | \ZipArchive::OVERWRITE );
+		if ( true !== $open ) {
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: %d: ZipArchive open error code */
+					__( 'Could not open a new zip archive for writing (ZipArchive error %d).', 'acrossai-abilities-manager' ),
+					(int) $open
+				),
+			);
+		}
+
+		$prefix   = self::archive_prefix( $resolved['label'], $src_dir );
+		$appended = self::append_dir_to_zip( $zip, $src_dir, $prefix, $include_hidden );
+
+		if ( is_wp_error( $appended ) ) {
+			$zip->close();
+			if ( file_exists( $dest ) ) {
+				wp_delete_file( $dest );
+			}
+			return array(
+				'success' => false,
+				'message' => $appended->get_error_message(),
+			);
+		}
+
+		$zip->close();
+
+		if ( ! is_file( $dest ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Zip archive was not written to disk.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$size = (int) filesize( $dest );
+		if ( $size > $max_bytes ) {
+			wp_delete_file( $dest );
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: 1: archive bytes, 2: cap bytes */
+					__( 'Zip archive size (%1$d bytes) exceeds the configured cap (%2$d bytes).', 'acrossai-abilities-manager' ),
+					$size,
+					$max_bytes
+				),
+			);
+		}
+
+		return array(
+			'success'   => true,
+			'file_path' => Backups_Storage::to_abspath_relative( $dest ),
+			'file_url'  => Backups_Storage::url_for( $dest ),
+			'size'      => $size,
+			'sha256'    => Backups_Storage::sha256_of( $dest ),
+			'target'    => $resolved['label'],
+			'message'   => sprintf(
+				/* translators: 1: number of files added, 2: archive size in bytes */
+				__( 'Zip created with %1$d entries (%2$d bytes).', 'acrossai-abilities-manager' ),
+				(int) $appended,
+				$size
+			),
+		);
+	}
+
+	/**
+	 * Best-effort size estimate for a source directory, used purely as an
+	 * up-front guard against ballooning archives. Skips unreadable entries.
+	 */
+	private static function estimate_tree_size( string $dir, bool $include_hidden ): int {
+		if ( ! is_dir( $dir ) ) {
+			return 0;
+		}
+		$total = 0;
+		try {
+			$iter = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::SKIP_DOTS ),
+				\RecursiveIteratorIterator::SELF_FIRST
+			);
+		} catch ( \Throwable $e ) {
+			return 0;
+		}
+		/** @var \SplFileInfo $entry */
+		foreach ( $iter as $entry ) {
+			$name = $entry->getFilename();
+			if ( ! $include_hidden && '' !== $name && '.' === $name[0] ) {
+				continue;
+			}
+			if ( $entry->isFile() ) {
+				$total += (int) $entry->getSize();
+			}
+		}
+		return $total;
+	}
+
+	/**
+	 * Decide the leading directory name inside the archive. Using a stable
+	 * prefix (e.g. "hello-dolly/") makes the resulting zip easy to inspect
+	 * and mirrors what WP core's Plugin/Theme upgraders expect on install.
+	 */
+	private static function archive_prefix( string $label, string $src_dir ): string {
+		$base = basename( $src_dir );
+		if ( str_starts_with( $label, 'plugin:' ) || str_starts_with( $label, 'theme:' ) ) {
+			return $base . '/';
+		}
+		if ( 'uploads' === $label ) {
+			return 'uploads/';
+		}
+		if ( 'mu-plugins' === $label ) {
+			return 'mu-plugins/';
+		}
+		return $base . '/';
+	}
+
+	/**
+	 * Recursively add every file/dir under $src to $zip, prefixed with $prefix.
+	 * Returns the number of files added, or a WP_Error on failure.
+	 *
+	 * @return int|\WP_Error
+	 */
+	private static function append_dir_to_zip( \ZipArchive $zip, string $src, string $prefix, bool $include_hidden ) {
+		$src   = rtrim( $src, '/' );
+		$count = 0;
+
+		try {
+			$iter = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator( $src, \FilesystemIterator::SKIP_DOTS ),
+				\RecursiveIteratorIterator::SELF_FIRST
+			);
+		} catch ( \Throwable $e ) {
+			return new \WP_Error(
+				'zip_iterate_failed',
+				sprintf(
+					/* translators: %s: PHP error message */
+					__( 'Could not iterate source directory: %s', 'acrossai-abilities-manager' ),
+					$e->getMessage()
+				)
+			);
+		}
+
+		/** @var \SplFileInfo $entry */
+		foreach ( $iter as $entry ) {
+			$name = $entry->getFilename();
+			if ( ! $include_hidden && '' !== $name && '.' === $name[0] ) {
+				continue;
+			}
+
+			$path = $entry->getPathname();
+			$rel  = ltrim( str_replace( $src, '', $path ), '/\\' );
+			$rel  = str_replace( '\\', '/', $rel );
+
+			if ( '' === $rel ) {
+				continue;
+			}
+
+			if ( $entry->isDir() ) {
+				$zip->addEmptyDir( $prefix . $rel );
+				continue;
+			}
+			if ( $entry->isFile() ) {
+				if ( ! $zip->addFile( $path, $prefix . $rel ) ) {
+					return new \WP_Error(
+						'zip_add_failed',
+						sprintf(
+							/* translators: %s: file path that failed to be added */
+							__( 'Could not add file to archive: %s', 'acrossai-abilities-manager' ),
+							$rel
+						)
+					);
+				}
+				++$count;
+			}
+		}
+
+		return $count;
+	}
+}

--- a/includes/Abilities/FileManager/Zip_Delete.php
+++ b/includes/Abilities/FileManager/Zip_Delete.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Zip_Delete ability (Feature 041).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\FileManager
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Backups_Storage;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Delete a zip stored under acrossai-backups/ or acrossai-staging/. Idempotent
+ * — deleting a missing file returns success with a note.
+ */
+class Zip_Delete extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/zip-delete',
+			'args' => array(
+				'label'               => __( 'Delete Zip Backup', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Delete a zip stored under acrossai-backups/ or acrossai-staging/. Path outside those two directories is rejected; deleting a missing file returns success with a note.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-file-manager',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'file_path' => array(
+							'type'        => 'string',
+							'description' => __( 'ABSPATH-relative path or bare filename inside acrossai-backups/ or acrossai-staging/.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'required'             => array( 'file_path' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'deleted_path' => array( 'type' => 'string' ),
+						'existed'      => array( 'type' => 'boolean' ),
+						'message'      => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'file-manager',
+						'sub_group'       => 'backups',
+						'sub_group_label' => __( 'Backups', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response( 'install' );
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		$file_path = sanitize_text_field( (string) ( $input['file_path'] ?? '' ) );
+
+		$resolved = Backups_Storage::resolve_managed_path( $file_path );
+		if ( is_wp_error( $resolved ) ) {
+			return array(
+				'success' => false,
+				'message' => $resolved->get_error_message(),
+			);
+		}
+
+		$rel      = Backups_Storage::to_abspath_relative( $resolved );
+		$existed  = is_file( $resolved );
+
+		if ( ! $existed ) {
+			return array(
+				'success'      => true,
+				'deleted_path' => $rel,
+				'existed'      => false,
+				'message'      => __( 'File was already absent — nothing to delete.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		wp_delete_file( $resolved );
+
+		if ( is_file( $resolved ) ) {
+			return array(
+				'success'      => false,
+				'deleted_path' => $rel,
+				'existed'      => true,
+				'message'      => __( 'File could not be deleted.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		return array(
+			'success'      => true,
+			'deleted_path' => $rel,
+			'existed'      => true,
+			'message'      => __( 'File deleted.', 'acrossai-abilities-manager' ),
+		);
+	}
+}

--- a/includes/Abilities/FileManager/Zip_Download.php
+++ b/includes/Abilities/FileManager/Zip_Download.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Zip_Download ability (Feature 041).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\FileManager
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Backups_Storage;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return a fresh download URL and metadata for a zip already stored under
+ * acrossai-backups/ or acrossai-staging/. Callers use this to retrieve an
+ * older backup they didn't just create.
+ */
+class Zip_Download extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/zip-download',
+			'args' => array(
+				'label'               => __( 'Download Zip Backup', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Look up a zip already stored under acrossai-backups/ or acrossai-staging/ and return its download URL plus metadata (size, sha256, created_at).', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-file-manager',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'file_path' => array(
+							'type'        => 'string',
+							'description' => __( 'ABSPATH-relative path (or bare filename) that resolves inside acrossai-backups/ or acrossai-staging/.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'required'             => array( 'file_path' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'file_path'  => array( 'type' => 'string' ),
+						'file_url'   => array( 'type' => 'string' ),
+						'size'       => array( 'type' => 'integer' ),
+						'sha256'     => array( 'type' => 'string' ),
+						'created_at' => array( 'type' => 'string' ),
+						'message'    => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'file-manager',
+						'sub_group'       => 'backups',
+						'sub_group_label' => __( 'Backups', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$file_path = sanitize_text_field( (string) ( $input['file_path'] ?? '' ) );
+
+		$resolved = Backups_Storage::resolve_managed_path( $file_path );
+		if ( is_wp_error( $resolved ) ) {
+			return array(
+				'success' => false,
+				'message' => $resolved->get_error_message(),
+			);
+		}
+
+		if ( ! is_file( $resolved ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'File does not exist.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		return array(
+			'success'    => true,
+			'file_path'  => Backups_Storage::to_abspath_relative( $resolved ),
+			'file_url'   => Backups_Storage::url_for( $resolved ),
+			'size'       => (int) filesize( $resolved ),
+			'sha256'     => Backups_Storage::sha256_of( $resolved ),
+			'created_at' => gmdate( 'c', (int) filemtime( $resolved ) ),
+		);
+	}
+}

--- a/includes/Abilities/FileManager/Zip_Extract.php
+++ b/includes/Abilities/FileManager/Zip_Extract.php
@@ -1,0 +1,422 @@
+<?php
+/**
+ * Zip_Extract ability (Feature 041).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\FileManager
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Zip_Target_Resolver;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Extract a zip archive (already on disk or fetched from a URL) into the
+ * resolved target directory (plugin / theme / uploads / mu-plugins / path).
+ *
+ * The zip is opened with PHP's ZipArchive so every entry can be inspected for
+ * "zip slip" attempts (`..` segments, absolute paths) BEFORE extraction. Only
+ * clean archives are extracted, and only after DISALLOW_FILE_MODS is checked.
+ */
+class Zip_Extract extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/zip-extract',
+			'args' => array(
+				'label'               => __( 'Extract Zip Backup', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Extract a zip archive (already on disk or fetched from a URL) into the resolved target directory. Every entry is checked for path traversal before extraction; DISALLOW_FILE_MODS short-circuits the ability.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-file-manager',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'source'      => array(
+							'type'                 => 'object',
+							'description'          => __( 'Where to read the zip from. Provide either "path" (ABSPATH-relative) or "url".', 'acrossai-abilities-manager' ),
+							'properties'           => array(
+								'path' => array(
+									'type'        => 'string',
+									'description' => __( 'ABSPATH-relative path to a zip already on disk.', 'acrossai-abilities-manager' ),
+								),
+								'url'  => array(
+									'type'        => 'string',
+									'format'      => 'uri',
+									'description' => __( 'Remote HTTP(S) URL for the zip.', 'acrossai-abilities-manager' ),
+								),
+							),
+							'anyOf'                => array(
+								array( 'required' => array( 'path' ) ),
+								array( 'required' => array( 'url' ) ),
+							),
+							'additionalProperties' => false,
+						),
+						'target_type' => array(
+							'type'        => 'string',
+							'enum'        => Zip_Target_Resolver::supported_types(),
+							'description' => __( 'Destination type: plugin, theme, uploads, mu-plugins, or an arbitrary path under ABSPATH.', 'acrossai-abilities-manager' ),
+						),
+						'target'      => array(
+							'type'        => 'string',
+							'description' => __( 'Plugin slug, theme stylesheet, or ABSPATH-relative path. Ignored for "uploads" and "mu-plugins".', 'acrossai-abilities-manager' ),
+						),
+						'overwrite'   => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'When true, existing files in the target directory are overwritten. When false (default), unzip_file() is used with clobber=false semantics.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'required'             => array( 'source', 'target_type' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'extracted_to' => array( 'type' => 'string' ),
+						'files_count'  => array( 'type' => 'integer' ),
+						'target'       => array( 'type' => 'string' ),
+						'message'      => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'file-manager',
+						'sub_group'       => 'backups',
+						'sub_group_label' => __( 'Backups', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response( 'install' );
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		if ( ! class_exists( '\ZipArchive' ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'PHP ZipArchive extension is not available on this server.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$source = isset( $input['source'] ) && is_array( $input['source'] ) ? $input['source'] : array();
+		if ( empty( $source['path'] ) && empty( $source['url'] ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Provide "source.path" (zip already on disk) or "source.url" (remote fetch).', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$target_type = (string) ( $input['target_type'] ?? '' );
+		$target      = (string) ( $input['target'] ?? '' );
+		$overwrite   = ! empty( $input['overwrite'] );
+
+		$resolved = Zip_Target_Resolver::resolve_destination( $target_type, $target );
+		if ( is_wp_error( $resolved ) ) {
+			return array(
+				'success' => false,
+				'message' => $resolved->get_error_message(),
+			);
+		}
+		$dest_dir = rtrim( $resolved['abs_path'], '/' );
+
+		$fetched = $this->resolve_zip_source( $source );
+		if ( isset( $fetched['error'] ) ) {
+			return array(
+				'success' => false,
+				'message' => $fetched['error'],
+			);
+		}
+		$zip_path        = $fetched['path'];
+		$delete_zip_when = $fetched['cleanup']; // 'always' when fetched from URL; 'never' for on-disk sources.
+
+		$audit = $this->audit_zip_entries( $zip_path );
+		if ( isset( $audit['error'] ) ) {
+			if ( 'always' === $delete_zip_when && file_exists( $zip_path ) ) {
+				wp_delete_file( $zip_path );
+			}
+			return array(
+				'success' => false,
+				'message' => $audit['error'],
+			);
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		global $wp_filesystem;
+		if ( ! function_exists( '\WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+		if ( ! WP_Filesystem() ) {
+			if ( 'always' === $delete_zip_when && file_exists( $zip_path ) ) {
+				wp_delete_file( $zip_path );
+			}
+			return array(
+				'success' => false,
+				'message' => __( 'Could not initialize WP_Filesystem for extraction.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( ! wp_mkdir_p( $dest_dir ) ) {
+			if ( 'always' === $delete_zip_when && file_exists( $zip_path ) ) {
+				wp_delete_file( $zip_path );
+			}
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: %s: destination directory */
+					__( 'Could not create destination directory: %s', 'acrossai-abilities-manager' ),
+					$dest_dir
+				),
+			);
+		}
+
+		if ( $overwrite ) {
+			$extracted = $this->extract_with_overwrite( $zip_path, $dest_dir );
+		} else {
+			$extracted = unzip_file( $zip_path, $dest_dir );
+		}
+
+		if ( 'always' === $delete_zip_when && file_exists( $zip_path ) ) {
+			wp_delete_file( $zip_path );
+		}
+
+		if ( is_wp_error( $extracted ) ) {
+			return array(
+				'success' => false,
+				'message' => $extracted->get_error_message(),
+			);
+		}
+
+		return array(
+			'success'      => true,
+			'extracted_to' => $dest_dir,
+			'files_count'  => (int) $audit['files_count'],
+			'target'       => $resolved['label'],
+			'message'      => sprintf(
+				/* translators: 1: files count, 2: destination directory */
+				__( 'Extracted %1$d entries into %2$s.', 'acrossai-abilities-manager' ),
+				(int) $audit['files_count'],
+				$dest_dir
+			),
+		);
+	}
+
+	/**
+	 * Turn the input `source` into a local zip file path.
+	 *
+	 * @param array<string,mixed> $source
+	 * @return array{path: string, cleanup: 'always'|'never'}|array{error: string}
+	 */
+	private function resolve_zip_source( array $source ): array {
+		if ( ! empty( $source['url'] ) ) {
+			$url = sanitize_url( (string) $source['url'] );
+			if ( ! wp_http_validate_url( $url ) ) {
+				return array( 'error' => __( 'A valid http(s) URL is required.', 'acrossai-abilities-manager' ) );
+			}
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			$tmp = download_url( $url );
+			if ( is_wp_error( $tmp ) ) {
+				return array( 'error' => $tmp->get_error_message() );
+			}
+			return array(
+				'path'    => (string) $tmp,
+				'cleanup' => 'always',
+			);
+		}
+
+		$rel_path = sanitize_text_field( (string) $source['path'] );
+		if ( '' === $rel_path ) {
+			return array( 'error' => __( 'The "source.path" is empty.', 'acrossai-abilities-manager' ) );
+		}
+		$base = rtrim( realpath( ABSPATH ) ?: ABSPATH, '/' );
+		$abs  = realpath( $base . '/' . ltrim( $rel_path, '/' ) );
+		if ( false === $abs || 0 !== strpos( $abs, $base . '/' ) ) {
+			return array( 'error' => __( 'The "source.path" must resolve to a zip file inside ABSPATH.', 'acrossai-abilities-manager' ) );
+		}
+		if ( ! is_file( $abs ) ) {
+			return array( 'error' => __( 'The zip file does not exist at the given "source.path".', 'acrossai-abilities-manager' ) );
+		}
+		return array(
+			'path'    => $abs,
+			'cleanup' => 'never',
+		);
+	}
+
+	/**
+	 * Inspect every entry in the zip and reject the archive when any entry
+	 * contains a path traversal segment, absolute path, or backslash. Also
+	 * validates the total decompressed size against the size cap and counts
+	 * files for the response.
+	 *
+	 * @return array{files_count: int, uncompressed: int}|array{error: string}
+	 */
+	private function audit_zip_entries( string $zip_path ): array {
+		$zip = new \ZipArchive();
+		$rc  = $zip->open( $zip_path, \ZipArchive::CHECKCONS );
+		if ( true !== $rc ) {
+			return array(
+				'error' => sprintf(
+					/* translators: %d: ZipArchive::open() return code */
+					__( 'Could not open zip for inspection (ZipArchive error %d).', 'acrossai-abilities-manager' ),
+					(int) $rc
+				),
+			);
+		}
+
+		/**
+		 * Filter the maximum extraction size (bytes).
+		 *
+		 * @param int $bytes Default 512 MB.
+		 */
+		$max_bytes = (int) apply_filters( 'acrossai_abilities_manager_zip_max_bytes', 512 * 1024 * 1024 );
+
+		$files_count  = 0;
+		$uncompressed = 0;
+		$num          = $zip->numFiles;
+		for ( $i = 0; $i < $num; $i++ ) {
+			$stat = $zip->statIndex( $i );
+			if ( ! is_array( $stat ) ) {
+				$zip->close();
+				return array(
+					'error' => sprintf(
+						/* translators: %d: entry index */
+						__( 'Could not stat zip entry %d.', 'acrossai-abilities-manager' ),
+						$i
+					),
+				);
+			}
+			$name = (string) ( $stat['name'] ?? '' );
+			if ( '' === $name ) {
+				$zip->close();
+				return array( 'error' => __( 'Zip archive contains an unnamed entry.', 'acrossai-abilities-manager' ) );
+			}
+			if ( false !== strpos( $name, "\0" ) ) {
+				$zip->close();
+				return array( 'error' => __( 'Zip archive contains an entry with a null byte.', 'acrossai-abilities-manager' ) );
+			}
+			if ( false !== strpos( $name, '\\' ) ) {
+				$zip->close();
+				return array(
+					'error' => sprintf(
+						/* translators: %s: rejected entry name */
+						__( 'Zip archive contains an entry with a backslash: %s', 'acrossai-abilities-manager' ),
+						$name
+					),
+				);
+			}
+			if ( '/' === substr( $name, 0, 1 ) ) {
+				$zip->close();
+				return array(
+					'error' => sprintf(
+						/* translators: %s: rejected entry name */
+						__( 'Zip archive contains an entry with an absolute path: %s', 'acrossai-abilities-manager' ),
+						$name
+					),
+				);
+			}
+			$parts = explode( '/', $name );
+			foreach ( $parts as $part ) {
+				if ( '..' === $part ) {
+					$zip->close();
+					return array(
+						'error' => sprintf(
+							/* translators: %s: rejected entry name */
+							__( 'Zip archive contains a path-traversal entry: %s', 'acrossai-abilities-manager' ),
+							$name
+						),
+					);
+				}
+			}
+			$uncompressed += (int) ( $stat['size'] ?? 0 );
+			if ( '/' !== substr( $name, -1 ) ) {
+				++$files_count;
+			}
+		}
+
+		$zip->close();
+
+		if ( $uncompressed > $max_bytes ) {
+			return array(
+				'error' => sprintf(
+					/* translators: 1: uncompressed size, 2: cap */
+					__( 'Zip decompresses to %1$d bytes which exceeds the configured cap of %2$d bytes.', 'acrossai-abilities-manager' ),
+					$uncompressed,
+					$max_bytes
+				),
+			);
+		}
+
+		return array(
+			'files_count'  => $files_count,
+			'uncompressed' => $uncompressed,
+		);
+	}
+
+	/**
+	 * Overwrite-friendly extraction. `unzip_file()` never overwrites; when the
+	 * caller asks for overwrite=true we drop directly to ZipArchive::extractTo
+	 * after the audit has already vetted every entry.
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function extract_with_overwrite( string $zip_path, string $dest_dir ) {
+		$zip = new \ZipArchive();
+		$rc  = $zip->open( $zip_path );
+		if ( true !== $rc ) {
+			return new \WP_Error(
+				'zip_open_failed',
+				sprintf(
+					/* translators: %d: ZipArchive::open() return code */
+					__( 'Could not open zip for extraction (ZipArchive error %d).', 'acrossai-abilities-manager' ),
+					(int) $rc
+				)
+			);
+		}
+		if ( ! $zip->extractTo( $dest_dir ) ) {
+			$zip->close();
+			return new \WP_Error(
+				'zip_extract_failed',
+				__( 'ZipArchive::extractTo() failed.', 'acrossai-abilities-manager' )
+			);
+		}
+		$zip->close();
+		return true;
+	}
+}

--- a/includes/Abilities/FileManager/Zip_List.php
+++ b/includes/Abilities/FileManager/Zip_List.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Zip_List ability (Feature 041).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\FileManager
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Backups_Storage;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List zips inside acrossai-backups/ (or acrossai-staging/) with metadata,
+ * newest first. Feeds any "restore from a previous backup" flow.
+ */
+class Zip_List extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/zip-list',
+			'args' => array(
+				'label'               => __( 'List Zip Backups', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List zips inside acrossai-backups/ (default) or acrossai-staging/, newest first, with size, sha256, created_at.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-file-manager',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'dir'    => array(
+							'type'        => 'string',
+							'enum'        => array( Backups_Storage::BACKUPS_DIR, Backups_Storage::STAGING_DIR ),
+							'default'     => Backups_Storage::BACKUPS_DIR,
+							'description' => __( 'Which managed directory to list: "acrossai-backups" (default) or "acrossai-staging".', 'acrossai-abilities-manager' ),
+						),
+						'limit'  => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'maximum'     => 200,
+							'default'     => 50,
+							'description' => __( 'Max entries to return (1..200).', 'acrossai-abilities-manager' ),
+						),
+						'offset' => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+							'default' => 0,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'items'   => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'                 => 'object',
+								'properties'           => array(
+									'file_path'  => array( 'type' => 'string' ),
+									'file_url'   => array( 'type' => 'string' ),
+									'size'       => array( 'type' => 'integer' ),
+									'sha256'     => array( 'type' => 'string' ),
+									'created_at' => array( 'type' => 'string' ),
+								),
+								'additionalProperties' => false,
+							),
+						),
+						'total'   => array( 'type' => 'integer' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'file-manager',
+						'sub_group'       => 'backups',
+						'sub_group_label' => __( 'Backups', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$dir    = sanitize_key( (string) ( $input['dir'] ?? Backups_Storage::BACKUPS_DIR ) );
+		$limit  = isset( $input['limit'] ) ? (int) $input['limit'] : 50;
+		$offset = isset( $input['offset'] ) ? (int) $input['offset'] : 0;
+
+		if ( Backups_Storage::BACKUPS_DIR !== $dir && Backups_Storage::STAGING_DIR !== $dir ) {
+			return array(
+				'success' => false,
+				'message' => __( '"dir" must be "acrossai-backups" or "acrossai-staging".', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$result = Backups_Storage::list_entries( $dir, $limit, $offset );
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => false,
+				'message' => $result->get_error_message(),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'items'   => $result['items'],
+			'total'   => (int) $result['total'],
+		);
+	}
+}

--- a/includes/Abilities/FileManager/Zip_Upload.php
+++ b/includes/Abilities/FileManager/Zip_Upload.php
@@ -1,0 +1,731 @@
+<?php
+/**
+ * Zip_Upload ability (Feature 041).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\FileManager
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Backups_Storage;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Upload a zip archive to wp-content/uploads/acrossai-backups/.
+ *
+ * Supports three input modes:
+ *   - base64  : small single-shot upload (raw base64 or data URL)
+ *   - url     : server-side fetch via download_url()
+ *   - chunked : session/index/is_final protocol, staged under acrossai-staging/
+ *
+ * The finalized archive is verified to start with the PK\x03\x04 magic bytes
+ * and lives under acrossai-backups/ with a random filename. The response
+ * carries file_path / file_url / size / sha256, which callers hand to
+ * Zip_Extract on the destination site.
+ */
+class Zip_Upload extends Ability_Definition {
+
+	public const CHUNK_SWEEP_HOOK = 'acrossai_abilities_manager_zip_upload_sweep_chunks';
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/zip-upload',
+			'args' => array(
+				'label'               => __( 'Upload Zip Backup', 'acrossai-abilities-manager' ),
+				'description'         => __( "Upload a zip archive to wp-content/uploads/acrossai-backups/ for later extraction via zip-extract. Three input modes:\n\n  1) \"data\" (base64) — single-shot, best for small zips.\n  2) \"url\" — server-side fetch via download_url().\n  3) \"data\" + \"chunk\" — session/index/is_final protocol; ≤ 8 MB base64 per chunk, ≤ 64 MB base64 per session, staged under acrossai-staging/.\n\nOn success the response carries file_path (ABSPATH-relative), file_url, size, and sha256; hand file_path to zip-extract on the destination site.", 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-file-manager',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'url'            => array(
+							'type'        => 'string',
+							'format'      => 'uri',
+							'description' => __( 'Remote HTTP(S) URL to fetch. Mutually exclusive with "data".', 'acrossai-abilities-manager' ),
+						),
+						'data'           => array(
+							'type'        => 'string',
+							'description' => __( 'Base64-encoded zip bytes (raw or "data:application/zip;base64,…"). Pair with "chunk" to stream large uploads.', 'acrossai-abilities-manager' ),
+						),
+						'chunk'          => array(
+							'type'                 => 'object',
+							'description'          => __( 'Multi-part upload marker paired with "data". Send successive chunks under the same "session_id" with 0-based sequential "index". The final call must set "is_final":true.', 'acrossai-abilities-manager' ),
+							'properties'           => array(
+								'session_id' => array(
+									'type'    => 'string',
+									'pattern' => '^[A-Za-z0-9_-]{8,64}$',
+								),
+								'index'      => array(
+									'type'    => 'integer',
+									'minimum' => 0,
+								),
+								'is_final'   => array(
+									'type' => 'boolean',
+								),
+								'total'      => array(
+									'type'    => 'integer',
+									'minimum' => 1,
+								),
+							),
+							'required'             => array( 'session_id', 'index' ),
+							'additionalProperties' => false,
+						),
+						'filename_hint'  => array(
+							'type'        => 'string',
+							'description' => __( 'Optional filename hint. Sanitized and combined with a random suffix; never used verbatim.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'anyOf'                => array(
+						array( 'required' => array( 'url' ) ),
+						array( 'required' => array( 'data' ) ),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'finalized'      => array( 'type' => 'boolean' ),
+						'file_path'      => array( 'type' => 'string' ),
+						'file_url'       => array( 'type' => 'string' ),
+						'size'           => array( 'type' => 'integer' ),
+						'sha256'         => array( 'type' => 'string' ),
+						'session_id'     => array( 'type' => 'string' ),
+						'chunk_received' => array( 'type' => 'integer' ),
+						'bytes_staged'   => array( 'type' => 'integer' ),
+						'message'        => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'file-manager',
+						'sub_group'       => 'backups',
+						'sub_group_label' => __( 'Backups', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response( 'install' );
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		$url  = sanitize_url( (string) ( $input['url'] ?? '' ) );
+		$data = (string) ( $input['data'] ?? '' );
+
+		if ( '' === $url && '' === $data ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Provide either "url" (remote fetch) or "data" (base64 zip bytes).', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$filename_hint = sanitize_file_name( (string) ( $input['filename_hint'] ?? '' ) );
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		if ( '' !== $url ) {
+			return $this->finalize_from_url( $url, $filename_hint );
+		}
+
+		if ( isset( $input['chunk'] ) && is_array( $input['chunk'] ) ) {
+			return $this->handle_chunk( $data, $input['chunk'], $filename_hint );
+		}
+
+		return $this->finalize_from_base64( $data, $filename_hint );
+	}
+
+	/**
+	 * Fetch a zip from an HTTP(S) URL and finalize it into acrossai-backups/.
+	 */
+	private function finalize_from_url( string $url, string $filename_hint ): array {
+		if ( ! wp_http_validate_url( $url ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A valid http(s) URL is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$tmp = download_url( $url );
+		if ( is_wp_error( $tmp ) ) {
+			return array(
+				'success' => false,
+				'message' => $tmp->get_error_message(),
+			);
+		}
+
+		$magic_error = self::validate_zip_magic( $tmp );
+		if ( null !== $magic_error ) {
+			wp_delete_file( $tmp );
+			return array(
+				'success' => false,
+				'message' => $magic_error,
+			);
+		}
+
+		$size_cap_error = self::validate_size_cap( (int) filesize( $tmp ) );
+		if ( null !== $size_cap_error ) {
+			wp_delete_file( $tmp );
+			return array(
+				'success' => false,
+				'message' => $size_cap_error,
+			);
+		}
+
+		return $this->move_to_backups( $tmp, $filename_hint, 'url' );
+	}
+
+	/**
+	 * Decode a base64 blob into a zip file inside acrossai-backups/.
+	 */
+	private function finalize_from_base64( string $raw, string $filename_hint ): array {
+		$decoded = $this->decode_base64_payload( $raw );
+		if ( isset( $decoded['error'] ) ) {
+			return array(
+				'success' => false,
+				'message' => $decoded['error'],
+			);
+		}
+
+		$size_cap_error = self::validate_size_cap( strlen( $decoded['decoded'] ) );
+		if ( null !== $size_cap_error ) {
+			return array(
+				'success' => false,
+				'message' => $size_cap_error,
+			);
+		}
+
+		$tmp = wp_tempnam( 'acrossai-zip-upload.zip' );
+		if ( ! $tmp ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Could not create a temporary file for the base64 payload.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$wrote = file_put_contents( $tmp, $decoded['decoded'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		if ( false === $wrote ) {
+			wp_delete_file( $tmp );
+			return array(
+				'success' => false,
+				'message' => __( 'Could not write the decoded bytes to disk.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$magic_error = self::validate_zip_magic( $tmp );
+		if ( null !== $magic_error ) {
+			wp_delete_file( $tmp );
+			return array(
+				'success' => false,
+				'message' => $magic_error,
+			);
+		}
+
+		return $this->move_to_backups( $tmp, $filename_hint, 'base64' );
+	}
+
+	/**
+	 * Route a chunked base64 upload. Non-final chunks return a progress
+	 * envelope; the final chunk assembles + validates + finalizes.
+	 *
+	 * @param array<string,mixed> $chunk
+	 */
+	private function handle_chunk( string $data, array $chunk, string $filename_hint ): array {
+		$session_id = self::sanitize_session_id( (string) ( $chunk['session_id'] ?? '' ) );
+		if ( '' === $session_id ) {
+			return array(
+				'success' => false,
+				'message' => __( 'The "chunk.session_id" must match /^[A-Za-z0-9_-]{8,64}$/.', 'acrossai-abilities-manager' ),
+			);
+		}
+		if ( ! isset( $chunk['index'] ) || ! is_numeric( $chunk['index'] ) || (int) $chunk['index'] < 0 ) {
+			return array(
+				'success' => false,
+				'message' => __( 'The "chunk.index" is required and must be a non-negative integer.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$index    = (int) $chunk['index'];
+		$is_final = ! empty( $chunk['is_final'] );
+
+		$staging_dir = Backups_Storage::staging_path();
+		if ( false === $staging_dir ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Could not create the chunk staging directory under wp-content/uploads/acrossai-staging.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		list( $b64_path, $meta_path ) = self::chunk_paths( $staging_dir, $session_id );
+		$meta                         = self::read_chunk_meta( $meta_path );
+		$expected_index               = $meta['last_index'] + 1;
+
+		if ( $index !== $expected_index ) {
+			self::cleanup_chunk_session( $b64_path, $meta_path );
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: 1: expected index, 2: received index */
+					__( 'Chunk received out of order (expected %1$d, got %2$d). Session discarded — start over from index 0.', 'acrossai-abilities-manager' ),
+					$expected_index,
+					$index
+				),
+			);
+		}
+
+		$raw = trim( $data );
+		if ( '' === $raw ) {
+			self::cleanup_chunk_session( $b64_path, $meta_path );
+			return array(
+				'success' => false,
+				'message' => __( 'The "data" field is empty for this chunk.', 'acrossai-abilities-manager' ),
+			);
+		}
+		if ( 0 === stripos( $raw, 'data:' ) ) {
+			$comma = strpos( $raw, ',' );
+			if ( false === $comma ) {
+				self::cleanup_chunk_session( $b64_path, $meta_path );
+				return array(
+					'success' => false,
+					'message' => __( 'Data URL is missing the "," separator.', 'acrossai-abilities-manager' ),
+				);
+			}
+			$header = substr( $raw, 5, $comma - 5 );
+			if ( false === stripos( $header, ';base64' ) ) {
+				self::cleanup_chunk_session( $b64_path, $meta_path );
+				return array(
+					'success' => false,
+					'message' => __( 'Only base64-encoded data URLs are supported (";base64" required in header).', 'acrossai-abilities-manager' ),
+				);
+			}
+			$raw = substr( $raw, $comma + 1 );
+		}
+		$raw = preg_replace( '/\s+/', '', $raw ) ?? '';
+		if ( '' === $raw ) {
+			self::cleanup_chunk_session( $b64_path, $meta_path );
+			return array(
+				'success' => false,
+				'message' => __( 'Chunk contained no base64 payload after stripping whitespace.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		/**
+		 * Filter the per-chunk base64 size cap. Default: 8 MB.
+		 *
+		 * @param int $bytes Default 8 * 1024 * 1024.
+		 */
+		$chunk_max = (int) apply_filters( 'acrossai_abilities_manager_zip_upload_chunk_max_bytes', 8 * 1024 * 1024 );
+		if ( strlen( $raw ) > $chunk_max ) {
+			self::cleanup_chunk_session( $b64_path, $meta_path );
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: %d: chunk cap in bytes */
+					__( 'Chunk exceeds the per-chunk base64 cap (%d bytes). Split into smaller chunks.', 'acrossai-abilities-manager' ),
+					$chunk_max
+				),
+			);
+		}
+
+		/**
+		 * Filter the total per-session base64 size cap. Default: 64 MB.
+		 *
+		 * @param int $bytes Default 64 * 1024 * 1024.
+		 */
+		$session_max = (int) apply_filters( 'acrossai_abilities_manager_zip_upload_session_max_bytes', 64 * 1024 * 1024 );
+		if ( ( $meta['bytes'] + strlen( $raw ) ) > $session_max ) {
+			self::cleanup_chunk_session( $b64_path, $meta_path );
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: %d: session cap in bytes */
+					__( 'Session would exceed the total base64 cap (%d bytes). Session discarded.', 'acrossai-abilities-manager' ),
+					$session_max
+				),
+			);
+		}
+
+		$fp = fopen( $b64_path, 'ab' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		if ( false === $fp ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Could not open the chunk staging file for writing.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$locked = flock( $fp, LOCK_EX );
+		$wrote  = fwrite( $fp, $raw ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+		if ( $locked ) {
+			flock( $fp, LOCK_UN );
+		}
+		fclose( $fp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		if ( false === $wrote || $wrote !== strlen( $raw ) ) {
+			self::cleanup_chunk_session( $b64_path, $meta_path );
+			return array(
+				'success' => false,
+				'message' => __( 'Could not append chunk bytes to staging file.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$now                = time();
+		$meta['last_index'] = $index;
+		$meta['bytes']      = $meta['bytes'] + strlen( $raw );
+		$meta['updated_at'] = $now;
+		if ( 0 === (int) $meta['created_at'] ) {
+			$meta['created_at'] = $now;
+		}
+		self::write_chunk_meta( $meta_path, $meta );
+
+		if ( ! $is_final ) {
+			return array(
+				'success'        => true,
+				'finalized'      => false,
+				'session_id'     => $session_id,
+				'chunk_received' => $index,
+				'bytes_staged'   => (int) $meta['bytes'],
+				'message'        => sprintf(
+					/* translators: 1: chunk index, 2: cumulative bytes staged */
+					__( 'Chunk %1$d accepted (%2$d base64 bytes staged). Send the next chunk or set "is_final":true.', 'acrossai-abilities-manager' ),
+					$index,
+					(int) $meta['bytes']
+				),
+			);
+		}
+
+		if ( isset( $chunk['total'] ) && is_numeric( $chunk['total'] ) ) {
+			$expected_total = (int) $chunk['total'];
+			if ( $expected_total !== ( $index + 1 ) ) {
+				self::cleanup_chunk_session( $b64_path, $meta_path );
+				return array(
+					'success' => false,
+					'message' => sprintf(
+						/* translators: 1: declared total, 2: received count */
+						__( 'Final chunk arrived with index=%2$d but "chunk.total"=%1$d — session discarded.', 'acrossai-abilities-manager' ),
+						$expected_total,
+						$index
+					),
+				);
+			}
+		}
+
+		$raw_all = @file_get_contents( $b64_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_get_contents, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.PHP.NoSilencedErrors.Discouraged
+		self::cleanup_chunk_session( $b64_path, $meta_path );
+		if ( false === $raw_all || '' === $raw_all ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Chunk staging file was empty or unreadable.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$decoded = $this->decode_base64_payload( $raw_all );
+		if ( isset( $decoded['error'] ) ) {
+			return array(
+				'success' => false,
+				'message' => $decoded['error'],
+			);
+		}
+		$size_cap_error = self::validate_size_cap( strlen( $decoded['decoded'] ) );
+		if ( null !== $size_cap_error ) {
+			return array(
+				'success' => false,
+				'message' => $size_cap_error,
+			);
+		}
+
+		$tmp = wp_tempnam( 'acrossai-zip-upload.zip' );
+		if ( ! $tmp ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Could not create a temporary file for the assembled zip.', 'acrossai-abilities-manager' ),
+			);
+		}
+		if ( false === file_put_contents( $tmp, $decoded['decoded'] ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			wp_delete_file( $tmp );
+			return array(
+				'success' => false,
+				'message' => __( 'Could not write the assembled zip to disk.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$magic_error = self::validate_zip_magic( $tmp );
+		if ( null !== $magic_error ) {
+			wp_delete_file( $tmp );
+			return array(
+				'success' => false,
+				'message' => $magic_error,
+			);
+		}
+
+		return $this->move_to_backups( $tmp, $filename_hint, 'chunk' );
+	}
+
+	/**
+	 * Move a validated tmp zip into acrossai-backups/ with a random filename
+	 * and return the standard success envelope.
+	 */
+	private function move_to_backups( string $tmp, string $filename_hint, string $source_label ): array {
+		$backups = Backups_Storage::backups_path();
+		if ( false === $backups ) {
+			if ( file_exists( $tmp ) ) {
+				wp_delete_file( $tmp );
+			}
+			return array(
+				'success' => false,
+				'message' => __( 'Could not create the backups directory.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$filename = Backups_Storage::random_backup_filename( 'upload', $filename_hint );
+		$dest     = trailingslashit( $backups ) . $filename;
+
+		if ( ! @rename( $tmp, $dest ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			if ( ! @copy( $tmp, $dest ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				if ( file_exists( $tmp ) ) {
+					wp_delete_file( $tmp );
+				}
+				return array(
+					'success' => false,
+					'message' => __( 'Could not move the finalized zip into acrossai-backups/.', 'acrossai-abilities-manager' ),
+				);
+			}
+			if ( file_exists( $tmp ) ) {
+				wp_delete_file( $tmp );
+			}
+		}
+
+		return array(
+			'success'   => true,
+			'finalized' => true,
+			'file_path' => Backups_Storage::to_abspath_relative( $dest ),
+			'file_url'  => Backups_Storage::url_for( $dest ),
+			'size'      => (int) filesize( $dest ),
+			'sha256'    => Backups_Storage::sha256_of( $dest ),
+			'message'   => sprintf(
+				/* translators: %s: input mode ("url", "base64", "chunk") */
+				__( 'Zip upload finalized (source: %s).', 'acrossai-abilities-manager' ),
+				$source_label
+			),
+		);
+	}
+
+	/**
+	 * Strip a data-URL header, strip whitespace, base64-decode.
+	 *
+	 * @return array{decoded: string}|array{error: string}
+	 */
+	private function decode_base64_payload( string $raw ): array {
+		$raw = trim( $raw );
+		if ( '' === $raw ) {
+			return array( 'error' => __( 'The "data" field is empty.', 'acrossai-abilities-manager' ) );
+		}
+		if ( 0 === stripos( $raw, 'data:' ) ) {
+			$comma = strpos( $raw, ',' );
+			if ( false === $comma ) {
+				return array( 'error' => __( 'Data URL is missing the "," separator.', 'acrossai-abilities-manager' ) );
+			}
+			$header = substr( $raw, 5, $comma - 5 );
+			if ( false === stripos( $header, ';base64' ) ) {
+				return array( 'error' => __( 'Only base64-encoded data URLs are supported.', 'acrossai-abilities-manager' ) );
+			}
+			$raw = substr( $raw, $comma + 1 );
+		}
+		$raw = preg_replace( '/\s+/', '', $raw ) ?? '';
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Caller-supplied base64; the result is written to a WP temp file, validated for zip magic bytes, and only then moved into acrossai-backups/.
+		$decoded = base64_decode( $raw, true );
+		if ( false === $decoded || '' === $decoded ) {
+			return array( 'error' => __( 'The "data" field is not valid base64.', 'acrossai-abilities-manager' ) );
+		}
+		return array( 'decoded' => $decoded );
+	}
+
+	private static function sanitize_session_id( string $sid ): string {
+		return preg_match( '/^[A-Za-z0-9_-]{8,64}$/', $sid ) ? $sid : '';
+	}
+
+	/**
+	 * @return array{0: string, 1: string}
+	 */
+	private static function chunk_paths( string $dir, string $session_id ): array {
+		return array(
+			trailingslashit( $dir ) . 'zip-' . $session_id . '.b64',
+			trailingslashit( $dir ) . 'zip-' . $session_id . '.meta.json',
+		);
+	}
+
+	/**
+	 * @return array{last_index: int, bytes: int, created_at: int, updated_at: int}
+	 */
+	private static function read_chunk_meta( string $meta_path ): array {
+		$defaults = array(
+			'last_index' => -1,
+			'bytes'      => 0,
+			'created_at' => 0,
+			'updated_at' => 0,
+		);
+		if ( ! is_file( $meta_path ) ) {
+			return $defaults;
+		}
+		$raw = @file_get_contents( $meta_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_get_contents, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( false === $raw || '' === $raw ) {
+			return $defaults;
+		}
+		$parsed = json_decode( $raw, true );
+		if ( ! is_array( $parsed ) ) {
+			return $defaults;
+		}
+		return array(
+			'last_index' => isset( $parsed['last_index'] ) ? (int) $parsed['last_index'] : -1,
+			'bytes'      => isset( $parsed['bytes'] ) ? (int) $parsed['bytes'] : 0,
+			'created_at' => isset( $parsed['created_at'] ) ? (int) $parsed['created_at'] : 0,
+			'updated_at' => isset( $parsed['updated_at'] ) ? (int) $parsed['updated_at'] : 0,
+		);
+	}
+
+	/**
+	 * @param array{last_index: int, bytes: int, created_at: int, updated_at: int} $meta
+	 */
+	private static function write_chunk_meta( string $meta_path, array $meta ): bool {
+		$json = wp_json_encode( $meta );
+		if ( false === $json ) {
+			return false;
+		}
+		return false !== file_put_contents( $meta_path, $json, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	}
+
+	private static function cleanup_chunk_session( string $b64_path, string $meta_path ): void {
+		if ( file_exists( $b64_path ) ) {
+			wp_delete_file( $b64_path );
+		}
+		if ( file_exists( $meta_path ) ) {
+			wp_delete_file( $meta_path );
+		}
+	}
+
+	/**
+	 * Reject archives above the configured backup cap. Returns null when OK.
+	 */
+	private static function validate_size_cap( int $bytes ): ?string {
+		/**
+		 * Same cap Zip_Create honours — anything above it is rejected.
+		 *
+		 * @param int $bytes Default 512 MB.
+		 */
+		$max = (int) apply_filters( 'acrossai_abilities_manager_zip_max_bytes', 512 * 1024 * 1024 );
+		if ( $bytes > $max ) {
+			return sprintf(
+				/* translators: 1: submitted bytes, 2: max cap bytes */
+				__( 'Zip size (%1$d bytes) exceeds the configured cap (%2$d bytes).', 'acrossai-abilities-manager' ),
+				$bytes,
+				$max
+			);
+		}
+		return null;
+	}
+
+	/**
+	 * Check for the standard "PK\x03\x04" zip magic. Returns null when the
+	 * file starts with a valid zip signature.
+	 */
+	private static function validate_zip_magic( string $path ): ?string {
+		if ( ! is_file( $path ) ) {
+			return __( 'Uploaded file could not be located after staging.', 'acrossai-abilities-manager' );
+		}
+		$fp = fopen( $path, 'rb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		if ( false === $fp ) {
+			return __( 'Could not read the uploaded file for zip validation.', 'acrossai-abilities-manager' );
+		}
+		$head = fread( $fp, 4 );
+		fclose( $fp ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		if ( false === $head || strlen( $head ) < 4 ) {
+			return __( 'Uploaded file is too small to be a zip archive.', 'acrossai-abilities-manager' );
+		}
+		// Accept the standard local-file-header magic AND the empty/spanned variants.
+		$magic = substr( $head, 0, 4 );
+		if ( "PK\x03\x04" === $magic || "PK\x05\x06" === $magic || "PK\x07\x08" === $magic ) {
+			return null;
+		}
+		return __( 'Uploaded file is not a valid zip archive (missing PK signature).', 'acrossai-abilities-manager' );
+	}
+
+	/**
+	 * Cron callback: delete abandoned chunk sessions. Silent, best-effort.
+	 */
+	public static function sweep_chunk_sessions(): void {
+		$staging = Backups_Storage::staging_path();
+		if ( false === $staging ) {
+			return;
+		}
+		/**
+		 * TTL for abandoned zip-upload sessions. Default: 1 day.
+		 *
+		 * @param int $ttl Default DAY_IN_SECONDS.
+		 */
+		$ttl    = (int) apply_filters( 'acrossai_abilities_manager_zip_upload_session_ttl', DAY_IN_SECONDS );
+		$cutoff = time() - max( $ttl, MINUTE_IN_SECONDS );
+
+		$metas = glob( trailingslashit( $staging ) . 'zip-*.meta.json' );
+		if ( ! is_array( $metas ) ) {
+			return;
+		}
+		foreach ( $metas as $meta_path ) {
+			$raw = @file_get_contents( $meta_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_get_contents, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.PHP.NoSilencedErrors.Discouraged
+			if ( false === $raw ) {
+				continue;
+			}
+			$parsed  = json_decode( $raw, true );
+			$updated = is_array( $parsed ) && isset( $parsed['updated_at'] ) ? (int) $parsed['updated_at'] : 0;
+			if ( $updated > $cutoff ) {
+				continue;
+			}
+			$b64_path = preg_replace( '/\.meta\.json$/', '.b64', $meta_path );
+			if ( is_string( $b64_path ) && file_exists( $b64_path ) ) {
+				wp_delete_file( $b64_path );
+			}
+			wp_delete_file( $meta_path );
+		}
+	}
+
+	/**
+	 * Schedule the daily sweep (idempotent).
+	 */
+	public static function register_sweep_cron(): void {
+		if ( ! wp_next_scheduled( self::CHUNK_SWEEP_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CHUNK_SWEEP_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the sweep — called on plugin deactivation.
+	 */
+	public static function unregister_sweep_cron(): void {
+		wp_clear_scheduled_hook( self::CHUNK_SWEEP_HOOK );
+	}
+}

--- a/includes/Abilities/Plugins/Plugin_Update.php
+++ b/includes/Abilities/Plugins/Plugin_Update.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Plugin_Update ability (Feature 041).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Plugins
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Plugins;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Plugin_Helpers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Apply the pending update for one or more installed plugins.
+ *
+ * Wraps Plugin_Upgrader::bulk_upgrade() the same way Plugin_Install wraps
+ * Plugin_Upgrader::install(). Bare slugs are resolved through Plugin_Helpers;
+ * fully-qualified plugin files (e.g. "hello-dolly/hello.php") are used as-is.
+ */
+class Plugin_Update extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/plugin-update',
+			'args' => array(
+				'label'               => __( 'Update Plugin', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Apply the pending update for one or more installed plugins. Accepts plugin files (e.g. "hello-dolly/hello.php") or bare slugs (resolved via Plugin_Helpers). Re-running when no update is available is a no-op.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-plugins',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'update_plugins' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'slugs'              => array(
+							'type'        => 'array',
+							'minItems'    => 1,
+							'items'       => array( 'type' => 'string' ),
+							'description' => __( 'One or more plugin files or slugs to update.', 'acrossai-abilities-manager' ),
+						),
+						'clear_update_cache' => array(
+							'type'    => 'boolean',
+							'default' => true,
+						),
+					),
+					'required'             => array( 'slugs' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'results'       => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'                 => 'object',
+								'properties'           => array(
+									'slug'         => array( 'type' => 'string' ),
+									'from_version' => array( 'type' => 'string' ),
+									'to_version'   => array( 'type' => 'string' ),
+									'updated'      => array( 'type' => 'boolean' ),
+									'message'      => array( 'type' => 'string' ),
+								),
+								'additionalProperties' => false,
+							),
+						),
+						'updated_count' => array( 'type' => 'integer' ),
+						'failed_count'  => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'plugins',
+						'sub_group'       => 'lifecycle',
+						'sub_group_label' => __( 'Lifecycle', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response( 'install' );
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		$slugs = isset( $input['slugs'] ) && is_array( $input['slugs'] ) ? $input['slugs'] : array();
+		if ( empty( $slugs ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Provide at least one plugin slug or file in "slugs".', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		if ( ! function_exists( 'get_plugin_updates' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/update.php';
+		}
+		if ( ! class_exists( '\Plugin_Upgrader' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
+
+		$installed       = get_plugins();
+		$plugin_updates  = get_plugin_updates();
+		$plugin_files    = array();
+		$per_slug_result = array();
+
+		foreach ( $slugs as $raw_slug ) {
+			$identifier = sanitize_text_field( (string) $raw_slug );
+			if ( '' === $identifier ) {
+				continue;
+			}
+
+			$plugin_file = null;
+			if ( isset( $installed[ $identifier ] ) ) {
+				$plugin_file = $identifier;
+			} else {
+				$resolved = Plugin_Helpers::resolve_plugin( $identifier );
+				if ( ! empty( $resolved['plugin_file'] ) && $resolved['certainty'] >= 8.0 ) {
+					$plugin_file = (string) $resolved['plugin_file'];
+				}
+			}
+
+			if ( null === $plugin_file ) {
+				$per_slug_result[ $identifier ] = array(
+					'slug'         => $identifier,
+					'from_version' => '',
+					'to_version'   => '',
+					'updated'      => false,
+					'message'      => __( 'Could not resolve plugin.', 'acrossai-abilities-manager' ),
+				);
+				continue;
+			}
+
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- WordPress plugin header keys.
+			$from_version = isset( $installed[ $plugin_file ]['Version'] ) ? (string) $installed[ $plugin_file ]['Version'] : '';
+			$to_version   = '';
+			if ( isset( $plugin_updates[ $plugin_file ]->update->new_version ) ) {
+				$to_version = (string) $plugin_updates[ $plugin_file ]->update->new_version;
+			}
+
+			if ( ! isset( $plugin_updates[ $plugin_file ] ) ) {
+				$per_slug_result[ $plugin_file ] = array(
+					'slug'         => $plugin_file,
+					'from_version' => $from_version,
+					'to_version'   => $from_version,
+					'updated'      => false,
+					'message'      => __( 'No update available.', 'acrossai-abilities-manager' ),
+				);
+				continue;
+			}
+
+			$plugin_files[]                  = $plugin_file;
+			$per_slug_result[ $plugin_file ] = array(
+				'slug'         => $plugin_file,
+				'from_version' => $from_version,
+				'to_version'   => $to_version,
+				'updated'      => false,
+				'message'      => __( 'Pending upgrade.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( empty( $plugin_files ) ) {
+			$updated_count = 0;
+			$failed_count  = 0;
+			foreach ( $per_slug_result as $entry ) {
+				if ( ! $entry['updated'] && __( 'No update available.', 'acrossai-abilities-manager' ) !== $entry['message'] ) {
+					++$failed_count;
+				}
+			}
+			return array(
+				'success'       => true,
+				'results'       => array_values( $per_slug_result ),
+				'updated_count' => $updated_count,
+				'failed_count'  => $failed_count,
+				'message'       => __( 'No pending plugin updates for the given slugs.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$skin     = new \WP_Ajax_Upgrader_Skin();
+		$upgrader = new \Plugin_Upgrader( $skin );
+		$results  = $upgrader->bulk_upgrade(
+			$plugin_files,
+			array(
+				'clear_update_cache' => ! isset( $input['clear_update_cache'] ) || (bool) $input['clear_update_cache'],
+			)
+		);
+
+		wp_clean_plugins_cache();
+		$installed_after = get_plugins();
+
+		$updated_count = 0;
+		$failed_count  = 0;
+
+		foreach ( $plugin_files as $plugin_file ) {
+			$result = $results[ $plugin_file ] ?? null;
+
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- WP plugin header keys.
+			$now_version = isset( $installed_after[ $plugin_file ]['Version'] ) ? (string) $installed_after[ $plugin_file ]['Version'] : '';
+
+			if ( is_wp_error( $result ) ) {
+				$per_slug_result[ $plugin_file ]['updated']    = false;
+				$per_slug_result[ $plugin_file ]['message']    = $result->get_error_message();
+				$per_slug_result[ $plugin_file ]['to_version'] = $now_version;
+				++$failed_count;
+				continue;
+			}
+
+			if ( null === $result || false === $result ) {
+				$skin_errors = $skin->get_errors();
+				$msg         = is_wp_error( $skin_errors ) && $skin_errors->has_errors()
+					? $skin_errors->get_error_message()
+					: __( 'Upgrade did not report success.', 'acrossai-abilities-manager' );
+				$per_slug_result[ $plugin_file ]['updated']    = false;
+				$per_slug_result[ $plugin_file ]['message']    = $msg;
+				$per_slug_result[ $plugin_file ]['to_version'] = $now_version;
+				++$failed_count;
+				continue;
+			}
+
+			$per_slug_result[ $plugin_file ]['updated']    = true;
+			$per_slug_result[ $plugin_file ]['to_version'] = $now_version;
+			$per_slug_result[ $plugin_file ]['message']    = __( 'Updated.', 'acrossai-abilities-manager' );
+			++$updated_count;
+		}
+
+		return array(
+			'success'       => true,
+			'results'       => array_values( $per_slug_result ),
+			'updated_count' => $updated_count,
+			'failed_count'  => $failed_count,
+			'message'       => sprintf(
+				/* translators: 1: updated count, 2: failed count */
+				__( 'Plugin update completed: %1$d updated, %2$d failed.', 'acrossai-abilities-manager' ),
+				$updated_count,
+				$failed_count
+			),
+		);
+	}
+}

--- a/includes/Abilities/Themes/Theme_Update.php
+++ b/includes/Abilities/Themes/Theme_Update.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Theme_Update ability (Feature 041).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Themes
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Themes;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Theme_Helpers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Apply the pending update for one or more installed themes.
+ *
+ * Wraps Theme_Upgrader::bulk_upgrade() the same way Theme_Install wraps
+ * Theme_Upgrader::install(). Accepts stylesheets (e.g. "twentytwentyfour") or
+ * theme names / partials — resolved via Theme_Helpers::resolve_theme().
+ */
+class Theme_Update extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/theme-update',
+			'args' => array(
+				'label'               => __( 'Update Theme', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Apply the pending update for one or more installed themes. Accepts stylesheet directory names (e.g. "twentytwentyfour") or theme names (resolved via Theme_Helpers). Re-running when no update is available is a no-op.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-themes',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'update_themes' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'stylesheets'        => array(
+							'type'        => 'array',
+							'minItems'    => 1,
+							'items'       => array( 'type' => 'string' ),
+							'description' => __( 'One or more theme stylesheets or theme names to update.', 'acrossai-abilities-manager' ),
+						),
+						'clear_update_cache' => array(
+							'type'    => 'boolean',
+							'default' => true,
+						),
+					),
+					'required'             => array( 'stylesheets' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'results'       => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'                 => 'object',
+								'properties'           => array(
+									'stylesheet'   => array( 'type' => 'string' ),
+									'from_version' => array( 'type' => 'string' ),
+									'to_version'   => array( 'type' => 'string' ),
+									'updated'      => array( 'type' => 'boolean' ),
+									'message'      => array( 'type' => 'string' ),
+								),
+								'additionalProperties' => false,
+							),
+						),
+						'updated_count' => array( 'type' => 'integer' ),
+						'failed_count'  => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'themes',
+						'sub_group'       => 'lifecycle',
+						'sub_group_label' => __( 'Lifecycle', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response( 'install' );
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		$stylesheets = isset( $input['stylesheets'] ) && is_array( $input['stylesheets'] ) ? $input['stylesheets'] : array();
+		if ( empty( $stylesheets ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Provide at least one theme stylesheet in "stylesheets".', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( ! function_exists( 'get_theme_updates' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/update.php';
+		}
+		if ( ! class_exists( '\Theme_Upgrader' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
+
+		$all_themes      = wp_get_themes();
+		$theme_updates   = get_theme_updates();
+		$per_slug_result = array();
+		$to_upgrade      = array();
+
+		foreach ( $stylesheets as $raw_slug ) {
+			$identifier = sanitize_text_field( (string) $raw_slug );
+			if ( '' === $identifier ) {
+				continue;
+			}
+
+			$stylesheet = null;
+			if ( isset( $all_themes[ $identifier ] ) ) {
+				$stylesheet = $identifier;
+			} else {
+				$resolved = Theme_Helpers::resolve_theme( $identifier );
+				if ( ! empty( $resolved['stylesheet'] ) && $resolved['certainty'] >= 8.0 ) {
+					$stylesheet = (string) $resolved['stylesheet'];
+				}
+			}
+
+			if ( null === $stylesheet ) {
+				$per_slug_result[ $identifier ] = array(
+					'stylesheet'   => $identifier,
+					'from_version' => '',
+					'to_version'   => '',
+					'updated'      => false,
+					'message'      => __( 'Could not resolve theme.', 'acrossai-abilities-manager' ),
+				);
+				continue;
+			}
+
+			$from_version = isset( $all_themes[ $stylesheet ] ) ? (string) $all_themes[ $stylesheet ]->get( 'Version' ) : '';
+			$to_version   = '';
+			if ( isset( $theme_updates[ $stylesheet ]->update['new_version'] ) ) {
+				$to_version = (string) $theme_updates[ $stylesheet ]->update['new_version'];
+			}
+
+			if ( ! isset( $theme_updates[ $stylesheet ] ) ) {
+				$per_slug_result[ $stylesheet ] = array(
+					'stylesheet'   => $stylesheet,
+					'from_version' => $from_version,
+					'to_version'   => $from_version,
+					'updated'      => false,
+					'message'      => __( 'No update available.', 'acrossai-abilities-manager' ),
+				);
+				continue;
+			}
+
+			$to_upgrade[]                   = $stylesheet;
+			$per_slug_result[ $stylesheet ] = array(
+				'stylesheet'   => $stylesheet,
+				'from_version' => $from_version,
+				'to_version'   => $to_version,
+				'updated'      => false,
+				'message'      => __( 'Pending upgrade.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( empty( $to_upgrade ) ) {
+			$updated_count = 0;
+			$failed_count  = 0;
+			foreach ( $per_slug_result as $entry ) {
+				if ( ! $entry['updated'] && __( 'No update available.', 'acrossai-abilities-manager' ) !== $entry['message'] ) {
+					++$failed_count;
+				}
+			}
+			return array(
+				'success'       => true,
+				'results'       => array_values( $per_slug_result ),
+				'updated_count' => $updated_count,
+				'failed_count'  => $failed_count,
+				'message'       => __( 'No pending theme updates for the given stylesheets.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$skin     = new \WP_Ajax_Upgrader_Skin();
+		$upgrader = new \Theme_Upgrader( $skin );
+		$results  = $upgrader->bulk_upgrade(
+			$to_upgrade,
+			array(
+				'clear_update_cache' => ! isset( $input['clear_update_cache'] ) || (bool) $input['clear_update_cache'],
+			)
+		);
+
+		wp_clean_themes_cache();
+		$themes_after = wp_get_themes();
+
+		$updated_count = 0;
+		$failed_count  = 0;
+
+		foreach ( $to_upgrade as $stylesheet ) {
+			$result      = $results[ $stylesheet ] ?? null;
+			$now_version = isset( $themes_after[ $stylesheet ] ) ? (string) $themes_after[ $stylesheet ]->get( 'Version' ) : '';
+
+			if ( is_wp_error( $result ) ) {
+				$per_slug_result[ $stylesheet ]['updated']    = false;
+				$per_slug_result[ $stylesheet ]['message']    = $result->get_error_message();
+				$per_slug_result[ $stylesheet ]['to_version'] = $now_version;
+				++$failed_count;
+				continue;
+			}
+			if ( null === $result || false === $result ) {
+				$skin_errors = $skin->get_errors();
+				$msg         = is_wp_error( $skin_errors ) && $skin_errors->has_errors()
+					? $skin_errors->get_error_message()
+					: __( 'Upgrade did not report success.', 'acrossai-abilities-manager' );
+				$per_slug_result[ $stylesheet ]['updated']    = false;
+				$per_slug_result[ $stylesheet ]['message']    = $msg;
+				$per_slug_result[ $stylesheet ]['to_version'] = $now_version;
+				++$failed_count;
+				continue;
+			}
+
+			$per_slug_result[ $stylesheet ]['updated']    = true;
+			$per_slug_result[ $stylesheet ]['to_version'] = $now_version;
+			$per_slug_result[ $stylesheet ]['message']    = __( 'Updated.', 'acrossai-abilities-manager' );
+			++$updated_count;
+		}
+
+		return array(
+			'success'       => true,
+			'results'       => array_values( $per_slug_result ),
+			'updated_count' => $updated_count,
+			'failed_count'  => $failed_count,
+			'message'       => sprintf(
+				/* translators: 1: updated count, 2: failed count */
+				__( 'Theme update completed: %1$d updated, %2$d failed.', 'acrossai-abilities-manager' ),
+				$updated_count,
+				$failed_count
+			),
+		);
+	}
+}

--- a/includes/Abilities/Utilities/Backups_Storage.php
+++ b/includes/Abilities/Utilities/Backups_Storage.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * Backups storage helper for the Zip_* abilities (Feature 041).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Utilities
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Utilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Single point of truth for the two managed directories used by the Zip_*
+ * abilities:
+ *
+ *   - wp-content/uploads/acrossai-backups/  → finalized zip archives
+ *   - wp-content/uploads/acrossai-staging/  → in-progress chunked uploads
+ *
+ * The directories are hardened on first use with `.htaccess` (deny access) and
+ * an empty `index.php` to prevent directory listing / PHP execution. Every
+ * caller-supplied path is validated to resolve INSIDE one of these dirs;
+ * anything else is rejected as a WP_Error so callers never touch the wider
+ * filesystem through this helper.
+ */
+final class Backups_Storage {
+
+	public const BACKUPS_DIR = 'acrossai-backups';
+	public const STAGING_DIR = 'acrossai-staging';
+
+	/**
+	 * Absolute path to the finalized-backups directory. Creates + hardens on
+	 * first call. Returns false when the uploads dir is unavailable.
+	 *
+	 * @return string|false
+	 */
+	public static function backups_path() {
+		return self::resolve_dir( self::BACKUPS_DIR );
+	}
+
+	/**
+	 * URL to the finalized-backups directory (without trailing slash).
+	 *
+	 * @return string|false
+	 */
+	public static function backups_url() {
+		$uploads = wp_upload_dir( null, false );
+		if ( ! empty( $uploads['error'] ) || empty( $uploads['baseurl'] ) ) {
+			return false;
+		}
+		return trailingslashit( $uploads['baseurl'] ) . self::BACKUPS_DIR;
+	}
+
+	/**
+	 * Absolute path to the chunked-upload staging directory.
+	 *
+	 * @return string|false
+	 */
+	public static function staging_path() {
+		return self::resolve_dir( self::STAGING_DIR );
+	}
+
+	/**
+	 * Generate a random filename for a new backup: `backup-{type}-{slug}-{rand}.zip`.
+	 *
+	 * The random suffix always contains 12 chars of [A-Za-z0-9]. type/slug are
+	 * sanitized through sanitize_key(); when they are empty the segments are
+	 * omitted so callers never introduce path separators through this helper.
+	 */
+	public static function random_backup_filename( string $target_type, string $target ): string {
+		$type_seg = sanitize_key( $target_type );
+		$slug_seg = sanitize_key( str_replace( array( '/', '\\', '.' ), '-', $target ) );
+
+		$parts = array( 'backup' );
+		if ( '' !== $type_seg ) {
+			$parts[] = $type_seg;
+		}
+		if ( '' !== $slug_seg ) {
+			$parts[] = $slug_seg;
+		}
+		$parts[] = wp_generate_password( 12, false, false );
+
+		return implode( '-', $parts ) . '.zip';
+	}
+
+	/**
+	 * Given an ABSPATH-relative or bare filename input, return the absolute path
+	 * IF it resolves inside `acrossai-backups/` or `acrossai-staging/`; return a
+	 * WP_Error otherwise. Callers pass this to file operations so they cannot
+	 * be tricked into touching arbitrary paths.
+	 *
+	 * Accepts:
+	 *   - bare filename ("backup-plugin-xyz.zip") → resolved against backups dir
+	 *   - relative path starting with "wp-content/uploads/..." → validated
+	 *   - relative path starting with the plugin's managed sub-dir names
+	 *
+	 * @return string|\WP_Error
+	 */
+	public static function resolve_managed_path( string $rel_or_name ) {
+		$rel_or_name = trim( $rel_or_name );
+		if ( '' === $rel_or_name ) {
+			return new \WP_Error(
+				'invalid_path',
+				__( 'A file path is required.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		// Reject obvious traversal / absolute paths up front.
+		if ( false !== strpos( $rel_or_name, "\0" ) ) {
+			return new \WP_Error(
+				'invalid_path',
+				__( 'Path contains disallowed characters.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		$backups = self::backups_path();
+		$staging = self::staging_path();
+		if ( false === $backups && false === $staging ) {
+			return new \WP_Error(
+				'uploads_unavailable',
+				__( 'Uploads directory is unavailable on this site.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		// Bare filename → default to backups dir.
+		if ( false === strpos( $rel_or_name, '/' ) && false === strpos( $rel_or_name, '\\' ) ) {
+			if ( false === $backups ) {
+				return new \WP_Error(
+					'uploads_unavailable',
+					__( 'Backups directory is unavailable on this site.', 'acrossai-abilities-manager' )
+				);
+			}
+			$candidate = trailingslashit( $backups ) . $rel_or_name;
+		} else {
+			// Interpret relative to ABSPATH.
+			$base      = rtrim( realpath( ABSPATH ) ?: ABSPATH, '/' );
+			$candidate = $base . '/' . ltrim( $rel_or_name, '/' );
+		}
+
+		$parent = realpath( dirname( $candidate ) );
+		if ( false === $parent ) {
+			return new \WP_Error(
+				'invalid_path',
+				__( 'Path does not resolve.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		$parent_slash = $parent . '/';
+		$in_backups   = false !== $backups && ( $parent === rtrim( $backups, '/' ) || 0 === strpos( $parent_slash, trailingslashit( $backups ) ) );
+		$in_staging   = false !== $staging && ( $parent === rtrim( $staging, '/' ) || 0 === strpos( $parent_slash, trailingslashit( $staging ) ) );
+
+		if ( ! $in_backups && ! $in_staging ) {
+			return new \WP_Error(
+				'path_out_of_bounds',
+				__( 'Path must resolve inside acrossai-backups/ or acrossai-staging/.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		return $candidate;
+	}
+
+	/**
+	 * List zip entries in one of the two managed directories, with metadata.
+	 *
+	 * @param string $which  BACKUPS_DIR or STAGING_DIR.
+	 * @param int    $limit  Max entries to return (clamped to 1..200).
+	 * @param int    $offset Offset (clamped to >= 0).
+	 * @return array{items: array<int, array{file_path: string, file_url: string, size: int, sha256: string, created_at: string}>, total: int}|\WP_Error
+	 */
+	public static function list_entries( string $which, int $limit = 50, int $offset = 0 ) {
+		$which = self::BACKUPS_DIR === $which ? self::BACKUPS_DIR : self::STAGING_DIR;
+		$dir   = self::resolve_dir( $which );
+		if ( false === $dir ) {
+			return new \WP_Error(
+				'uploads_unavailable',
+				__( 'Directory is unavailable on this site.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		$limit  = max( 1, min( 200, $limit ) );
+		$offset = max( 0, $offset );
+
+		$files = glob( trailingslashit( $dir ) . '*.zip' );
+		if ( ! is_array( $files ) ) {
+			$files = array();
+		}
+
+		usort(
+			$files,
+			static function ( string $a, string $b ): int {
+				$ma = (int) @filemtime( $a ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				$mb = (int) @filemtime( $b ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				return $mb <=> $ma;
+			}
+		);
+
+		$total = count( $files );
+		$slice = array_slice( $files, $offset, $limit );
+
+		$uploads_base    = wp_upload_dir( null, false );
+		$uploads_basedir = ! empty( $uploads_base['basedir'] ) ? rtrim( (string) $uploads_base['basedir'], '/' ) : '';
+		$uploads_baseurl = ! empty( $uploads_base['baseurl'] ) ? rtrim( (string) $uploads_base['baseurl'], '/' ) : '';
+		$abspath         = rtrim( realpath( ABSPATH ) ?: ABSPATH, '/' );
+
+		$items = array();
+		foreach ( $slice as $abs ) {
+			$rel = $abs;
+			if ( '' !== $abspath && 0 === strpos( $abs, $abspath . '/' ) ) {
+				$rel = substr( $abs, strlen( $abspath ) + 1 );
+			}
+
+			$url = '';
+			if ( '' !== $uploads_basedir && 0 === strpos( $abs, $uploads_basedir . '/' ) ) {
+				$url = $uploads_baseurl . '/' . ltrim( substr( $abs, strlen( $uploads_basedir ) ), '/' );
+			}
+
+			$items[] = array(
+				'file_path'  => $rel,
+				'file_url'   => $url,
+				'size'       => (int) @filesize( $abs ), // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				'sha256'     => self::sha256_of( $abs ),
+				'created_at' => gmdate( 'c', (int) @filemtime( $abs ) ), // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			);
+		}
+
+		return array(
+			'items' => $items,
+			'total' => $total,
+		);
+	}
+
+	/**
+	 * Compute the SHA-256 of a file, or '' when it cannot be read. Skips large
+	 * files gracefully.
+	 */
+	public static function sha256_of( string $abs_path ): string {
+		if ( ! is_file( $abs_path ) || ! is_readable( $abs_path ) ) {
+			return '';
+		}
+		$hash = @hash_file( 'sha256', $abs_path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		return is_string( $hash ) ? $hash : '';
+	}
+
+	/**
+	 * Convert an absolute path inside uploads/ into ABSPATH-relative form for
+	 * transport to callers. Returns the input unchanged when it is already
+	 * outside ABSPATH.
+	 */
+	public static function to_abspath_relative( string $abs_path ): string {
+		$abspath = rtrim( realpath( ABSPATH ) ?: ABSPATH, '/' );
+		if ( '' !== $abspath && 0 === strpos( $abs_path, $abspath . '/' ) ) {
+			return substr( $abs_path, strlen( $abspath ) + 1 );
+		}
+		return $abs_path;
+	}
+
+	/**
+	 * Return the wp-uploads URL for an absolute path inside uploads/, or ''
+	 * when it is not under uploads/.
+	 */
+	public static function url_for( string $abs_path ): string {
+		$uploads = wp_upload_dir( null, false );
+		if ( empty( $uploads['basedir'] ) || empty( $uploads['baseurl'] ) ) {
+			return '';
+		}
+		$basedir = rtrim( (string) $uploads['basedir'], '/' );
+		$baseurl = rtrim( (string) $uploads['baseurl'], '/' );
+		if ( 0 === strpos( $abs_path, $basedir . '/' ) ) {
+			return $baseurl . '/' . ltrim( substr( $abs_path, strlen( $basedir ) ), '/' );
+		}
+		return '';
+	}
+
+	/**
+	 * Ensure the given managed sub-dir exists inside uploads/ with hardening
+	 * files. Returns the absolute path or false on failure.
+	 *
+	 * @return string|false
+	 */
+	private static function resolve_dir( string $subdir ) {
+		$uploads = wp_upload_dir( null, false );
+		if ( ! empty( $uploads['error'] ) || empty( $uploads['basedir'] ) ) {
+			return false;
+		}
+		$dir = trailingslashit( (string) $uploads['basedir'] ) . $subdir;
+		if ( ! wp_mkdir_p( $dir ) ) {
+			return false;
+		}
+
+		$htaccess = $dir . '/.htaccess';
+		if ( ! file_exists( $htaccess ) ) {
+			// Block PHP execution and disable directory listing, but allow
+			// direct downloads of the finalized .zip files so the URLs returned
+			// by Zip_Create / Zip_Download remain fetchable. Random filenames
+			// provide the enumeration defense.
+			$rules = "Options -Indexes\n"
+				. "<FilesMatch \"\\.(php|phtml|phar|pl|py|jsp|asp|htm|html|shtml)$\">\n"
+				. "\tDeny from all\n"
+				. "\t<IfModule mod_authz_core.c>\n"
+				. "\t\tRequire all denied\n"
+				. "\t</IfModule>\n"
+				. "</FilesMatch>\n";
+			@file_put_contents( $htaccess, $rules ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents, WordPress.PHP.NoSilencedErrors.Discouraged
+		}
+		$index_php = $dir . '/index.php';
+		if ( ! file_exists( $index_php ) ) {
+			@file_put_contents( $index_php, "<?php\n// Silence is golden.\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents, WordPress.PHP.NoSilencedErrors.Discouraged
+		}
+		return $dir;
+	}
+}

--- a/includes/Abilities/Utilities/Zip_Target_Resolver.php
+++ b/includes/Abilities/Utilities/Zip_Target_Resolver.php
@@ -1,0 +1,381 @@
+<?php
+/**
+ * Target resolver shared by Zip_Create and Zip_Extract (Feature 041).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Utilities
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Utilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolves the (target_type, target) input pair used by the Zip_Create /
+ * Zip_Extract abilities into an absolute filesystem path that lives inside
+ * the WordPress install.
+ *
+ * Supported target_type values:
+ *
+ *   - plugin      : $target is a plugin slug or plugin file. Resolved via
+ *                   Plugin_Helpers; returns the plugin's containing directory.
+ *   - theme       : $target is a stylesheet or theme name. Resolved via
+ *                   Theme_Helpers; returns the theme's directory.
+ *   - uploads     : $target is ignored. Returns wp_get_upload_dir()['basedir'].
+ *   - mu-plugins  : $target is ignored. Returns WPMU_PLUGIN_DIR.
+ *   - path        : $target is a path relative to ABSPATH. Returns the
+ *                   absolute path after a realpath() boundary check.
+ *
+ * Every branch protects against path traversal — the returned path must be a
+ * child of ABSPATH; anything outside is rejected as a WP_Error.
+ */
+final class Zip_Target_Resolver {
+
+	public const TYPE_PLUGIN     = 'plugin';
+	public const TYPE_THEME      = 'theme';
+	public const TYPE_UPLOADS    = 'uploads';
+	public const TYPE_MU_PLUGINS = 'mu-plugins';
+	public const TYPE_PATH       = 'path';
+
+	/**
+	 * All supported target types (used by JSON Schema enums).
+	 *
+	 * @return string[]
+	 */
+	public static function supported_types(): array {
+		return array(
+			self::TYPE_PLUGIN,
+			self::TYPE_THEME,
+			self::TYPE_UPLOADS,
+			self::TYPE_MU_PLUGINS,
+			self::TYPE_PATH,
+		);
+	}
+
+	/**
+	 * Resolve a source directory (must exist).
+	 *
+	 * @return array{abs_path: string, label: string}|\WP_Error
+	 */
+	public static function resolve_source( string $target_type, string $target ) {
+		$resolved = self::resolve( $target_type, $target, false );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+		if ( ! is_dir( $resolved['abs_path'] ) ) {
+			return new \WP_Error(
+				'target_not_found',
+				sprintf(
+					/* translators: %s: resolved absolute path */
+					__( 'The resolved target directory does not exist: %s', 'acrossai-abilities-manager' ),
+					$resolved['abs_path']
+				)
+			);
+		}
+		return $resolved;
+	}
+
+	/**
+	 * Resolve a destination directory. Non-existent directories are created
+	 * for path/uploads targets (subfolder inside uploads/) and must already
+	 * exist for plugin / theme / mu-plugins.
+	 *
+	 * @return array{abs_path: string, label: string}|\WP_Error
+	 */
+	public static function resolve_destination( string $target_type, string $target ) {
+		$resolved = self::resolve( $target_type, $target, true );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+		if ( ! is_dir( $resolved['abs_path'] ) ) {
+			if ( ! wp_mkdir_p( $resolved['abs_path'] ) ) {
+				return new \WP_Error(
+					'destination_create_failed',
+					sprintf(
+						/* translators: %s: resolved absolute path */
+						__( 'Could not create destination directory: %s', 'acrossai-abilities-manager' ),
+						$resolved['abs_path']
+					)
+				);
+			}
+		}
+		return $resolved;
+	}
+
+	/**
+	 * Core resolution shared by resolve_source() and resolve_destination().
+	 *
+	 * @param bool $for_destination When true, the boundary check tolerates a
+	 *                              missing directory (the caller may create it).
+	 *
+	 * @return array{abs_path: string, label: string}|\WP_Error
+	 */
+	private static function resolve( string $target_type, string $target, bool $for_destination ) {
+		$target_type = sanitize_key( $target_type );
+		$target      = sanitize_text_field( $target );
+
+		if ( ! in_array( $target_type, self::supported_types(), true ) ) {
+			return new \WP_Error(
+				'invalid_target_type',
+				sprintf(
+					/* translators: 1: submitted target_type, 2: comma-separated list of supported types */
+					__( 'Unsupported target_type "%1$s". Must be one of: %2$s', 'acrossai-abilities-manager' ),
+					$target_type,
+					implode( ', ', self::supported_types() )
+				)
+			);
+		}
+
+		switch ( $target_type ) {
+			case self::TYPE_PLUGIN:
+				return self::resolve_plugin_dir( $target );
+
+			case self::TYPE_THEME:
+				return self::resolve_theme_dir( $target );
+
+			case self::TYPE_UPLOADS:
+				$uploads = wp_upload_dir( null, false );
+				if ( ! empty( $uploads['error'] ) || empty( $uploads['basedir'] ) ) {
+					return new \WP_Error(
+						'uploads_unavailable',
+						__( 'Uploads directory is unavailable.', 'acrossai-abilities-manager' )
+					);
+				}
+				return array(
+					'abs_path' => rtrim( (string) $uploads['basedir'], '/' ),
+					'label'    => 'uploads',
+				);
+
+			case self::TYPE_MU_PLUGINS:
+				if ( ! defined( 'WPMU_PLUGIN_DIR' ) ) {
+					return new \WP_Error(
+						'mu_plugins_unavailable',
+						__( 'WPMU_PLUGIN_DIR is not defined on this install.', 'acrossai-abilities-manager' )
+					);
+				}
+				$mu_dir = rtrim( (string) WPMU_PLUGIN_DIR, '/' );
+				if ( $for_destination && ! is_dir( $mu_dir ) ) {
+					if ( ! wp_mkdir_p( $mu_dir ) ) {
+						return new \WP_Error(
+							'mu_plugins_create_failed',
+							__( 'Could not create the mu-plugins directory.', 'acrossai-abilities-manager' )
+						);
+					}
+				}
+				return array(
+					'abs_path' => $mu_dir,
+					'label'    => 'mu-plugins',
+				);
+
+			case self::TYPE_PATH:
+			default:
+				return self::resolve_abspath_relative( $target, $for_destination );
+		}
+	}
+
+	/**
+	 * Resolve a plugin slug / file / name to its containing directory.
+	 *
+	 * @return array{abs_path: string, label: string}|\WP_Error
+	 */
+	private static function resolve_plugin_dir( string $target ) {
+		if ( '' === $target ) {
+			return new \WP_Error(
+				'invalid_target',
+				__( 'A plugin slug is required when target_type is "plugin".', 'acrossai-abilities-manager' )
+			);
+		}
+
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$plugin_file = null;
+
+		if ( function_exists( '\get_plugins' ) ) {
+			$installed = get_plugins();
+			if ( isset( $installed[ $target ] ) ) {
+				$plugin_file = $target;
+			}
+		}
+
+		if ( null === $plugin_file ) {
+			$resolved = Plugin_Helpers::resolve_plugin( $target );
+			if ( ! empty( $resolved['plugin_file'] ) && $resolved['certainty'] >= 8.0 ) {
+				$plugin_file = (string) $resolved['plugin_file'];
+			}
+		}
+
+		if ( null === $plugin_file ) {
+			$plugins_dir = defined( 'WP_PLUGIN_DIR' ) ? rtrim( (string) WP_PLUGIN_DIR, '/' ) : rtrim( WP_CONTENT_DIR, '/' ) . '/plugins';
+			$candidate   = $plugins_dir . '/' . ltrim( $target, '/' );
+			$candidate   = rtrim( $candidate, '/' );
+			if ( is_dir( $candidate ) ) {
+				return array(
+					'abs_path' => $candidate,
+					'label'    => 'plugin:' . basename( $candidate ),
+				);
+			}
+
+			return new \WP_Error(
+				'plugin_not_found',
+				sprintf(
+					/* translators: %s: submitted plugin slug */
+					__( 'Could not resolve plugin "%s".', 'acrossai-abilities-manager' ),
+					$target
+				)
+			);
+		}
+
+		$plugins_dir = defined( 'WP_PLUGIN_DIR' ) ? rtrim( (string) WP_PLUGIN_DIR, '/' ) : rtrim( WP_CONTENT_DIR, '/' ) . '/plugins';
+
+		// A plugin file like "hello.php" (single-file plugin) has no dir of its own — zip the file itself would be surprising.
+		// For a plugin file like "hello-dolly/hello.php" the directory is "hello-dolly".
+		$slug_dir = strtok( $plugin_file, '/' );
+		if ( false === $slug_dir || '' === $slug_dir || strpos( $plugin_file, '/' ) === false ) {
+			return new \WP_Error(
+				'plugin_single_file',
+				sprintf(
+					/* translators: %s: plugin file path */
+					__( 'Plugin "%s" is a single file with no directory to archive.', 'acrossai-abilities-manager' ),
+					$plugin_file
+				)
+			);
+		}
+
+		$abs = $plugins_dir . '/' . $slug_dir;
+		if ( ! is_dir( $abs ) ) {
+			return new \WP_Error(
+				'plugin_dir_missing',
+				sprintf(
+					/* translators: %s: plugin directory path */
+					__( 'Resolved plugin directory does not exist: %s', 'acrossai-abilities-manager' ),
+					$abs
+				)
+			);
+		}
+
+		return array(
+			'abs_path' => $abs,
+			'label'    => 'plugin:' . $slug_dir,
+		);
+	}
+
+	/**
+	 * Resolve a theme stylesheet / name to its directory.
+	 *
+	 * @return array{abs_path: string, label: string}|\WP_Error
+	 */
+	private static function resolve_theme_dir( string $target ) {
+		if ( '' === $target ) {
+			return new \WP_Error(
+				'invalid_target',
+				__( 'A theme stylesheet is required when target_type is "theme".', 'acrossai-abilities-manager' )
+			);
+		}
+
+		$stylesheet = null;
+
+		if ( function_exists( '\wp_get_theme' ) ) {
+			$theme = wp_get_theme( $target );
+			if ( $theme && $theme->exists() ) {
+				$stylesheet = (string) $theme->get_stylesheet();
+			}
+		}
+
+		if ( null === $stylesheet ) {
+			$resolved = Theme_Helpers::resolve_theme( $target );
+			if ( ! empty( $resolved['stylesheet'] ) && $resolved['certainty'] >= 8.0 ) {
+				$stylesheet = (string) $resolved['stylesheet'];
+			}
+		}
+
+		if ( null === $stylesheet ) {
+			return new \WP_Error(
+				'theme_not_found',
+				sprintf(
+					/* translators: %s: submitted theme identifier */
+					__( 'Could not resolve theme "%s".', 'acrossai-abilities-manager' ),
+					$target
+				)
+			);
+		}
+
+		$themes_root = get_theme_root( $stylesheet );
+		if ( ! is_string( $themes_root ) || '' === $themes_root ) {
+			$themes_root = rtrim( WP_CONTENT_DIR, '/' ) . '/themes';
+		}
+		$abs = rtrim( $themes_root, '/' ) . '/' . $stylesheet;
+
+		if ( ! is_dir( $abs ) ) {
+			return new \WP_Error(
+				'theme_dir_missing',
+				sprintf(
+					/* translators: %s: theme directory */
+					__( 'Resolved theme directory does not exist: %s', 'acrossai-abilities-manager' ),
+					$abs
+				)
+			);
+		}
+
+		return array(
+			'abs_path' => $abs,
+			'label'    => 'theme:' . $stylesheet,
+		);
+	}
+
+	/**
+	 * Resolve an ABSPATH-relative path with a realpath boundary check.
+	 *
+	 * @return array{abs_path: string, label: string}|\WP_Error
+	 */
+	private static function resolve_abspath_relative( string $rel_path, bool $for_destination ) {
+		if ( '' === $rel_path ) {
+			return new \WP_Error(
+				'invalid_target',
+				__( 'A path is required when target_type is "path".', 'acrossai-abilities-manager' )
+			);
+		}
+		if ( false !== strpos( $rel_path, "\0" ) ) {
+			return new \WP_Error(
+				'invalid_path',
+				__( 'Path contains disallowed characters.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		$base      = rtrim( realpath( ABSPATH ) ?: ABSPATH, '/' );
+		$candidate = $base . '/' . ltrim( $rel_path, '/' );
+
+		// For a source path, the whole path must exist.
+		if ( ! $for_destination ) {
+			$abs = realpath( $candidate );
+			if ( false === $abs || ( $abs !== $base && 0 !== strpos( $abs, $base . '/' ) ) ) {
+				return new \WP_Error(
+					'path_out_of_bounds',
+					__( 'Path must resolve inside ABSPATH.', 'acrossai-abilities-manager' )
+				);
+			}
+			return array(
+				'abs_path' => $abs,
+				'label'    => 'path:' . $rel_path,
+			);
+		}
+
+		// For a destination path the leaf may not exist yet, but the resolved
+		// parent MUST live inside ABSPATH.
+		$parent = realpath( dirname( $candidate ) );
+		if ( false === $parent || ( $parent !== $base && 0 !== strpos( $parent, $base . '/' ) ) ) {
+			return new \WP_Error(
+				'path_out_of_bounds',
+				__( 'Destination parent must resolve inside ABSPATH.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		return array(
+			'abs_path' => $parent . '/' . basename( $candidate ),
+			'label'    => 'path:' . $rel_path,
+		);
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,6 +38,9 @@
 			<file>tests/phpunit/abilities/Absorbed/Test_Feature_046_Payload_Shape.php</file>
 			<file>tests/phpunit/abilities/Absorbed/Test_Feature_046_Permission_Gates.php</file>
 		</testsuite>
+		<testsuite name="feature-041-unit">
+			<file>tests/phpunit/abilities/Test_Feature_041_Backup_Abilities.php</file>
+		</testsuite>
 	</testsuites>
 	<source>
 		<include>

--- a/tests/phpunit/abilities/Test_Feature_041_Backup_Abilities.php
+++ b/tests/phpunit/abilities/Test_Feature_041_Backup_Abilities.php
@@ -1,0 +1,467 @@
+<?php
+/**
+ * Structural tests for the Feature 041 backup/restore + update abilities.
+ *
+ * Source-inspection only, mirroring the existing
+ * tests/phpunit/abilities/Absorbed/ suite: the plugin's stub bootstrap can't
+ * safely construct the full plugin, so instead each ability source file is
+ * checked for the required scaffolding (Ability_Definition extend, args
+ * shape, rebranded slugs, security guards).
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Feature_041_Backup_Abilities.
+ */
+class Test_Feature_041_Backup_Abilities extends WP_UnitTestCase {
+
+	/**
+	 * Absolute paths to every ability source file exercised by these tests.
+	 *
+	 * @var array<string,string>
+	 */
+	private array $sources = array();
+
+	/**
+	 * Path to the bootstrap file that must instantiate every new ability.
+	 *
+	 * @var string
+	 */
+	private string $bootstrap_source = '';
+
+	/**
+	 * Path to the Backups_Storage utility.
+	 *
+	 * @var string
+	 */
+	private string $backups_storage_source = '';
+
+	/**
+	 * Path to the Zip_Target_Resolver utility.
+	 *
+	 * @var string
+	 */
+	private string $target_resolver_source = '';
+
+	/**
+	 * Load every source file once per test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$plugin_root = dirname( __DIR__, 3 );
+
+		$this->sources = array(
+			'zip_create'    => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/FileManager/Zip_Create.php'
+			),
+			'zip_upload'    => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/FileManager/Zip_Upload.php'
+			),
+			'zip_extract'   => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/FileManager/Zip_Extract.php'
+			),
+			'zip_download'  => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/FileManager/Zip_Download.php'
+			),
+			'zip_list'      => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/FileManager/Zip_List.php'
+			),
+			'zip_delete'    => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/FileManager/Zip_Delete.php'
+			),
+			'plugin_update' => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Plugins/Plugin_Update.php'
+			),
+			'theme_update'  => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Themes/Theme_Update.php'
+			),
+		);
+
+		$this->bootstrap_source       = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php'
+		);
+		$this->backups_storage_source = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Utilities/Backups_Storage.php'
+		);
+		$this->target_resolver_source = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Utilities/Zip_Target_Resolver.php'
+		);
+	}
+
+	// =========================================================================
+	// Every new ability extends Ability_Definition and carries the full args shape
+	// =========================================================================
+
+	/**
+	 * Every ability class extends Ability_Definition — same audit the Feature
+	 * 046 suite runs against its samples.
+	 *
+	 * @return void
+	 */
+	public function test_all_abilities_extend_ability_definition(): void {
+		foreach ( $this->sources as $tag => $src ) {
+			$this->assertStringContainsString(
+				'extends Ability_Definition',
+				$src,
+				"$tag must extend Ability_Definition"
+			);
+		}
+	}
+
+	/**
+	 * Every ability declares the required top-level `args` keys.
+	 *
+	 * @return void
+	 */
+	public function test_all_abilities_carry_full_args_shape(): void {
+		$required_keys = array(
+			"'name'",
+			"'label'",
+			"'description'",
+			"'category'",
+			"'execute_callback'",
+			"'permission_callback'",
+			"'input_schema'",
+			"'output_schema'",
+			"'meta'",
+		);
+		foreach ( $this->sources as $tag => $src ) {
+			foreach ( $required_keys as $key ) {
+				$this->assertStringContainsString(
+					$key,
+					$src,
+					"$tag must expose args key $key"
+				);
+			}
+		}
+	}
+
+	// =========================================================================
+	// Slugs / categories align with the rebranded namespace
+	// =========================================================================
+
+	/**
+	 * Every ability name uses the acrossai-abilities-manager/ prefix, and the
+	 * category matches the FileManager / Plugins / Themes rebranded slugs.
+	 *
+	 * @return void
+	 */
+	public function test_all_abilities_use_rebranded_slugs(): void {
+		$expected = array(
+			'zip_create'    => array(
+				'name'     => 'acrossai-abilities-manager/zip-create',
+				'category' => 'acrossai-abilities-manager-file-manager',
+			),
+			'zip_upload'    => array(
+				'name'     => 'acrossai-abilities-manager/zip-upload',
+				'category' => 'acrossai-abilities-manager-file-manager',
+			),
+			'zip_extract'   => array(
+				'name'     => 'acrossai-abilities-manager/zip-extract',
+				'category' => 'acrossai-abilities-manager-file-manager',
+			),
+			'zip_download'  => array(
+				'name'     => 'acrossai-abilities-manager/zip-download',
+				'category' => 'acrossai-abilities-manager-file-manager',
+			),
+			'zip_list'      => array(
+				'name'     => 'acrossai-abilities-manager/zip-list',
+				'category' => 'acrossai-abilities-manager-file-manager',
+			),
+			'zip_delete'    => array(
+				'name'     => 'acrossai-abilities-manager/zip-delete',
+				'category' => 'acrossai-abilities-manager-file-manager',
+			),
+			'plugin_update' => array(
+				'name'     => 'acrossai-abilities-manager/plugin-update',
+				'category' => 'acrossai-abilities-manager-plugins',
+			),
+			'theme_update'  => array(
+				'name'     => 'acrossai-abilities-manager/theme-update',
+				'category' => 'acrossai-abilities-manager-themes',
+			),
+		);
+		foreach ( $expected as $tag => $pair ) {
+			$this->assertStringContainsString(
+				"'{$pair['name']}'",
+				$this->sources[ $tag ],
+				"$tag must carry rebranded ability name"
+			);
+			$this->assertStringContainsString(
+				"'{$pair['category']}'",
+				$this->sources[ $tag ],
+				"$tag must carry rebranded category slug"
+			);
+		}
+	}
+
+	// =========================================================================
+	// Security posture
+	// =========================================================================
+
+	/**
+	 * Every ability declares a permission_callback.
+	 *
+	 * @return void
+	 */
+	public function test_all_abilities_declare_permission_callback(): void {
+		foreach ( $this->sources as $tag => $src ) {
+			$this->assertStringContainsString(
+				"'permission_callback'",
+				$src,
+				"$tag must declare a permission_callback"
+			);
+		}
+	}
+
+	/**
+	 * Every ability's permission_callback gates via at least `manage_options`.
+	 * Plugin/Theme_Update additionally require the WP update capability.
+	 *
+	 * @return void
+	 */
+	public function test_all_abilities_use_manage_options_gate(): void {
+		foreach ( $this->sources as $tag => $src ) {
+			$this->assertMatchesRegularExpression(
+				"/current_user_can\(\s*'manage_options'\s*\)/",
+				$src,
+				"$tag must gate via current_user_can( 'manage_options' )"
+			);
+		}
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'update_plugins'\s*\)/",
+			$this->sources['plugin_update'],
+			'plugin_update must additionally gate via update_plugins.'
+		);
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'update_themes'\s*\)/",
+			$this->sources['theme_update'],
+			'theme_update must additionally gate via update_themes.'
+		);
+	}
+
+	/**
+	 * Destructive/mutating abilities must honour the DISALLOW_FILE_MODS guard
+	 * via File_Mods_Guard::blocked_response(). Read-only Zip_Download and
+	 * Zip_List are exempt.
+	 *
+	 * @return void
+	 */
+	public function test_mutating_abilities_call_file_mods_guard(): void {
+		$must_guard = array(
+			'zip_upload',
+			'zip_extract',
+			'zip_delete',
+			'plugin_update',
+			'theme_update',
+		);
+		foreach ( $must_guard as $tag ) {
+			$this->assertStringContainsString(
+				'File_Mods_Guard::blocked_response',
+				$this->sources[ $tag ],
+				"$tag must invoke File_Mods_Guard::blocked_response()"
+			);
+		}
+	}
+
+	/**
+	 * Zip_Extract must audit archive entries for zip-slip / traversal before
+	 * extraction. The audit rejects `..` segments and absolute paths.
+	 *
+	 * @return void
+	 */
+	public function test_zip_extract_audits_for_traversal(): void {
+		$src = $this->sources['zip_extract'];
+		$this->assertStringContainsString(
+			"'..'",
+			$src,
+			'Zip_Extract must reject entries containing ".." segments.'
+		);
+		$this->assertMatchesRegularExpression(
+			"/substr\(\s*\\\$name,\s*0,\s*1\s*\)/",
+			$src,
+			'Zip_Extract must reject entries with an absolute path (leading "/").'
+		);
+	}
+
+	/**
+	 * Zip_Upload must validate the finalized bytes carry a valid zip magic
+	 * signature (PK\\x03\\x04 / PK\\x05\\x06 / PK\\x07\\x08) before moving
+	 * the archive into acrossai-backups/.
+	 *
+	 * @return void
+	 */
+	public function test_zip_upload_validates_zip_magic(): void {
+		$this->assertStringContainsString(
+			'"PK\\x03\\x04"',
+			$this->sources['zip_upload'],
+			'Zip_Upload must include the standard local-file-header magic check.'
+		);
+	}
+
+	// =========================================================================
+	// Bootstrap wires every new ability
+	// =========================================================================
+
+	/**
+	 * The core bootstrap instantiates every ability so its constructor hooks
+	 * `acrossai_abilities_api_init`.
+	 *
+	 * @return void
+	 */
+	public function test_bootstrap_instantiates_every_new_ability(): void {
+		$expected = array(
+			'new FileManager\\Zip_Create()',
+			'new FileManager\\Zip_Upload()',
+			'new FileManager\\Zip_Extract()',
+			'new FileManager\\Zip_Download()',
+			'new FileManager\\Zip_List()',
+			'new FileManager\\Zip_Delete()',
+			'new Plugins\\Plugin_Update()',
+			'new Themes\\Theme_Update()',
+		);
+		foreach ( $expected as $needle ) {
+			$this->assertStringContainsString(
+				$needle,
+				$this->bootstrap_source,
+				"Bootstrap must contain: $needle"
+			);
+		}
+	}
+
+	/**
+	 * Bootstrap registers the Zip_Upload chunk-sweeper cron the same way it
+	 * registers the Upload_Media sweeper.
+	 *
+	 * @return void
+	 */
+	public function test_bootstrap_registers_zip_upload_sweeper(): void {
+		$this->assertStringContainsString(
+			'FileManager\\Zip_Upload::CHUNK_SWEEP_HOOK',
+			$this->bootstrap_source
+		);
+		$this->assertStringContainsString(
+			"FileManager\\Zip_Upload::class, 'sweep_chunk_sessions'",
+			$this->bootstrap_source
+		);
+		$this->assertStringContainsString(
+			'FileManager\\Zip_Upload::register_sweep_cron();',
+			$this->bootstrap_source
+		);
+	}
+
+	// =========================================================================
+	// Utilities carry the expected surface
+	// =========================================================================
+
+	/**
+	 * Backups_Storage exposes the constants and helpers every Zip_* ability
+	 * imports.
+	 *
+	 * @return void
+	 */
+	public function test_backups_storage_exposes_required_surface(): void {
+		$src = $this->backups_storage_source;
+		foreach (
+			array(
+				"public const BACKUPS_DIR = 'acrossai-backups';",
+				"public const STAGING_DIR = 'acrossai-staging';",
+				'public static function backups_path()',
+				'public static function staging_path()',
+				'public static function resolve_managed_path(',
+				'public static function random_backup_filename(',
+				'public static function list_entries(',
+				'public static function sha256_of(',
+			) as $needle
+		) {
+			$this->assertStringContainsString(
+				$needle,
+				$src,
+				"Backups_Storage must expose: $needle"
+			);
+		}
+	}
+
+	/**
+	 * Backups_Storage writes hardening files (.htaccess + index.php) on first
+	 * use but MUST allow direct downloads of .zip files (otherwise Zip_Create's
+	 * returned file_url is unreachable).
+	 *
+	 * @return void
+	 */
+	public function test_backups_storage_hardening_allows_zip_downloads(): void {
+		$src = $this->backups_storage_source;
+		$this->assertStringContainsString(
+			'.htaccess',
+			$src,
+			'Backups_Storage must write an .htaccess for hardening.'
+		);
+		$this->assertStringContainsString(
+			'index.php',
+			$src,
+			'Backups_Storage must write an index.php for enumeration defense.'
+		);
+		$this->assertStringNotContainsString(
+			'Deny from all\n<IfModule',
+			$src,
+			'Backups_Storage must NOT globally deny all requests — .zip downloads must remain reachable via file_url.'
+		);
+		$this->assertMatchesRegularExpression(
+			'/FilesMatch[^\n]+\\\.\\(php/',
+			$src,
+			'Backups_Storage hardening must scope the deny to executable extensions.'
+		);
+	}
+
+	/**
+	 * Zip_Target_Resolver enumerates the five supported target types.
+	 *
+	 * @return void
+	 */
+	public function test_target_resolver_supports_all_five_types(): void {
+		$src = $this->target_resolver_source;
+		foreach (
+			array(
+				"public const TYPE_PLUGIN     = 'plugin';",
+				"public const TYPE_THEME      = 'theme';",
+				"public const TYPE_UPLOADS    = 'uploads';",
+				"public const TYPE_MU_PLUGINS = 'mu-plugins';",
+				"public const TYPE_PATH       = 'path';",
+			) as $needle
+		) {
+			$this->assertStringContainsString(
+				$needle,
+				$src,
+				"Zip_Target_Resolver must declare: $needle"
+			);
+		}
+	}
+
+	/**
+	 * The `path` branch of Zip_Target_Resolver applies the same
+	 * realpath()-inside-ABSPATH boundary check that File_Read uses.
+	 *
+	 * @return void
+	 */
+	public function test_target_resolver_boundary_checks_path_targets(): void {
+		$this->assertMatchesRegularExpression(
+			'/realpath\(\s*ABSPATH\s*\)/',
+			$this->target_resolver_source,
+			'Zip_Target_Resolver must resolve ABSPATH via realpath() for boundary checks.'
+		);
+		$this->assertMatchesRegularExpression(
+			"/strpos\(\s*\\\$parent,\s*\\\$base\s*\\.\s*'\\/'/",
+			$this->target_resolver_source,
+			'Zip_Target_Resolver must verify the resolved parent lives inside ABSPATH.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Adds **8 new abilities** to the acrossai-abilities-manager surface, grouped under existing Category folders (no new module per Constitution §I). All new abilities enforce `manage_options`; every mutating ability routes through `File_Mods_Guard::blocked_response('install')`.

### FileManager (sub_group: Backups)

- **Zip_Create** — archives a plugin/theme/uploads/mu-plugins/path into `wp-content/uploads/acrossai-backups/<random>.zip` and returns download URL + SHA-256. Filterable size cap (`acrossai_abilities_manager_zip_max_bytes`, 512 MB).
- **Zip_Upload** — base64 / URL / chunked (session/index/is_final, ≤8 MB per chunk, ≤64 MB per session — both filterable) upload of a zip into `acrossai-backups/`. Validates `PK\x03\x04` magic on finalize. Skips the media library.
- **Zip_Extract** — extracts a zip already on disk (`source.path`, ABSPATH-relative) or fetched from a URL. Audits every entry for zip-slip (`..`, absolute path, backslash, null byte) BEFORE extraction. Uses `unzip_file()` by default; `overwrite=true` drops to `ZipArchive::extractTo`.
- **Zip_Download** — returns fresh URL + size + sha256 + created_at for any zip inside `acrossai-backups/` or `acrossai-staging/`.
- **Zip_List** — paginated listing of managed zips, newest first.
- **Zip_Delete** — idempotent delete inside the managed dirs.

### Plugins / Themes (sub_group: Lifecycle)

- **Plugin_Update** — wraps `Plugin_Upgrader::bulk_upgrade()`. Additional cap: `update_plugins`.
- **Theme_Update** — wraps `Theme_Upgrader::bulk_upgrade()`. Additional cap: `update_themes`.

### Shared utilities (Constitution §VI)

- `Backups_Storage` — bootstraps `acrossai-backups/` + `acrossai-staging/` with hardening (`.htaccess` blocks PHP execution, permits `.zip` downloads; `index.php` blocks enumeration). Random filenames, `realpath()` boundary check, SHA-256, listing.
- `Zip_Target_Resolver` — maps `(target_type, target)` to an absolute path via `Plugin_Helpers` / `Theme_Helpers` / `wp_get_upload_dir()` / `WPMU_PLUGIN_DIR` / ABSPATH-boundary-checked realpath.

### Wiring

`AcrossAI_Core_Abilities_Bootstrap::register_abilities()` instantiates all 8 new abilities and registers the `Zip_Upload` chunk-sweeper on a new daily cron (`acrossai_abilities_manager_zip_upload_sweep_chunks`).

## Test plan

- [x] `composer run phpstan` (level 8) — zero errors
- [x] `composer run phpcs` — zero errors
- [x] `composer test` — 143 tests, 466 assertions, all pass (14 new Feature 041 tests, 152 new assertions)
- [ ] Manual e2e in a Local site: Zip_Create → Zip_List → Zip_Download URL fetch → Zip_Extract → verify files land
- [ ] Zip-slip: craft `../evil.php` entry, confirm Zip_Extract rejects with clean error
- [ ] `DISALLOW_FILE_MODS` in wp-config → Zip_Upload / Zip_Extract / Zip_Delete / Plugin_Update / Theme_Update all short-circuit
- [ ] Plugin_Update: pin Hello Dolly older, run `Update_Check`, then `Plugin_Update {slugs:["hello-dolly/hello.php"]}` and verify version bumps
- [ ] Idempotency: re-run Plugin_Update with no update available → `updated_count: 0` with clean success

🤖 Generated with [Claude Code](https://claude.com/claude-code)