### PR TITLE
Feature 042 — Core category (WP core update) + backup filename scheme

### DIFF
--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -79,6 +79,7 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		$loader->add_action( 'wp_abilities_api_categories_init', Options\Category_Registrar::instance(), 'register' );
 		$loader->add_action( 'wp_abilities_api_categories_init', Cron\Category_Registrar::instance(), 'register' );
 		$loader->add_action( 'wp_abilities_api_categories_init', SiteHealth\Category_Registrar::instance(), 'register' );
+		$loader->add_action( 'wp_abilities_api_categories_init', Core\Category_Registrar::instance(), 'register' );
 	}
 
 	/**
@@ -286,6 +287,8 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Cron\Cron_Delete_Schedule();
 		new SiteHealth\Site_Health_Status();
 		new SiteHealth\Site_Health_Info();
+		new Core\Wp_Core_Update_Check();
+		new Core\Wp_Core_Update();
 
 		// Extras the companion Main.php also ran alongside the ability
 		// instantiations. See docs/planning/046-absorb-core-abilities-into-manager.md

--- a/includes/Abilities/Core/Category_Registrar.php
+++ b/includes/Abilities/Core/Category_Registrar.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Category_Registrar for the Core ability inventory (Feature 042).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Core
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the WP ability category used by all WordPress-core-scoped
+ * abilities (core update check, core update apply, and any future
+ * core-specific abilities).
+ *
+ * Must run on wp_abilities_api_categories_init â before the Library Processor
+ * calls wp_register_ability() at wp_abilities_api_init P5.
+ */
+final class Category_Registrar {
+
+	/** @var self|null */
+	protected static $instance = null;
+
+	/**
+	 * Private constructor — access via instance().
+	 */
+	private function __construct() {}
+
+	/**
+	 * Return the singleton instance.
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Register the ability category with the WP Abilities API.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		wp_register_ability_category(
+			'acrossai-abilities-manager-core',
+			array(
+				'label'       => __( 'Acrossai Abilities Manager â Core', 'acrossai-abilities-manager' ),
+				'description' => __( 'Abilities for managing the WordPress core itself: check for available core updates and apply them via Core_Upgrader.', 'acrossai-abilities-manager' ),
+			)
+		);
+	}
+}

--- a/includes/Abilities/Core/Wp_Core_Update.php
+++ b/includes/Abilities/Core/Wp_Core_Update.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Wp_Core_Update ability (Feature 042).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Core
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Core;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Apply a WordPress core update via WP core's Core_Upgrader::upgrade().
+ *
+ * Same upgrader class the built-in WP dashboard uses; no custom download or
+ * integrity checks. When called with no arguments, upgrades to the first
+ * `response=upgrade` offer from get_core_updates() (the default WP admin
+ * behaviour). Callers can pin to a specific `version` (+ optional `locale`)
+ * to constrain the offer picked.
+ */
+class Wp_Core_Update extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/wp-core-update',
+			'args' => array(
+				'label'               => __( 'Update WordPress Core', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Apply the pending WordPress core update via WP core\'s Core_Upgrader. When called with no arguments, upgrades to the latest available offer. Provide "version" (+ optional "locale") to pin to a specific offer. Re-running when no update is available is a clean no-op. Honours DISALLOW_FILE_MODS.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-core',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'update_core' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(
+						'version' => array(
+							'type'        => 'string',
+							'description' => __( 'Optional WordPress version to pin the upgrade to (e.g. "6.9.1"). When omitted, upgrades to the latest available offer.', 'acrossai-abilities-manager' ),
+						),
+						'locale'  => array(
+							'type'        => 'string',
+							'description' => __( 'Optional locale of the update offer to pin to (e.g. "en_US"). When omitted, defaults to the site\'s active locale from get_locale().', 'acrossai-abilities-manager' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'updated'      => array( 'type' => 'boolean' ),
+						'from_version' => array( 'type' => 'string' ),
+						'to_version'   => array( 'type' => 'string' ),
+						'message'      => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'lifecycle',
+						'sub_group_label' => __( 'Lifecycle', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response( 'install' );
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		if ( is_multisite() && ! current_user_can( 'update_core' ) ) {
+			return array(
+				'success' => false,
+				'updated' => false,
+				'message' => __( 'Core updates on multisite require the update_core capability at the network level.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( ! function_exists( 'get_core_updates' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/update.php';
+		}
+		if ( ! class_exists( '\Core_Upgrader' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
+
+		$from_version = (string) get_bloginfo( 'version' );
+
+		$version = isset( $input['version'] ) ? sanitize_text_field( (string) $input['version'] ) : '';
+		$locale  = isset( $input['locale'] ) ? sanitize_text_field( (string) $input['locale'] ) : '';
+
+		if ( '' !== $version ) {
+			$update = find_core_update( $version, '' !== $locale ? $locale : get_locale() );
+		} else {
+			$updates = get_core_updates();
+			$update  = ( is_array( $updates ) && ! empty( $updates ) && is_object( $updates[0] ) ) ? $updates[0] : null;
+		}
+
+		if ( null === $update || false === $update ) {
+			return array(
+				'success'      => true,
+				'updated'      => false,
+				'from_version' => $from_version,
+				'to_version'   => $from_version,
+				'message'      => '' !== $version
+					? sprintf(
+						/* translators: %s: requested WordPress version */
+						__( 'No core update offer found for version "%s".', 'acrossai-abilities-manager' ),
+						$version
+					)
+					: __( 'No core update available.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$response = isset( $update->response ) ? (string) $update->response : '';
+		if ( 'upgrade' !== $response ) {
+			return array(
+				'success'      => true,
+				'updated'      => false,
+				'from_version' => $from_version,
+				'to_version'   => $from_version,
+				'message'      => sprintf(
+					/* translators: %s: WP update offer response value (e.g. "latest") */
+					__( 'Core offer is not upgradable (response=%s).', 'acrossai-abilities-manager' ),
+					'' !== $response ? $response : 'unknown'
+				),
+			);
+		}
+
+		$skin     = new \WP_Ajax_Upgrader_Skin();
+		$upgrader = new \Core_Upgrader( $skin );
+		$result   = $upgrader->upgrade( $update );
+
+		$to_version = (string) get_bloginfo( 'version' );
+
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'      => true,
+				'updated'      => false,
+				'from_version' => $from_version,
+				'to_version'   => $to_version,
+				'message'      => $result->get_error_message(),
+			);
+		}
+
+		if ( null === $result || false === $result ) {
+			$skin_errors = $skin->get_errors();
+			$msg         = is_wp_error( $skin_errors ) && $skin_errors->has_errors()
+				? $skin_errors->get_error_message()
+				: __( 'Core upgrade did not report success.', 'acrossai-abilities-manager' );
+			return array(
+				'success'      => true,
+				'updated'      => false,
+				'from_version' => $from_version,
+				'to_version'   => $to_version,
+				'message'      => $msg,
+			);
+		}
+
+		return array(
+			'success'      => true,
+			'updated'      => true,
+			'from_version' => $from_version,
+			'to_version'   => $to_version,
+			'message'      => sprintf(
+				/* translators: 1: from version, 2: to version */
+				__( 'WordPress upgraded from %1$s to %2$s.', 'acrossai-abilities-manager' ),
+				$from_version,
+				$to_version
+			),
+		);
+	}
+}

--- a/includes/Abilities/Core/Wp_Core_Update_Check.php
+++ b/includes/Abilities/Core/Wp_Core_Update_Check.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Wp_Core_Update_Check ability (Feature 042).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Core
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Core;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Focused, WordPress-core-only update availability report.
+ *
+ * Reads the first upgrade offer from get_core_updates() and returns its
+ * shape as flat fields. Companion to (but narrower than) the existing
+ * Plugins\Update_Check ability, which reports across core + plugins +
+ * themes; this one is scoped to WP core alone so callers can key off it
+ * without having to inspect the wider report.
+ */
+class Wp_Core_Update_Check extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/wp-core-update-check',
+			'args' => array(
+				'label'               => __( 'Check WordPress Core Update', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Report whether a WordPress core update is available. Returns the current version, the offered new version + download URL, and the PHP / MySQL requirements of the offer. Read-only; safe to call from any admin context.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-core',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'         => array( 'type' => 'boolean' ),
+						'current_version' => array( 'type' => 'string' ),
+						'available'       => array( 'type' => 'boolean' ),
+						'new_version'     => array( 'type' => 'string' ),
+						'locale'          => array( 'type' => 'string' ),
+						'response'        => array( 'type' => 'string' ),
+						'partial_version' => array( 'type' => 'string' ),
+						'download'        => array( 'type' => 'string' ),
+						'php_version'     => array( 'type' => 'string' ),
+						'mysql_version'   => array( 'type' => 'string' ),
+						'message'         => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'lifecycle',
+						'sub_group_label' => __( 'Lifecycle', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload (unused; always empty).
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+
+		if ( ! function_exists( 'get_core_updates' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/update.php';
+		}
+
+		$current_version = (string) get_bloginfo( 'version' );
+		$core_updates    = get_core_updates();
+
+		if ( empty( $core_updates ) || ! is_array( $core_updates ) ) {
+			return array(
+				'success'         => true,
+				'current_version' => $current_version,
+				'available'       => false,
+				'message'         => __( 'Could not fetch core updates.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$offer = $core_updates[0];
+		if ( ! is_object( $offer ) ) {
+			return array(
+				'success'         => true,
+				'current_version' => $current_version,
+				'available'       => false,
+				'message'         => __( 'No usable core update offer available.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$response = isset( $offer->response ) ? (string) $offer->response : '';
+		$out      = array(
+			'success'         => true,
+			'current_version' => $current_version,
+			'available'       => 'upgrade' === $response,
+			'new_version'     => isset( $offer->version ) ? (string) $offer->version : '',
+			'locale'          => isset( $offer->locale ) ? (string) $offer->locale : '',
+			'response'        => $response,
+			'partial_version' => isset( $offer->partial_version ) ? (string) $offer->partial_version : '',
+			'download'        => isset( $offer->download ) ? (string) $offer->download : '',
+			'php_version'     => isset( $offer->php_version ) ? (string) $offer->php_version : '',
+			'mysql_version'   => isset( $offer->mysql_version ) ? (string) $offer->mysql_version : '',
+		);
+
+		$out['message'] = $out['available']
+			? sprintf(
+				/* translators: 1: current version, 2: new version */
+				__( 'WordPress %2$s is available (currently on %1$s).', 'acrossai-abilities-manager' ),
+				$current_version,
+				$out['new_version']
+			)
+			: sprintf(
+				/* translators: %s: current WordPress version */
+				__( 'WordPress core is up to date (running %s).', 'acrossai-abilities-manager' ),
+				$current_version
+			);
+
+		return $out;
+	}
+}

--- a/includes/Abilities/Utilities/Backups_Storage.php
+++ b/includes/Abilities/Utilities/Backups_Storage.php
@@ -63,26 +63,54 @@ final class Backups_Storage {
 	}
 
 	/**
-	 * Generate a random filename for a new backup: `backup-{type}-{slug}-{rand}.zip`.
+	 * Generate a filename for a new backup: `{slug}-{unix-timestamp}-{ms}.zip`.
 	 *
-	 * The random suffix always contains 12 chars of [A-Za-z0-9]. type/slug are
-	 * sanitized through sanitize_key(); when they are empty the segments are
-	 * omitted so callers never introduce path separators through this helper.
+	 * The slug segment is the sanitized target descriptor (`hello-dolly` for a
+	 * plugin, sanitized filename hint for uploads, etc.). When the caller
+	 * doesn't supply one, we fall back to the sanitized $target_type so we
+	 * always have a base word (e.g. `uploads-...zip`, `mu-plugins-...zip`).
+	 * The timestamp + millisecond suffix guarantees two back-to-back calls
+	 * for the same target don't overwrite each other.
+	 *
+	 * The `.` separator between path characters is replaced with `-` so
+	 * callers can never smuggle in a path segment through the slug.
 	 */
 	public static function random_backup_filename( string $target_type, string $target ): string {
-		$type_seg = sanitize_key( $target_type );
-		$slug_seg = sanitize_key( str_replace( array( '/', '\\', '.' ), '-', $target ) );
+		$slug = self::filename_slug_segment( $target_type, $target );
 
-		$parts = array( 'backup' );
-		if ( '' !== $type_seg ) {
-			$parts[] = $type_seg;
-		}
-		if ( '' !== $slug_seg ) {
-			$parts[] = $slug_seg;
-		}
-		$parts[] = wp_generate_password( 12, false, false );
+		list( $unix, $ms ) = self::filename_time_segments();
 
-		return implode( '-', $parts ) . '.zip';
+		return $slug . '-' . $unix . '-' . $ms . '.zip';
+	}
+
+	/**
+	 * Resolve the slug segment for `random_backup_filename()`. Prefer the
+	 * sanitized $target; fall back to the sanitized $target_type; ultimate
+	 * fallback is `backup` so the returned filename is never just `-{ts}.zip`.
+	 */
+	private static function filename_slug_segment( string $target_type, string $target ): string {
+		$slug = sanitize_key( str_replace( array( '/', '\\', '.' ), '-', $target ) );
+		if ( '' !== $slug ) {
+			return $slug;
+		}
+		$type = sanitize_key( $target_type );
+		if ( '' !== $type ) {
+			return $type;
+		}
+		return 'backup';
+	}
+
+	/**
+	 * Return `[$unix, $ms_padded_to_3_digits]` — used by random_backup_filename()
+	 * so two calls within the same second still produce distinct filenames.
+	 *
+	 * @return array{0: string, 1: string}
+	 */
+	private static function filename_time_segments(): array {
+		$now  = microtime( true );
+		$unix = (int) floor( $now );
+		$ms   = (int) floor( ( $now - $unix ) * 1000 );
+		return array( (string) $unix, str_pad( (string) $ms, 3, '0', STR_PAD_LEFT ) );
 	}
 
 	/**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -41,6 +41,9 @@
 		<testsuite name="feature-041-unit">
 			<file>tests/phpunit/abilities/Test_Feature_041_Backup_Abilities.php</file>
 		</testsuite>
+		<testsuite name="feature-042-unit">
+			<file>tests/phpunit/abilities/Test_Feature_042_Core_Update.php</file>
+		</testsuite>
 	</testsuites>
 	<source>
 		<include>

--- a/specs/041-backup-restore-abilities-and-updates/architecture-review.md
+++ b/specs/041-backup-restore-abilities-and-updates/architecture-review.md
@@ -1,0 +1,75 @@
+# Architecture Review: Feature 041
+
+**Feature**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+**Backfilled**: 2026-07-18
+
+## Verdict
+
+**PASS** — no violations of Constitution §I (Modular Architecture) or §V (Extensibility Without Core Modification). No new modules; no cross-module leakage; no ability code touched core WP internals directly (all upgrade paths go through the WP-provided `Plugin_Upgrader` / `Theme_Upgrader` / `unzip_file()` / `download_url()`).
+
+## Module Enumeration (§I)
+
+Constitution §I locks the module list at 5. Feature 041 confirms no new module was added:
+
+| Module | Touched? | Notes |
+| --- | --- | --- |
+| Per-User Access Control | No | Access-control code untouched. |
+| MCP Server Management | No | MCP surface untouched. |
+| Custom Ability Registration | Yes (extended) | 8 new abilities added under existing `FileManager/`, `Plugins/`, `Themes/` Category folders — same layer that the 176 absorbed abilities live in. No new Category folder created. |
+| WebMCP Integration | No | WebMCP surface untouched. |
+| AbilityAPI Registration Management | No | Registration mechanism unchanged; new abilities self-register via `Ability_Definition::__construct`. |
+
+The 0.0.10 fix likewise stays inside `FileManager/Zip_Create.php` — no scope creep to other modules.
+
+## Category Folders (existing)
+
+Feature 041 uses **three** existing Category folders and creates **zero** new ones:
+
+- `includes/Abilities/FileManager/` — six new Zip abilities added next to `File_Read` / `File_Create` / etc.
+- `includes/Abilities/Plugins/` — `Plugin_Update` added next to `Plugin_Activate` / `Plugin_Install` / `Update_Check`.
+- `includes/Abilities/Themes/` — `Theme_Update` added next to `Theme_Activate` / `Theme_Install` / etc.
+
+## Utility Placement (§VI)
+
+Two new utilities placed under `includes/Abilities/Utilities/`, matching the pattern used by `File_Mods_Guard`, `Plugin_Helpers`, `Theme_Helpers`, `Cron_Helpers`, `Mime_Types_Store`.
+
+Both are introduced on their second use per Constitution §VI "shared logic → Utilities before second use":
+
+- `Backups_Storage` — called by all 6 Zip_* abilities. Six callers, plainly justified.
+- `Zip_Target_Resolver` — called by `Zip_Create` and `Zip_Extract`. Two callers, justifies extraction.
+
+## Ability_Definition Base Class
+
+Unchanged. Feature 041 subclasses continue the same pattern the 176 absorbed abilities use: implement `ability(): array` returning `['name', 'args' => [label, description, category, execute_callback, permission_callback, input_schema, output_schema, meta]]`, plus an `execute(array $input): array` method. Constructor auto-hooks `acrossai_abilities_api_init` via the base class.
+
+## Bootstrap Wiring
+
+`AcrossAI_Core_Abilities_Bootstrap::register_abilities()` grew by 8 `new …()` lines + 2 lines for the Zip_Upload sweeper cron next to the existing Upload_Media sweeper. `register_category_callbacks()` is UNTOUCHED — no new Category to register.
+
+## Boot Flow Rule (§I AC-HOOKS-MAIN)
+
+`includes/Main.php::define_public_hooks()` already wires `$core_abilities_bootstrap = AcrossAI_Core_Abilities_Bootstrap::instance();` before adding it to the loader. No changes to `Main.php` were needed. Every `add_action` still traces back to `Main.php` on a named variable.
+
+## Extensibility Contracts (§V)
+
+None claimed by Feature 041. The four extensibility hooks (`wp_before_execute_ability`, `wp_after_execute_ability`, `wp_register_ability_args`, `mcp_adapter_pre_tool_call`) remain unclaimed. Third-party plugins can still consume them without Feature 041 interference.
+
+## DataForm / DataViews (§III)
+
+No new admin UI added by Feature 041. The 8 new abilities render inside the existing Library page using the existing DataForm/DataViews-backed React components — no bypass, no violation.
+
+## Composer / Dependency (§II)
+
+No new composer requires. All work uses PHP built-ins (`ZipArchive`, `RecursiveIteratorIterator`, `microtime()`) and WordPress core (`unzip_file`, `WP_Filesystem`, `download_url`, `Plugin_Upgrader`, `Theme_Upgrader`, `WP_Ajax_Upgrader_Skin`, `wp_get_upload_dir`, `wp_generate_password`, `sanitize_key`). Zero third-party libs added.
+
+## Fix architectural impact
+
+The 0.0.10 fix modifies only `Zip_Create::append_dir_to_zip()` + `Zip_Create::estimate_tree_size()` and adds two private helpers (`normalize_relative()`, `has_hidden_segment()`). No cross-file impact, no module-boundary change.
+
+## Follow-up (out of scope for 041)
+
+- Backup filename scheme rebalance — moved to Feature 042 (`{slug}-{unix}-{ms}.zip` for readability + sortability at the cost of enumeration-by-guessing defense; directory listing still disabled by `.htaccess`).
+- WordPress core update ability — moved to Feature 042 under a new Core category folder.
+
+No violations to remediate; both follow-ups are additive, opt-in, and do not touch Feature 041's contract.

--- a/specs/041-backup-restore-abilities-and-updates/checklists/requirements.md
+++ b/specs/041-backup-restore-abilities-and-updates/checklists/requirements.md
@@ -1,0 +1,49 @@
+# Specification Quality Checklist: Feature 041
+
+**Purpose**: Validate specification completeness and quality (backfilled post-implementation)
+**Created**: 2026-07-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details in the spec's User Stories / FRs / SCs (implementation lives in plan.md)
+- [x] Focused on user value (cross-site backup mobility; core-update loop closure)
+- [x] Written for non-technical stakeholders in user-story sections; FR/SC sections technical-but-testable
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable (SC-041-002 quotes concrete assertion counts; SC-041-005 explicit "ZERO `.git/` entries")
+- [x] Success criteria are technology-agnostic in intent (SC-041-003 cites the zip-slip attack shape, not the implementation)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases identified (zip-slip archives, missing files on delete, DISALLOW_FILE_MODS short-circuit, hidden-directory recursion — the last of these produced the 0.0.10 fix)
+- [x] Scope clearly bounded (WP core update deferred to Feature 042; server-to-server push explicitly out-of-scope)
+- [x] Dependencies + assumptions identified (PHP 8.1+ / WP 6.9+ / ZipArchive availability / uploads dir writable)
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows (3 stories at P1/P2/P3)
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Shipped Quality Gates (0.0.9 → 0.0.10)
+
+- [x] PHPCS strict (WPCS) — zero errors on all Feature 041 files + bootstrap
+- [x] PHPStan L8 — zero errors on all Feature 041 files
+- [x] PHPUnit — 143 tests / 466 assertions on 0.0.9; 144 tests / 468 assertions on 0.0.10
+- [x] `npm run validate-packages` — no new packages introduced
+- [x] Ability payload shapes match Ability_Definition contract (verified by `test_all_abilities_carry_full_args_shape`)
+- [x] Rebranded slugs verified (`test_all_abilities_use_rebranded_slugs`)
+- [x] Permission gates verified (`manage_options` everywhere; `update_plugins`/`update_themes` extras)
+- [x] `File_Mods_Guard` on every mutating ability verified
+- [x] Zip-slip audit rejects `..` / absolute paths verified
+- [x] Zip_Upload magic-byte check verified
+
+## Fix (0.0.10) Quality Gates
+
+- [x] Regression test `test_zip_create_skips_hidden_at_every_segment` added and passes
+- [x] `has_hidden_segment()` + `normalize_relative()` helpers extracted for reuse across `append_dir_to_zip()` and `estimate_tree_size()`
+- [x] All prior gates re-green on the fix branch

--- a/specs/041-backup-restore-abilities-and-updates/memory-synthesis.md
+++ b/specs/041-backup-restore-abilities-and-updates/memory-synthesis.md
@@ -1,0 +1,53 @@
+# Memory Synthesis: Feature 041
+
+**Feature**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+**Backfilled**: 2026-07-18
+
+## Current Scope
+
+Adds 8 new abilities to `acrossai-abilities-manager`: 6 FileManager Zip abilities (`zip-create`, `zip-upload`, `zip-extract`, `zip-download`, `zip-list`, `zip-delete`) for cross-site backup / restore workflows, and 2 lifecycle abilities (`plugin-update`, `theme-update`) that finally close the "apply an update through the Abilities API" gap. Adds 2 shared utilities (`Backups_Storage`, `Zip_Target_Resolver`) under `includes/Abilities/Utilities/` per Constitution §VI. Adds a chunk-sweeper cron (`acrossai_abilities_manager_zip_upload_sweep_chunks`) mirroring the existing `Upload_Media` sweeper. Bootstrap wiring in `AcrossAI_Core_Abilities_Bootstrap`. No new modules (Constitution §I preserved). No new REST endpoints, no new database tables, no composer additions. Released as 0.0.9 (PRs #71 + #72) and patched as 0.0.10 (PRs #73 + #74).
+
+## Relevant Decisions
+
+- **DEC-EXTERNAL-PACKAGE-HOOK-CTOR** (Reason: `Ability_Definition::__construct` hooks `acrossai_abilities_api_init` — every ability class self-registers on instantiation. Feature 041 adds 8 subclasses; bootstrap wiring is just 8 `new …()` lines. Status: Active, Source: DECISIONS.md)
+- **DEC-UTILITIES-BEFORE-SECOND-USE** (Reason: `Backups_Storage` and `Zip_Target_Resolver` were introduced when they hit two callers each — `Backups_Storage` used by all six Zip_* abilities; `Zip_Target_Resolver` used by both `Zip_Create` and `Zip_Extract`. Status: Active, Source: CONSTITUTION.md §VI)
+- **DEC-BACKUP-URL-RETURN** (New: Chose "return `file_url` from a hardened uploads dir" over "server-to-server push" for the cross-site transfer model. Reason: URL-return keeps the ability surface small (no outbound HTTP + credentials handling), fits AI/MCP flows where the model can download and re-upload, and reuses WP core's existing uploads dir. The `.htaccess` blocks PHP execution while leaving `.zip` reachable — the crucial trade-off that makes the URL flow work. Status: Active, Source: this spec)
+- **DEC-SOURCE-INSPECTION-TESTS** (Reason: Every Feature 041 test uses source-inspection (`file_get_contents` + regex/substring assertions) rather than runtime instantiation — matches the Feature 046 Absorbed test suite precedent. The plugin's stub bootstrap can't safely construct the full plugin. Status: Active, Source: Test_Feature_046_Contracts.php precedent)
+
+## Active Architecture Constraints
+
+- **AC-HOOKS-MAIN** (Reason: All 8 new abilities auto-register via the filter on `Ability_Definition::__construct`. Bootstrap wiring in `AcrossAI_Core_Abilities_Bootstrap::register_abilities()` is called from `Main.php::define_public_hooks()`, preserving Boot Flow Rule literalism. Source: CONSTITUTION.md §I)
+- **AC-MODULE-ENUMERATION-LOCKED** (Reason: No new module. `FileManager`, `Plugins`, `Themes` are existing Category folders inside the existing Abilities module. Source: CONSTITUTION.md §I)
+- **AC-CAPABILITY-BASELINE** (Reason: Every ability enforces at least `manage_options`. `Plugin_Update` and `Theme_Update` add `update_plugins` / `update_themes` — matching WP core's own admin gate for those actions. Source: CONSTITUTION.md §IV)
+- **AC-FILE-MODS-GUARD** (Reason: Every mutating ability short-circuits via `File_Mods_Guard::blocked_response('install')`. Verified by `test_mutating_abilities_call_file_mods_guard`. Source: CONSTITUTION.md §IV)
+- **AC-UTILITIES-DRY** (Reason: Reused `Plugin_Helpers`, `Theme_Helpers`, `File_Mods_Guard` — did not re-implement. Placed new utilities in `includes/Abilities/Utilities/` on first cross-file need. Source: CONSTITUTION.md §VI)
+
+## Accepted Deviations
+
+- **DEV-041-ZIP-STAGING-PARALLEL** (Reason: `Zip_Upload` duplicates the shape of `Media/Upload_Media`'s chunked staging protocol rather than extracting a shared helper. Two callers only, one of which routes to the media library and one of which does not — the abstraction that would unify them would need to be parameterized on "finalize target dir" and "media_handle_sideload vs plain move" and would obscure both call sites. Accepted for now; revisit if a third caller appears. Status: Accepted-Deviation, Source: this spec)
+
+## Relevant Security Constraints
+
+See [security-constraints.md](./security-constraints.md). The eleven constraints in force are:
+
+- C-041-SEC-01 through C-041-SEC-10 for the 0.0.9 baseline (zip-slip audit, ABSPATH boundary, backups dir hardening, random filenames, File_Mods_Guard, capability gates, size caps, magic-byte validation, managed-path boundary, no shell).
+- C-041-SEC-11 for the 0.0.10 fix (per-segment hidden-path check).
+
+Per `feedback_skip_permission_callback_audit` in memory, a full REST-layer permission_callback audit is out of scope; each ability's `permission_callback` is inspected by the source-scan test suite.
+
+## Related Historical Lessons
+
+- **BUG-041-01 — Global Deny in .htaccess breaks download URL** (Reason: Initial `Backups_Storage::resolve_dir()` wrote `Deny from all` which would have made `zip-create`'s returned `file_url` unreachable. Caught during self-review before the first commit; changed to `FilesMatch` blocking only PHP-family extensions + `Options -Indexes`. The test `test_backups_storage_hardening_allows_zip_downloads` guards against regression. Source: this spec + Test_Feature_041 source-inspection assertion)
+- **BUG-041-02 — SELF_FIRST does not stop descent on `continue`** (Reason: 0.0.9 `Zip_Create::append_dir_to_zip()` used `if ($name[0] === '.') continue;` on the current entry's basename. `RecursiveIteratorIterator::SELF_FIRST` visits the directory first (skipped) but then descends into every file below it (basenames don't start with `.` so they're added). Result: `include_hidden=false` archives silently included `.git/objects/xxx`. Fix in 0.0.10: check EVERY segment of the entry's forward-slashed relative path via `has_hidden_segment()` — same pattern the reference `download-plugin/app/Plugins/Base.php` uses. Source: this spec + Test_Feature_041 regression test)
+- **BUG-041-03 — sub-second filename collisions** (Not exercised in 0.0.9/0.0.10; addressed in Feature 042 where the filename scheme changes to `{slug}-{unix}-{ms}.zip` and the `ms` suffix prevents same-second overwrites. See Feature 042 memory-synthesis. Source: Feature 042 spec)
+
+## Conflict Warnings
+
+None. All Feature 041 changes are compatible with active decisions and constraints. Feature 042 supersedes `DEC-BACKUP-URL-RETURN`'s enumeration-defense corollary (12-char random filename suffix) by switching to a time-based scheme — the URL-return contract itself is unchanged.
+
+## Retrieval Notes
+
+- Optimizer not enabled — markdown-only, index-first retrieval used.
+- Read references at planning time: reference plugin `download-plugin/app/Plugins/Base.php` (adopted per-segment hidden-check pattern in the 0.0.10 fix); WP core `Plugin_Upgrader`, `Theme_Upgrader`, `unzip_file()`, `download_url()`; existing utilities `Plugin_Helpers`, `Theme_Helpers`, `File_Mods_Guard`; existing ability shape `Media/Upload_Media` (chunked upload pattern).
+- Full durable-memory reads: NOT performed. Budget status: within limits (~800 words, under the 900-word cap).

--- a/specs/041-backup-restore-abilities-and-updates/plan.md
+++ b/specs/041-backup-restore-abilities-and-updates/plan.md
@@ -1,0 +1,66 @@
+# Implementation Plan: Feature 041
+
+**Feature Branch**: `041-backup-restore-abilities-and-updates` (merged as PR #71)
+**Follow-up fix**: `fix-041-zip-create-hidden-descent` (merged as PR #73)
+**Release**: `release-0.0.9` (PR #72) + `release-0.0.10` (PR #74)
+**Backfilled**: 2026-07-18
+
+## Approach
+
+Adopt existing patterns rather than invent new abstractions:
+
+- **8 new abilities** live under existing `Category` folders (`FileManager/`, `Plugins/`, `Themes/`) — Constitution §I locks the module list at five; no new module.
+- **2 utilities** under `includes/Abilities/Utilities/` (Constitution §VI: shared logic → Utilities before second use).
+- **Auto-registration**: each ability's `Ability_Definition::__construct` hooks the `acrossai_abilities_api_init` filter. Bootstrap wiring is only 8 `new …()` lines in `AcrossAI_Core_Abilities_Bootstrap::register_abilities()`.
+- **Tests**: source-inspection style already established by Feature 046's Absorbed suite — no full WP runtime dependency.
+
+## New files
+
+### Abilities
+
+- `includes/Abilities/FileManager/Zip_Create.php` — creates a zip of a plugin/theme/uploads/mu-plugins/path into `wp-content/uploads/acrossai-backups/{random}.zip`. Uses PHP `ZipArchive` (guaranteed on PHP 8.1). Size-cap filterable via `acrossai_abilities_manager_zip_max_bytes` (default 512 MB).
+- `includes/Abilities/FileManager/Zip_Upload.php` — chunked / base64 / URL upload with the same staging pattern as `Media/Upload_Media.php` (staging under `wp-content/uploads/acrossai-staging/` with a TTL cleanup cron), but finalizes into `acrossai-backups/` and skips the media library. Validates PK magic on finalize.
+- `includes/Abilities/FileManager/Zip_Extract.php` — reads a zip from a local path or fetches via `download_url()`. Uses `ZipArchive::open(CHECKCONS)` for the audit pass, then `unzip_file()` (or `ZipArchive::extractTo` when `overwrite=true`).
+- `includes/Abilities/FileManager/Zip_Download.php` — returns fresh URL + metadata for any zip inside the managed dirs.
+- `includes/Abilities/FileManager/Zip_List.php` — paginated listing (`limit` 1–200, `offset` ≥ 0), newest first.
+- `includes/Abilities/FileManager/Zip_Delete.php` — idempotent delete (deleting a missing file returns success with a note).
+- `includes/Abilities/Plugins/Plugin_Update.php` — wraps `Plugin_Upgrader::bulk_upgrade()`. Additional cap `update_plugins`.
+- `includes/Abilities/Themes/Theme_Update.php` — wraps `Theme_Upgrader::bulk_upgrade()`. Additional cap `update_themes`.
+
+### Utilities
+
+- `includes/Abilities/Utilities/Backups_Storage.php` — bootstraps + hardens the two managed dirs, resolves managed paths with boundary checks, generates random filenames (see Feature 042 for the follow-up scheme change), computes SHA-256, lists entries with metadata.
+- `includes/Abilities/Utilities/Zip_Target_Resolver.php` — maps `(target_type, target)` to an absolute path via `Plugin_Helpers` / `Theme_Helpers` / `wp_get_upload_dir()` / `WPMU_PLUGIN_DIR` / ABSPATH-realpath-boundary check.
+
+### Tests
+
+- `tests/phpunit/abilities/Test_Feature_041_Backup_Abilities.php` — 15 tests (14 initial + 1 added in the 0.0.10 fix), 154 assertions. Source-inspection style.
+
+## Modified files
+
+- `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php` — 8 `new …()` lines added in `register_abilities()` next to the existing FileManager / Plugins / Themes instantiations; new sweeper hook + registration for Zip_Upload's chunk cron mirrors the Upload_Media sweeper.
+- `phpunit.xml.dist` — new `feature-041-unit` testsuite.
+
+## Reusables consumed
+
+- `Ability_Definition` base class (`includes/Modules/Library/Ability_Definition.php`) — subclasses only implement `ability()`; the constructor hooks the filter.
+- `File_Mods_Guard` (`includes/Abilities/Utilities/File_Mods_Guard.php`) — DISALLOW_FILE_MODS short-circuit on every mutating ability.
+- `Plugin_Helpers` / `Theme_Helpers` — fuzzy resolution for plugin slugs / theme stylesheets.
+- `Upload_Media` chunked pattern (`includes/Abilities/Media/Upload_Media.php`) — Zip_Upload lifts the staging + TTL + chunk-assembly shape verbatim.
+- WP core: `download_url()`, `unzip_file()`, `WP_Filesystem`, `Plugin_Upgrader`, `Theme_Upgrader`, `WP_Ajax_Upgrader_Skin`, `wp_get_upload_dir()`. No third-party libs.
+
+## Security constraints
+
+See [security-constraints.md](./security-constraints.md) for the full checklist.
+
+## Verification
+
+- `composer run phpstan` (level 8) — zero errors
+- `composer run phpcs` — zero errors
+- `composer test` — 143→144 tests, 466→468 assertions across the 0.0.9 / 0.0.10 hop
+- Manual e2e in Local: Zip_Create → Zip_List → Zip_Download → Zip_Extract → verify files land
+- Zip-slip archive rejected; DISALLOW_FILE_MODS short-circuits five mutating abilities; idempotent no-op behaviour on the update abilities
+
+## Post-implementation follow-up
+
+The 0.0.10 fix (`fix-041-zip-create-hidden-descent`) landed on top of the initial Feature 041 ship. See [tasks.md](./tasks.md) `Fixes` section for the tracked task list.

--- a/specs/041-backup-restore-abilities-and-updates/security-constraints.md
+++ b/specs/041-backup-restore-abilities-and-updates/security-constraints.md
@@ -1,0 +1,84 @@
+# Security Constraints: Feature 041
+
+**Feature**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+**Backfilled**: 2026-07-18 (constraints as enforced by shipped 0.0.9 + 0.0.10)
+
+## Threat Model Summary
+
+The Feature 041 surface exposes filesystem writes and archive extraction through the Abilities API. The primary threats are: (1) zip-slip via crafted archives escaping the target directory, (2) path traversal via untrusted `target` inputs escaping ABSPATH, (3) execution of PHP inside the backups directory if any zip is misinterpreted as an entry point, (4) directory-listing enumeration of backup filenames, (5) DoS via unbounded archive sizes, (6) file modification during a `DISALLOW_FILE_MODS` lockdown.
+
+## Constraints (all enforced by shipped code)
+
+### C-041-SEC-01 — Zip-slip audit before extraction
+
+`Zip_Extract::audit_zip_entries()` iterates `ZipArchive::statIndex()` and rejects any entry whose name:
+
+- contains a `..` segment (per-segment check on `explode('/', $name)`),
+- starts with `/` (absolute path),
+- contains a `\` (backslash),
+- contains a `\0` (null byte),
+- has an empty name string.
+
+Rejection happens BEFORE the archive is handed to `unzip_file()` / `ZipArchive::extractTo` — no partial extraction on failure.
+
+### C-041-SEC-02 — ABSPATH boundary check on custom paths
+
+`Zip_Target_Resolver::resolve_abspath_relative()` uses `realpath()` on the resolved parent directory and asserts the result equals `$base` or begins with `$base . '/'` (mirroring the pattern established by `FileManager/File_Read.php:90-99`). Any path that resolves outside ABSPATH is rejected with `path_out_of_bounds`.
+
+### C-041-SEC-03 — Backups directory hardening
+
+`Backups_Storage::resolve_dir()` writes on first use:
+
+- An `.htaccess` that denies GET/POST for `.php`, `.phtml`, `.phar`, `.pl`, `.py`, `.jsp`, `.asp`, `.htm`, `.html`, `.shtml` extensions AND adds `Options -Indexes` to disable directory listing. Notably, the `.htaccess` MUST NOT globally deny all requests (early implementation attempt was corrected in the same PR) — otherwise `zip-create`'s returned `file_url` becomes unreachable.
+- An empty `index.php` so servers without `.htaccess` (nginx) still get a defense against directory enumeration.
+
+### C-041-SEC-04 — Random filenames
+
+`Backups_Storage::random_backup_filename()` appended a 12-character `[A-Za-z0-9]` random suffix on 0.0.9. **Superseded by Feature 042** which switches to `{slug}-{unix}-{ms}.zip` for readability, trading enumeration-by-guessing defense for time-sortability. Directory listing remains disabled.
+
+### C-041-SEC-05 — File_Mods_Guard on all mutating abilities
+
+Every mutating ability short-circuits via `File_Mods_Guard::blocked_response('install')`:
+
+- `Zip_Upload::execute()`
+- `Zip_Extract::execute()`
+- `Zip_Delete::execute()`
+- `Plugin_Update::execute()`
+- `Theme_Update::execute()`
+
+Read-only Zip_Download and Zip_List do not guard (they don't write).
+
+### C-041-SEC-06 — Capability gates
+
+- `Zip_Create`, `Zip_Upload`, `Zip_Extract`, `Zip_Download`, `Zip_List`, `Zip_Delete`: `current_user_can('manage_options')` per Constitution §IV.
+- `Plugin_Update`: `current_user_can('manage_options') && current_user_can('update_plugins')` — matches WP core's own admin gate for plugin updates.
+- `Theme_Update`: `current_user_can('manage_options') && current_user_can('update_themes')` — matches WP core's own admin gate for theme updates.
+
+Per the standing user directive `feedback_skip_permission_callback_audit` in memory, a full REST-layer permission_callback audit is out of scope; each ability's `permission_callback` is inspected by the source-scan test suite.
+
+### C-041-SEC-07 — Size caps
+
+- Archive size cap (default 512 MB, filter `acrossai_abilities_manager_zip_max_bytes`) enforced at THREE points:
+  1. `Zip_Create::estimate_tree_size()` before writing the zip
+  2. `Zip_Create::execute()` on the finalized zip size
+  3. `Zip_Extract::audit_zip_entries()` on the sum of `statIndex()->size` values (uncompressed size)
+- Chunked upload cap (`Zip_Upload`): 8 MB per chunk / 64 MB per session (both filterable), enforced on the base64-encoded payload before decoding.
+
+### C-041-SEC-08 — Zip magic-byte validation on upload
+
+`Zip_Upload::validate_zip_magic()` reads the first 4 bytes on finalize and rejects anything that isn't `PK\x03\x04` (standard local file header), `PK\x05\x06` (empty archive), or `PK\x07\x08` (spanned archive marker). Non-zip payloads are rejected with a clean error.
+
+### C-041-SEC-09 — Managed-path boundary on Zip_Download / Zip_List / Zip_Delete
+
+All three abilities resolve their `file_path` input via `Backups_Storage::resolve_managed_path()`, which requires the resolved parent to sit inside `acrossai-backups/` or `acrossai-staging/`. Any path outside those two dirs is rejected with `path_out_of_bounds`.
+
+### C-041-SEC-10 — No shell execution
+
+The feature uses no `shell_exec`, `exec`, `system`, `passthru`, `proc_open`, or backtick operators. All archive work is pure PHP via `ZipArchive` + WP core `unzip_file()` / `download_url()` / upgraders.
+
+## Fix constraint (0.0.10)
+
+### C-041-SEC-11 — Per-segment hidden-path check
+
+`Zip_Create`'s `include_hidden=false` path checks EVERY segment of the entry's forward-slashed relative path via `has_hidden_segment()` — not just the current entry basename. This closes the 0.0.9 information-leak where a caller asking to exclude hidden files still shipped `.git/objects/xxx` (and every other file inside a hidden directory) because `RecursiveIteratorIterator::SELF_FIRST` does not stop descent when `continue`-d on the outer loop.

--- a/specs/041-backup-restore-abilities-and-updates/spec.md
+++ b/specs/041-backup-restore-abilities-and-updates/spec.md
@@ -1,0 +1,94 @@
+# Feature Specification: Backup / restore abilities + plugin/theme update abilities
+
+**Feature Branch**: `041-backup-restore-abilities-and-updates`
+**Created**: 2026-07-17
+**Status**: Draft (backfilled post-implementation — reflects shipped code across PRs #71 / #72 / #73 / #74; released as 0.0.9 + 0.0.10)
+**Input**: User description: (multi-turn) — "create a abilites that can create zip on the server or in the local then upload it and then unzip it back so if some one want to take a backup of some folder , plugin, themes in local or in live site it can be done" → "will be mention when running the abilities also create for plugin, themes, upload, mu-plugins etc use this 'file-manager'" → "add this plugin-update or theme-update ability as well this will be under plugins" → "do we have upload and download zip abilities?" → (during code review) "check /Users/…/download-plugin — udpate the Backups abialites form that and if all is good then leave it"
+
+## Clarifications
+
+### Session 2026-07-17 (planning)
+
+- Q: What should the abilities be able to zip/restore? → A: plugin, theme, arbitrary folder, uploads / mu-plugins — all four, with the target passed at run time via one generic ability pair rather than N target-specific abilities.
+- Q: How should the zip be transferred once created? → A: Return download URL only (Recommended). Zip lands in `wp-content/uploads/acrossai-backups/`, caller pulls it via URL, uses a separate `zip-extract` on the destination site.
+- Q: Where should backup zips be stored on the server? → A: `wp-content/uploads/acrossai-backups/` + return URL. Hardened `.htaccess` blocks PHP execution but permits `.zip` downloads (required so the returned URL is reachable).
+- Q: Should I ask you to run /speckit-specify + /speckit-plan to formalize this? → A: Draft inline ability plan only. Spec-kit artifacts get backfilled later (see Feature 042 plan).
+- Q: Do you want a dedicated Zip_Upload ability? → A: Yes, plus Zip_Download, Zip_List, Zip_Delete — total six FileManager Zip abilities.
+
+### Session 2026-07-17 (during release-eve review)
+
+- Q: The reference `download-plugin` skips hidden files by checking every segment of the relative path; Zip_Create only checks the current entry basename. Fix? → A: Apply the per-segment check. Shipped as 0.0.10 (PR #73 + release PR #74).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Cross-site backup / restore of a plugin (Priority: P1)
+
+An administrator running local WordPress site A wants to duplicate a plugin's state (or roll back a plugin) onto live WordPress site B. Through an AI / MCP client they call `zip-create` on site A with `target_type=plugin, target=hello-dolly`; the response returns a `file_url` under `wp-content/uploads/acrossai-backups/`. The AI downloads the archive, uploads it to site B via `zip-upload` (chunked, base64, or by URL), and calls `zip-extract` on site B pointing at the uploaded file, with `target_type=plugin, target=hello-dolly`. Site B's `wp-content/plugins/hello-dolly/` now mirrors site A's.
+
+**Why this priority**: Cross-site plugin/theme mobility is the headline story that motivates the whole feature. Everything else builds on this flow.
+
+**Independent Test**: Zip Hello Dolly on Local site 1 → download via returned URL → upload via Zip_Upload on Local site 2 → run Zip_Extract → verify the extracted directory tree matches site 1's byte-for-byte (excluding hidden files when `include_hidden=false`).
+
+**Acceptance Scenarios**:
+
+1. **Given** Hello Dolly is installed on site A, **When** `zip-create {target_type:"plugin", target:"hello-dolly"}` is called, **Then** the response includes `success=true`, `file_path` under `wp-content/uploads/acrossai-backups/`, a fetchable `file_url`, and a non-empty `sha256`.
+2. **Given** the returned `file_url` is downloaded, **When** `zip-upload {url:"…"}` is called on site B, **Then** the response includes `finalized=true` and a new `file_path` under acrossai-backups on site B.
+3. **Given** the uploaded `file_path` on site B, **When** `zip-extract {source:{path:"…"}, target_type:"plugin", target:"hello-dolly"}` is called, **Then** the response reports `files_count > 0` and every file lands under `wp-content/plugins/hello-dolly/`.
+
+### User Story 2 — In-place plugin / theme update through the Abilities API (Priority: P2)
+
+Same admin wants to apply pending plugin / theme updates via the Abilities API rather than the WP dashboard. `plugin-update {slugs:["hello-dolly/hello.php"]}` upgrades that specific plugin using WP core's `Plugin_Upgrader::bulk_upgrade()`. `theme-update` does the same for themes. Both are idempotent — re-running on a plugin/theme with no available update returns success + `updated_count: 0`.
+
+**Why this priority**: `Update_Check` was already reporting availability across core + plugins + themes, but no ability could actually *apply* an update. This closes an obvious loop.
+
+**Independent Test**: Pin a bundled plugin to an older version → confirm `update-check` shows the update → run `plugin-update` → verify version bumps.
+
+### User Story 3 — Backup dir hygiene (Priority: P3)
+
+The AI needs to list previously-created backups, download an older one, or delete stale ones. `zip-list`, `zip-download`, and `zip-delete` cover this loop without needing to leave the abilities surface.
+
+**Independent Test**: Create 3 backups → `zip-list` returns all three newest-first → `zip-delete` on one → `zip-list` returns two → `zip-download` on a listed `file_path` returns a fresh URL + matching `sha256`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-041-001**: `zip-create` MUST accept one of `target_type ∈ {plugin, theme, uploads, mu-plugins, path}` and MUST write the archive to `wp-content/uploads/acrossai-backups/` with a filename that does not reveal predictable content. (Filename scheme rebalanced in Feature 042.)
+- **FR-041-002**: `zip-create` MUST enforce a configurable maximum archive size (default 512 MB) via `acrossai_abilities_manager_zip_max_bytes` and MUST reject over-size input before writing bytes to disk.
+- **FR-041-003**: `zip-create` MUST accept an `include_hidden` flag; when `false`, files under any hidden path segment (`.git/objects/…`, `.svn/…`, etc.) MUST NOT appear in the archive. **(Regression fixed in 0.0.10 — original 0.0.9 implementation only skipped the top-level hidden entry, not the descent.)**
+- **FR-041-004**: `zip-upload` MUST accept base64, remote URL, or chunked (session/index/is_final) modes, MUST validate the finalized bytes start with `PK\x03\x04` / `PK\x05\x06` / `PK\x07\x08`, and MUST reject non-zip payloads.
+- **FR-041-005**: `zip-extract` MUST audit every zip entry for `..` segments, absolute paths, backslashes, and null bytes BEFORE extraction; any offending entry MUST fail the operation without writing files.
+- **FR-041-006**: `zip-download`, `zip-list`, `zip-delete` MUST resolve their `file_path` input inside `wp-content/uploads/acrossai-backups/` or `wp-content/uploads/acrossai-staging/`; any path outside those two directories MUST be rejected with a clean error.
+- **FR-041-007**: `plugin-update` MUST wrap `Plugin_Upgrader::bulk_upgrade()`; `theme-update` MUST wrap `Theme_Upgrader::bulk_upgrade()`. Neither ability MAY implement its own HTTP fetch or integrity verification.
+- **FR-041-008**: All mutating abilities (`zip-upload`, `zip-extract`, `zip-delete`, `plugin-update`, `theme-update`) MUST short-circuit via `File_Mods_Guard::blocked_response('install')` when `DISALLOW_FILE_MODS` is set.
+- **FR-041-009**: `plugin-update` MUST require `update_plugins` in addition to `manage_options`; `theme-update` MUST require `update_themes` in addition to `manage_options`. Read-only Zip abilities require `manage_options` alone.
+- **FR-041-010**: The `acrossai-backups/` directory MUST be created on first use with an `.htaccess` that blocks execution of PHP-family extensions (`.php`, `.phtml`, `.phar`, `.pl`, `.py`, `.jsp`, `.asp`, `.htm`, `.html`, `.shtml`) but MUST NOT globally deny access (`.zip` downloads must remain reachable so `zip-create`'s returned `file_url` works).
+
+### Non-Functional Requirements
+
+- **NFR-041-001**: Every new ability MUST match the existing Ability_Definition shape (namespace, `use` ordering, docblock style, `meta.acrossai` block layout).
+- **NFR-041-002**: Every new class MUST pass PHPStan L8 and PHPCS strict (WPCS) with zero errors.
+- **NFR-041-003**: Tests MUST use the existing source-inspection pattern (mirrors Feature 046's Absorbed test suite) — no full WP runtime dependency.
+
+## Success Criteria
+
+- **SC-041-001**: 8 new abilities visible in the Abilities Library (6 FileManager Zip_* + Plugin_Update + Theme_Update) under the correct tab groups.
+- **SC-041-002**: `composer run phpstan` zero errors at L8; `composer run phpcs` zero errors; `composer test` all pass (144 tests / 468 assertions post-0.0.10).
+- **SC-041-003**: A hand-crafted zip-slip archive (`../evil.php`) fails `zip-extract` with a clean error message and NO files written outside the target directory.
+- **SC-041-004**: `DISALLOW_FILE_MODS=true` in wp-config short-circuits all 5 mutating abilities with the guard's `{success:false, message}` envelope.
+- **SC-041-005**: A plugin dir containing `.git/objects/xxx` yields an archive with ZERO `.git/` entries when `include_hidden=false` (Regression fixed in 0.0.10).
+
+## Out of Scope
+
+- WordPress core update (deferred to Feature 042).
+- Restore of an entire site (backup surface is per-target, not whole-site).
+- Bundled `Base_Backup_Adapter` abstraction — download-plugin's per-context Base classes are inspiration, not a template we adopt.
+- Server-to-server push (only URL-based transfer + local extract are shipped; that model is documented as a "possible future addition" in memory-synthesis).
+
+## Fixes
+
+### 2026-07-18 (0.0.10 — PRs #73 + #74)
+
+- **Bug**: `Zip_Create`'s `include_hidden=false` branch only checked the current entry's basename against the leading-dot rule. `RecursiveIteratorIterator::SELF_FIRST` does not stop descent when the outer `foreach` runs `continue`, so files INSIDE a hidden directory still got added because their basenames don't start with `.`.
+- **Fix**: Check every segment of the entry's forward-slashed relative path. Applied to both `append_dir_to_zip()` and `estimate_tree_size()`. Two small helpers extracted (`normalize_relative()`, `has_hidden_segment()`), mirroring the pattern used by the reference `download-plugin/app/Plugins/Base.php`.
+- **Migration**: Users who called `zip-create` with `include_hidden=false` on 0.0.9 against source trees containing hidden directories should regenerate those archives.

--- a/specs/041-backup-restore-abilities-and-updates/tasks.md
+++ b/specs/041-backup-restore-abilities-and-updates/tasks.md
@@ -1,0 +1,102 @@
+---
+
+description: "Task list for Feature 041 — Backup/restore abilities + plugin/theme update"
+---
+
+# Tasks: Feature 041
+
+**Input**: Design documents from `/specs/041-backup-restore-abilities-and-updates/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [memory-synthesis.md](./memory-synthesis.md), [security-constraints.md](./security-constraints.md), [architecture-review.md](./architecture-review.md)
+**Backfilled**: All tasks completed at implementation time; this file is the post-implementation record.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Parallelizable (different files, no dependencies)
+- **[Story]**: US1 (cross-site backup/restore) / US2 (plugin/theme update) / US3 (backup dir hygiene)
+
+---
+
+## Phase 1: Setup
+
+- [x] T001 Cut feature branch `041-backup-restore-abilities-and-updates` from `main` at `6f69b57`.
+
+---
+
+## Phase 2: Shared utilities (unblocks every ability)
+
+- [x] T002 Create `includes/Abilities/Utilities/Backups_Storage.php` — bootstraps `acrossai-backups/` + `acrossai-staging/` with hardening files, generates random filenames (`backup-{type}-{slug}-{12-random-chars}.zip`), exposes `resolve_managed_path()` / `list_entries()` / `sha256_of()` / `url_for()` / `to_abspath_relative()`. `.htaccess` blocks PHP execution but allows `.zip` downloads.
+- [x] T003 Create `includes/Abilities/Utilities/Zip_Target_Resolver.php` — 5 supported types (`TYPE_PLUGIN`, `TYPE_THEME`, `TYPE_UPLOADS`, `TYPE_MU_PLUGINS`, `TYPE_PATH`). Plugin resolution via `Plugin_Helpers`; theme via `Theme_Helpers`; `path` type applies the same `realpath()`-inside-ABSPATH check File_Read.php uses.
+
+---
+
+## Phase 3: US1 — Cross-site backup / restore (Priority: P1)
+
+- [x] T004 [US1] Create `includes/Abilities/FileManager/Zip_Create.php` — `ZipArchive::CREATE|OVERWRITE`, `RecursiveIteratorIterator` + SELF_FIRST, size-cap filter (default 512 MB). Returns `file_path`, `file_url`, `size`, `sha256`, `message`.
+- [x] T005 [US1] Create `includes/Abilities/FileManager/Zip_Upload.php` — three input modes (base64 / URL / chunked). Chunked mode reuses `Upload_Media`'s staging + TTL cleanup shape but finalizes into `acrossai-backups/`. Magic-byte check on finalize. Own sweeper cron `acrossai_abilities_manager_zip_upload_sweep_chunks`.
+- [x] T006 [US1] Create `includes/Abilities/FileManager/Zip_Extract.php` — audits every zip entry for `..`, absolute paths, backslashes, null bytes BEFORE extraction. Uses `unzip_file()` by default; `overwrite=true` drops to `ZipArchive::extractTo`. Guards on `File_Mods_Guard::blocked_response('install')`.
+
+---
+
+## Phase 4: US3 — Backup dir hygiene (Priority: P3)
+
+- [x] T007 [US3] Create `includes/Abilities/FileManager/Zip_Download.php` — read-only, returns URL + `size` + `sha256` + `created_at` for any file inside the managed dirs.
+- [x] T008 [US3] Create `includes/Abilities/FileManager/Zip_List.php` — paginated (`limit` 1–200, default 50; `offset` ≥ 0), newest first. Selectable `dir ∈ {backups, staging}`.
+- [x] T009 [US3] Create `includes/Abilities/FileManager/Zip_Delete.php` — idempotent (missing file → success with note). Guards on `File_Mods_Guard`.
+
+---
+
+## Phase 5: US2 — Plugin / theme update (Priority: P2)
+
+- [x] T010 [US2] Create `includes/Abilities/Plugins/Plugin_Update.php` — wraps `Plugin_Upgrader::bulk_upgrade()`. Accepts plugin files or bare slugs (resolved via `Plugin_Helpers`). Additional cap `update_plugins`. Guards on `File_Mods_Guard`.
+- [x] T011 [US2] Create `includes/Abilities/Themes/Theme_Update.php` — wraps `Theme_Upgrader::bulk_upgrade()`. Accepts stylesheets or theme names (resolved via `Theme_Helpers`). Additional cap `update_themes`. Guards on `File_Mods_Guard`.
+
+---
+
+## Phase 6: Bootstrap wiring + tests
+
+- [x] T012 Wire eight new abilities into `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap::register_abilities()`. Add Zip_Upload sweeper cron next to the existing Upload_Media sweeper.
+- [x] T013 Create `tests/phpunit/abilities/Test_Feature_041_Backup_Abilities.php` — 14 source-inspection tests covering Ability_Definition extends, full args shape, rebranded slugs/categories, permission gates (manage_options everywhere; update_plugins / update_themes extras on the two update abilities), `File_Mods_Guard` on every mutating ability, Zip_Extract zip-slip audit, Zip_Upload magic-byte check, bootstrap instantiation of every new class + sweeper registration, and the utility surface (Backups_Storage constants + helpers, hardening allows `.zip` downloads, Zip_Target_Resolver enumerates the five types with an ABSPATH boundary check).
+- [x] T014 Register new suite in `phpunit.xml.dist` as `feature-041-unit`.
+
+**Commit 1**: `acf5551 Feature 041 — Backup/restore abilities + plugin/theme update` (13 files, +3610)
+
+---
+
+## Phase 7: Quality gates
+
+- [x] T015 `composer run phpstan` (level 8) — zero errors
+- [x] T016 `composer run phpcs` — zero errors
+- [x] T017 `composer test` — 143 tests, 466 assertions, all pass
+
+---
+
+## Phase 8: Ship 0.0.9
+
+- [x] T018 Open PR #71 (feature branch → main). Merged as `dc49548`.
+- [x] T019 Cut `release-0.0.9` branch with version bump across `acrossai-abilities-manager.php` `Version:` header, `includes/Main.php` `ACROSSAI_ABILITIES_MANAGER_VERSION` constant, `README.txt` `Stable tag`. Add Changelog + Upgrade Notice entries.
+- [x] T020 Open PR #72 (release-0.0.9 → main). Merged as `b0a21d5`.
+- [x] T021 Tag `0.0.9`, cut GitHub release.
+
+**Commit 2**: `1bef861 Release 0.0.9 — bump version + changelog for Feature 041`
+
+---
+
+## Fixes
+
+### F1 — 0.0.10 fix for `include_hidden=false` recursive descent (2026-07-18)
+
+**Bug**: `RecursiveIteratorIterator::SELF_FIRST` does not stop descent when the outer `foreach` runs `continue` on a hidden entry — so files INSIDE a hidden directory (`.git/objects/xxx`) still landed in the archive because their basenames don't start with `.`. Only the top-level hidden directory entry was skipped.
+
+**Fix pattern**: Study reference plugin `download-plugin/app/Plugins/Base.php:282` which checks every path segment. Apply the same per-segment check.
+
+- [x] F1a Fix `Zip_Create::append_dir_to_zip()` and `estimate_tree_size()` — check EVERY segment of the entry's forward-slashed relative path.
+- [x] F1b Extract two small helpers: `normalize_relative()` (absolute pathname → forward-slashed relative path) and `has_hidden_segment()` (per-segment `.`-prefix check).
+- [x] F1c Add regression test `test_zip_create_skips_hidden_at_every_segment` to `Test_Feature_041_Backup_Abilities.php` (15 tests / 154 assertions).
+- [x] F1d Quality gates: phpstan L8 zero, phpcs zero, phpunit 144 tests / 468 assertions.
+- [x] F1e Open PR #73 (fix branch → main). Merged as `0e1a177`.
+- [x] F1f Cut `release-0.0.10` branch with version bump + 0.0.10 Changelog + Upgrade Notice entries.
+- [x] F1g Open PR #74 (release-0.0.10 → main). Merged as `0e8e03b`.
+- [x] F1h Tag `0.0.10`, cut GitHub release.
+
+**Commit 3**: `910d38c Feature 041 fix — Zip_Create honours include_hidden=false recursively`
+**Commit 4**: `f1f0d68 Release 0.0.10 — bump version + changelog for Feature 041 fix`

--- a/specs/042-core-category-and-wp-core-update/architecture-review.md
+++ b/specs/042-core-category-and-wp-core-update/architecture-review.md
@@ -1,0 +1,62 @@
+# Architecture Review: Feature 042
+
+**Feature**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+
+## Verdict
+
+**PASS** — no violations of Constitution §I (Modular Architecture), §V (Extensibility Without Core Modification), or §VI (DRY / Utilities). No new module. One new Category folder (`Core/`) joins the existing 17 as a sub-partition of the Custom Ability Registration module. Two new abilities auto-register via the existing `Ability_Definition` filter; bootstrap wiring is three lines of literal add-lines (one Category_Registrar callback + two `new Core\…()` instantiations) matching the pattern every other absorbed ability uses. No custom HTTP or updater code.
+
+## Module Enumeration (§I)
+
+Constitution §I locks the module list at 5. Feature 042 confirms no new module was added:
+
+| Module | Touched? | Notes |
+| --- | --- | --- |
+| Per-User Access Control | No | Access-control code untouched. |
+| MCP Server Management | No | MCP surface untouched. |
+| Custom Ability Registration | Yes (extended) | New `Core/` Category folder joins the existing 17 sub-partitions. Two new abilities inside. |
+| WebMCP Integration | No | WebMCP surface untouched. |
+| AbilityAPI Registration Management | No | Registration mechanism unchanged; new abilities self-register via `Ability_Definition::__construct`. |
+
+## Category Folders
+
+Feature 042 creates ONE new Category folder — `includes/Abilities/Core/` — bringing the count from 17 to 18. Every existing Category folder shares the same three-file shape (Category_Registrar + one or more ability classes). The Core folder mirrors that shape exactly.
+
+## Utility Placement (§VI)
+
+Feature 042 does NOT add any new utility class. `Backups_Storage::random_backup_filename()` gets two new private helpers (`filename_slug_segment()`, `filename_time_segments()`) inside the same file — private-method extraction to keep the public method readable. Not a shared-utility introduction under Constitution §VI.
+
+## Ability_Definition Base Class
+
+Unchanged. Both new abilities subclass it; both implement `ability(): array` and `execute(array $input): array`. Constructor auto-hooks `acrossai_abilities_api_init` via the base class.
+
+## Bootstrap Wiring
+
+`AcrossAI_Core_Abilities_Bootstrap::register_category_callbacks()` grew by ONE line — the new Core Category_Registrar registration. `register_abilities()` grew by TWO `new Core\…()` lines. All three edits sit next to the existing SiteHealth entries (bottom of each list) to preserve the visual ordering that mirrors Category-folder-ordering.
+
+## Boot Flow Rule (§I AC-HOOKS-MAIN)
+
+`includes/Main.php::define_public_hooks()` already wires the bootstrap via a named variable. No changes to `Main.php` needed. Every `add_action` still traces back to `Main.php` on a named variable.
+
+## Extensibility Contracts (§V)
+
+None claimed by Feature 042. The four extensibility hooks (`wp_before_execute_ability`, `wp_after_execute_ability`, `wp_register_ability_args`, `mcp_adapter_pre_tool_call`) remain unclaimed.
+
+## DataForm / DataViews (§III)
+
+No new admin UI added by Feature 042. Both new abilities render through the existing Library page's React components. No bypass, no violation.
+
+## Composer / Dependency (§II)
+
+No new composer requires. All work uses PHP built-ins (`microtime`, `str_pad`, `floor`) and WordPress core (`get_core_updates`, `find_core_update`, `Core_Upgrader`, `WP_Ajax_Upgrader_Skin`, `get_bloginfo`, `get_locale`, `is_multisite`, `current_user_can`, `sanitize_text_field`, `sanitize_key`). Zero third-party libs.
+
+## Spec-Kit Backfill Impact
+
+Feature 042 also authors the backfilled `specs/041-backup-restore-abilities-and-updates/` folder documenting the already-shipped Feature 041 + the 0.0.10 fix. This is a documentation-only backfill inside `specs/`; it does NOT modify any Feature 041 shipped code and is not a re-open of Feature 041's contract.
+
+## Follow-up (out of scope for 042)
+
+- Fixing the mojibake `â` character in all 18 Category_Registrar labels (must be done uniformly across the codebase in a separate cosmetic feature).
+- Adding a network-wide core-upgrade ability for multisite (out of scope per spec.md).
+- Adding a `Wp_Core_Downgrade` ability (WP core has no `Downgrader`; would need a bespoke implementation with different security posture).

--- a/specs/042-core-category-and-wp-core-update/checklists/requirements.md
+++ b/specs/042-core-category-and-wp-core-update/checklists/requirements.md
@@ -1,0 +1,46 @@
+# Specification Quality Checklist: Feature 042
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-07-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details in the spec's User Stories / FRs / SCs (implementation lives in plan.md)
+- [x] Focused on user value (close the core-update loop; readable/sortable backup filenames)
+- [x] Written for non-technical stakeholders in the user-story sections; FR/SC sections technical-but-testable
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable (SC-042-003 quotes a regex; SC-042-002 quotes target test/assertion counts)
+- [x] Success criteria are technology-agnostic in intent (SC-042-001 references user-visible "Core tab")
+- [x] All acceptance scenarios are defined
+- [x] Edge cases identified (invalid version pin, no update available, DISALLOW_FILE_MODS lockdown, multisite guard, sub-second collision on filenames)
+- [x] Scope is clearly bounded (downgrade path OUT; network bulk upgrade OUT; full-site backup OUT)
+- [x] Dependencies + assumptions identified (WP core `Core_Upgrader` present; PHP 8.1+; `microtime(true)` available)
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows (2 stories at P1/P2)
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Anti-drift checklist (per user directive "check first how the other abilites are writtin and follow the same patterns")
+
+- [x] `Wp_Core_Update_Check` shape mirrors `Plugins/Update_Check.php` (namespace, use ordering, `defined( 'ABSPATH' ) || exit;`, class docblock, `ability()` array key order, `meta.acrossai` block layout)
+- [x] `Wp_Core_Update` shape mirrors `Plugins/Plugin_Update.php` / `Themes/Theme_Update.php` (same result-interpretation ladder: `WP_Error` → failure with message; `null`/`false` → skin errors; anything else → success)
+- [x] `Core/Category_Registrar.php` mirrors `FileManager/Category_Registrar.php` (final singleton, `register()` method calling `wp_register_ability_category()`, mojibake `â` label preserved)
+- [x] `File_Mods_Guard::blocked_response('install')` invoked before any file mods (identical to `Plugin_Update` / `Theme_Update` / `Zip_Extract`)
+- [x] Both new abilities use the same `manage_options` baseline; `Wp_Core_Update` additionally requires `update_core` (matching the `update_plugins` / `update_themes` pattern of the existing update abilities)
+
+## Quality Gates
+
+- [ ] PHPCS strict (WPCS) — zero errors on all Feature 042 files (to be verified at implementation gate)
+- [ ] PHPStan L8 — zero errors (to be verified)
+- [ ] PHPUnit — 9 new tests pass; full suite green (to be verified)
+- [ ] Manual e2e: Core tab appears; filename shape verified via regex
+- [ ] `DISALLOW_FILE_MODS` short-circuit verified on `Wp_Core_Update`

--- a/specs/042-core-category-and-wp-core-update/memory-synthesis.md
+++ b/specs/042-core-category-and-wp-core-update/memory-synthesis.md
@@ -1,0 +1,51 @@
+# Memory Synthesis: Feature 042
+
+**Feature**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+
+## Current Scope
+
+Adds a new `Core` Category folder under `includes/Abilities/Core/` with a `Category_Registrar.php` (slug `acrossai-abilities-manager-core`) and two abilities: `wp-core-update-check` (read-only availability report) and `wp-core-update` (applies the update via `Core_Upgrader::upgrade()`). Rewrites `Backups_Storage::random_backup_filename()` to emit `{slug}-{unix-timestamp}-{ms}.zip` instead of the 0.0.9 `backup-{type}-{slug}-{random}.zip` scheme. Wires the new Category + abilities into `AcrossAI_Core_Abilities_Bootstrap`. Adds `Test_Feature_042_Core_Update.php` (9 source-inspection tests). No new REST endpoints, no new database tables, no composer changes. Target release: 0.0.11.
+
+## Relevant Decisions
+
+- **DEC-042-CORE-CATEGORY-NEW-FOLDER** (New: A new Category folder is added under `includes/Abilities/` — the 18th, joining Plugins / Themes / FileManager / Cache / Database / Users / Block / Settings / Fonts / Content / Taxonomies / Media / Comments / Menus / Options / Cron / SiteHealth. This is NOT a new module — Constitution §I locks the module list at 5; Category folders are the sub-partition of the existing Custom Ability Registration module. Justification: the WP core surface is a natural grouping and gives future core-scoped abilities a home. Status: Active, Source: this spec)
+- **DEC-042-FILENAME-TIME-BASED** (New: Backup filenames switch from random-suffix to time-based (`{slug}-{unix}-{ms}.zip`). Trade-off: gains human-readability + lexicographic-sort = chronological-sort; loses enumeration-by-guessing defense. Mitigations retained: directory listing disabled, PHP execution blocked, `manage_options` gate on list/download. User-approved after explicit clarification. Status: Active, Source: this spec)
+- **DEC-042-WP-CORE-ONLY** (New: The `wp-core-update` ability wraps `Core_Upgrader::upgrade()` exclusively — no custom HTTP fetch, no custom integrity verification, no bundled updater code. All upgrade infrastructure is WP core's responsibility. Motivated by user directive: "make sure to use the wordpress functions only for the core". Status: Active, Source: this spec)
+- **DEC-042-FIX-SPEC-KIT-BACKFILL** (New: Feature 041 gets a full spec-kit folder backfilled in the same round as Feature 042 (rather than a fix-only spec folder or forward-only). Matches the Feature 053 backfill precedent already in `git log`. The 0.0.10 fix is documented as a `Fixes` section inside Feature 041's spec + tasks, not a separate spec folder. Status: Active, Source: this spec Clarifications)
+
+## Active Architecture Constraints
+
+- **AC-HOOKS-MAIN** (Reason: Both new abilities auto-register via `Ability_Definition::__construct` on the `acrossai_abilities_api_init` filter. Bootstrap wiring is in `AcrossAI_Core_Abilities_Bootstrap::register_abilities()` — called from `Main.php::define_public_hooks()`. Boot Flow Rule literalism preserved. Source: CONSTITUTION.md §I)
+- **AC-MODULE-ENUMERATION-LOCKED** (Reason: No new module. `Core` is a new Category folder inside the existing Abilities module — same sub-partitioning strategy used for the other 17 Category folders. Source: CONSTITUTION.md §I)
+- **AC-CAPABILITY-BASELINE** (Reason: `Wp_Core_Update` enforces both `manage_options` AND `update_core` — matches WP core's own admin gate for core upgrades. Source: CONSTITUTION.md §IV)
+- **AC-FILE-MODS-GUARD** (Reason: `Wp_Core_Update` short-circuits via `File_Mods_Guard::blocked_response('install')` before any upgrade work. Source: CONSTITUTION.md §IV)
+- **AC-PATTERN-PARITY** (Reason: New ability classes match the exact shape used by `Plugins/Update_Check.php` / `Plugins/Plugin_Update.php` / `Themes/Theme_Update.php` — no creative shape drift, per explicit user directive. Source: this spec)
+
+## Accepted Deviations
+
+- **DEV-042-MOJIBAKE-LABEL** (Reason: The new `Core/Category_Registrar.php` label preserves the mojibake `â` character (should be `–` en-dash). All 17 existing Category_Registrar labels have the same encoding artifact — matching the pattern is more valuable than fixing this one instance. If fixed anywhere, must be fixed everywhere as a separate feature. Status: Accepted-Deviation, Source: this spec)
+
+## Relevant Security Constraints
+
+See [security-constraints.md](./security-constraints.md). Nine constraints in force:
+
+- C-042-SEC-01 through C-042-SEC-09 (both-cap gate, File_Mods_Guard, multisite guard, no custom HTTP, read-only check ability, sanitized version+locale inputs, filename trade-off acceptance, no shell, filename slug sanitization).
+
+Per `feedback_skip_permission_callback_audit` in memory, a full REST-layer permission_callback audit is out of scope; each ability's `permission_callback` is inspected by the source-scan test suite.
+
+## Related Historical Lessons
+
+- **BUG-041-02 — SELF_FIRST does not stop descent on `continue`** (Reason: Not exercised by Feature 042. `Wp_Core_Update` does not iterate directories. The 0.0.10 fix stays in force and documented in Feature 041's memory-synthesis. Source: Feature 041 memory-synthesis)
+- **BUG-041-01 — Global Deny in .htaccess breaks download URL** (Reason: Not exercised by Feature 042 — the `.htaccess` in `Backups_Storage::resolve_dir()` is unchanged. The `Options -Indexes` + PHP-family FilesMatch pattern remains the mitigation for the filename-scheme trade-off. Source: Feature 041 memory-synthesis)
+- **NEW BUG-042-01 — Sub-second filename collision on concurrent zip-create** (Reason: The 0.0.9 filename scheme used `wp_generate_password(12, false)` which is collision-resistant enough that concurrent same-target calls produced distinct filenames. The Feature 042 time-based scheme could collide if two calls hit within the same second — mitigated by the 3-digit `ms` suffix from `microtime(true)`. Test `test_filename_scheme_uses_slug_unix_ms` asserts the `ms` suffix is present. Source: this spec)
+
+## Conflict Warnings
+
+None. `DEC-042-FILENAME-TIME-BASED` supersedes the enumeration-defense corollary of Feature 041's `DEC-BACKUP-URL-RETURN`; the URL-return contract itself is unchanged.
+
+## Retrieval Notes
+
+- Optimizer not enabled — markdown-only, index-first retrieval used.
+- Read references at planning time: reference `Plugins/Update_Check.php` for `get_core_updates()` shape; `Plugins/Plugin_Update.php` + `Themes/Theme_Update.php` for the result-interpretation ladder; `FileManager/Category_Registrar.php` for the Category_Registrar template; WP core `Core_Upgrader`, `WP_Ajax_Upgrader_Skin`; existing utilities `Backups_Storage`, `File_Mods_Guard`.
+- Full durable-memory reads: NOT performed. Budget status: within limits (~750 words, under the 900-word cap).

--- a/specs/042-core-category-and-wp-core-update/plan.md
+++ b/specs/042-core-category-and-wp-core-update/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: Feature 042
+
+**Feature Branch**: `042-core-category-and-wp-core-update`
+**Base**: `main` at `0e8e03b` (release 0.0.10)
+**Target release**: 0.0.11
+
+## Approach
+
+Additive: no changes to existing modules or contracts. New Category folder + two new abilities + a filename-helper diff. Both new abilities model directly on existing plugin/theme lifecycle abilities so future maintainers instantly recognize the shape.
+
+## New files
+
+### Core category
+
+- `includes/Abilities/Core/Category_Registrar.php` — final singleton mirroring `FileManager/Category_Registrar.php`. Slug `acrossai-abilities-manager-core`, label preserves the mojibake `â` character to match the existing 17 Category_Registrar labels (this is a legacy encoding artifact across the whole codebase; not fixing it in this feature to stay pattern-consistent).
+- `includes/Abilities/Core/Wp_Core_Update_Check.php` — read-only. Modelled on `Plugins/Update_Check.php` (which already invokes `get_core_updates()` for its `core` sub-object). Empty input schema. Output flattens the WP offer object into JSON-friendly fields.
+- `includes/Abilities/Core/Wp_Core_Update.php` — modelled on `Plugins/Plugin_Update.php` and `Themes/Theme_Update.php`. Wraps `Core_Upgrader::upgrade()`. Optional `version` (+ optional `locale`) inputs; when omitted, uses the first `response=upgrade` offer.
+
+### Tests
+
+- `tests/phpunit/abilities/Test_Feature_042_Core_Update.php` — nine source-inspection tests covering: filename scheme (drop `backup-` prefix + 12-char random suffix, add microtime + ms + slug/unix/ms concatenation + ultimate slug fallback), Core Category_Registrar shape, Wp_Core_Update_Check shape + read-only annotations, Wp_Core_Update guards (`Core_Upgrader`, `File_Mods_Guard`, multisite guard, `WP_Ajax_Upgrader_Skin`), permission_callback ANDing `manage_options` with `update_core`, optional `version` + `locale` inputs, and bootstrap wiring.
+
+## Modified files
+
+- `includes/Abilities/Utilities/Backups_Storage.php` — replace `random_backup_filename()` body with the `{slug}-{unix}-{ms}.zip` scheme. Signature unchanged. Extract two tiny helpers (`filename_slug_segment()`, `filename_time_segments()`) for readability.
+- `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php` — add 1 line to `register_category_callbacks()` for the new Category_Registrar, add 2 `new Core\…()` lines to `register_abilities()`.
+- `phpunit.xml.dist` — new `feature-042-unit` testsuite.
+
+## Reusables
+
+- **`Ability_Definition`** (`includes/Modules/Library/Ability_Definition.php`) — both new abilities extend it; constructor auto-hooks the filter.
+- **`File_Mods_Guard`** (`includes/Abilities/Utilities/File_Mods_Guard.php`) — `Wp_Core_Update` guards on `blocked_response('install')`.
+- **`Plugins/Update_Check.php`** — reference for the `get_core_updates()` shape mapping. Feature 042's `Wp_Core_Update_Check` output is a superset of the `core` sub-object `Update_Check` already exposes.
+- **`Plugins/Plugin_Update.php` + `Themes/Theme_Update.php`** — reference for the `Plugin_Upgrader::bulk_upgrade()` result-interpretation shape. `Core_Upgrader::upgrade()` returns the same `true | WP_Error | false | null` union; the result-interpretation ladder is identical.
+- **WP core**: `get_core_updates()`, `find_core_update()`, `Core_Upgrader`, `WP_Ajax_Upgrader_Skin`, `get_bloginfo('version')`, `get_locale()`, `microtime(true)`, `sanitize_key()`, `sanitize_text_field()`. No third-party libs.
+
+## WP core update flow (mirrors wp-admin/update-core.php)
+
+```
+require_once ABSPATH . 'wp-admin/includes/update.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+require_once ABSPATH . 'wp-admin/includes/misc.php';
+
+$from_version = (string) get_bloginfo('version');
+
+$update = ! empty($input['version'])
+    ? find_core_update( $version, '' !== $locale ? $locale : get_locale() )
+    : ( get_core_updates()[0] ?? null );
+
+// null / false / response !== 'upgrade' → return clean no-op envelope
+
+$skin     = new \WP_Ajax_Upgrader_Skin();
+$upgrader = new \Core_Upgrader( $skin );
+$result   = $upgrader->upgrade( $update );
+
+$to_version = (string) get_bloginfo('version');
+// interpret $result identically to Plugin_Update / Theme_Update
+```
+
+## Security constraints
+
+See [security-constraints.md](./security-constraints.md).
+
+## Verification
+
+- `composer run phpstan` (level 8) — zero errors
+- `composer run phpcs` — zero errors
+- `composer test` — full suite green (target: 153 tests / 504 assertions)
+- Manual e2e: Core tab visible in Library UI; `wp-core-update-check` returns available/new_version fields; `wp-core-update` upgrades a version-pinned Local site; `zip-create` returns the new `{slug}-{unix}-{ms}.zip` filename shape.
+- Post-implementation: run `/speckit.memory-md.capture-from-diff` to harvest durable memory entries from the diff.
+
+## Ship
+
+Two PRs on merge, following the 041 → 0.0.9/0.0.10 cadence:
+
+1. **Feature PR** on branch `042-core-category-and-wp-core-update` → `main`. Ships the specs backfill + code + tests.
+2. **Release PR** on branch `release-0.0.11` → `main`. Version bump + Changelog + Upgrade Notice.
+
+Then tag `0.0.11` and cut GitHub release.

--- a/specs/042-core-category-and-wp-core-update/security-constraints.md
+++ b/specs/042-core-category-and-wp-core-update/security-constraints.md
@@ -1,0 +1,52 @@
+# Security Constraints: Feature 042
+
+**Feature**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+
+## Threat Model Summary
+
+Feature 042 adds a WordPress-core-upgrade path through the Abilities API and changes the backup filename scheme. Primary threats: (1) unauthorized core upgrade / downgrade / lateral pin to a vulnerable version, (2) core upgrade during `DISALLOW_FILE_MODS` lockdown, (3) upgrade attempted on multisite without network privileges, (4) predictable backup filenames enabling enumeration-by-guessing.
+
+## Constraints (enforced by shipped code)
+
+### C-042-SEC-01 — Both-capability gate on `Wp_Core_Update`
+
+`permission_callback` requires `current_user_can('manage_options') && current_user_can('update_core')`. Both must return true; `manage_options` alone is insufficient. Matches WP core's own admin gate for the "Update WordPress" screen.
+
+### C-042-SEC-02 — File_Mods_Guard on `Wp_Core_Update`
+
+`Wp_Core_Update::execute()` calls `File_Mods_Guard::blocked_response('install')` before any upgrade work. When `DISALLOW_FILE_MODS` is true, the ability returns the standard `{success:false, message:"…"}` envelope and does NOT invoke `Core_Upgrader`.
+
+### C-042-SEC-03 — Multisite guard
+
+`Wp_Core_Update::execute()` bails cleanly with `is_multisite() && ! current_user_can('update_core')` — matches WP core's `admin_page_access_denied()` path in wp-admin/update-core.php. Prevents non-super-admins from triggering a network-wide core upgrade.
+
+### C-042-SEC-04 — No custom HTTP fetch, no custom integrity checks
+
+`Wp_Core_Update` calls `Core_Upgrader::upgrade($update)` exclusively. The `$update` object comes from `get_core_updates()` / `find_core_update()`; both are WP core functions that read from the existing `update_core` transient (populated by WP's own update-check cron, which fetches from `api.wordpress.org` over HTTPS with core's built-in integrity verification). Feature 042 adds ZERO custom HTTP requests and ZERO custom cryptographic verification code.
+
+### C-042-SEC-05 — `Wp_Core_Update_Check` is read-only
+
+`Wp_Core_Update_Check::execute()` does not write to disk, does not modify options, does not touch the plugin/theme registries. Requires only `manage_options` (no `update_core`). Safe to call from any authenticated admin context.
+
+### C-042-SEC-06 — Version + locale inputs sanitized
+
+Both `version` and `locale` inputs pass through `sanitize_text_field()` before use. `find_core_update()` itself validates the version string against the offers WP core received from its update check; garbage input returns `null` and the ability returns a clean "No core update offer found for version …" envelope.
+
+### C-042-SEC-07 — Filename scheme trade-off explicitly accepted
+
+`{slug}-{unix}-{ms}.zip` filenames are predictable given a target + rough time of creation. This removes the enumeration-by-guessing defense the 12-char random suffix provided. Mitigations still in force:
+
+- `Options -Indexes` in `Backups_Storage`'s `.htaccess` — directory listing is blocked.
+- `FilesMatch` deny for PHP-family extensions — even if a filename is guessed and the file downloaded, it cannot execute code server-side.
+- `manage_options` capability gate on `zip-list` and `zip-download` — programmatic enumeration through the abilities API requires an admin session.
+
+Accepted per user direction (see [Clarifications in spec.md](./spec.md#clarifications)).
+
+### C-042-SEC-08 — No shell execution
+
+Feature 042 uses no `shell_exec` / `exec` / `system` / `proc_*` / backtick operators. All work is WP core PHP APIs.
+
+### C-042-SEC-09 — Filename slug segment sanitized
+
+`Backups_Storage::filename_slug_segment()` runs both `str_replace(['/','\\','.'], '-', $target)` AND `sanitize_key()` before returning. No path-separator smuggling through the slug. Falls back through `target_type` → literal `'backup'` so the filename never becomes just `-{ts}.zip`.

--- a/specs/042-core-category-and-wp-core-update/spec.md
+++ b/specs/042-core-category-and-wp-core-update/spec.md
@@ -1,0 +1,80 @@
+# Feature Specification: Core category (WP core update abilities) + backup filename scheme
+
+**Feature Branch**: `042-core-category-and-wp-core-update`
+**Created**: 2026-07-18
+**Status**: Draft
+**Input**: User description: "when zip is getting create make sure to name the same as slug-strtotime.zip and also creat a new abilitest what can check for wordpress update and if possible udpate wordpress abilites too make sure to use the wordpress functions only for the core create a new tab call Core and also a new caterioures with new folder name as core here /Users/…/includes/Abilities"
+
+## Clarifications
+
+### Session 2026-07-18
+
+- Q: Two backups of the same target created in the same second would collide with a pure `{slug}-{unix-timestamp}.zip` scheme (second overwrites first) — how to guard? → A: Append microtime — `{slug}-{unix}-{ms}.zip`. Keeps the timestamp-based naming; adds three digits of milliseconds so back-to-back calls produce distinct filenames.
+- Q: What update flow should the new WP core update ability follow? → A: Both — default to latest, allow version override. Optional `version` (+ optional `locale`) input; when omitted, upgrades to the first `response=upgrade` offer from `get_core_updates()`.
+- Q: Spec-kit backfill scope for Feature 041 + the 0.0.10 fix? → A: Full backfill: create `specs/041-backup-restore-abilities-and-updates/` with the whole artifact set; the 0.0.10 fix becomes a `Fixes` section inside 041's spec + tasks.
+- Q: Feature number for this new work? → A: 042 — next sequential (fills the gap; 041 gets its backfilled folder in the same round).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — WordPress core update through the Abilities API (Priority: P1)
+
+An administrator (or an AI / MCP client the admin has authorized) wants to apply a pending WordPress core update without leaving the abilities surface. `wp-core-update-check` reports whether an upgrade offer exists. `wp-core-update` applies the offer via WP core's `Core_Upgrader::upgrade()` — the same class the built-in WP dashboard uses. No `version` argument = update to latest offer; supplying `version` (+ optional `locale`) pins the upgrade to a specific offer via `find_core_update()`.
+
+**Why this priority**: The absorbed inventory has no ability that actually **applies** a core update. `Plugins/Update_Check` reports availability across core + plugins + themes but stops at "here's what's available". This closes the loop.
+
+**Independent Test**: On a site pinned to an older WP version, `wp-core-update-check` returns `available=true` with a populated `new_version` + `download` URL. Calling `wp-core-update` (no args) upgrades the site; `get_bloginfo('version')` after the call reflects the new version. Re-calling `wp-core-update` on the now-upgraded site returns `updated=false` with a clean "no core update available" envelope.
+
+**Acceptance Scenarios**:
+
+1. **Given** a site running WordPress N-1, **When** `wp-core-update-check {}` is called, **Then** the response includes `success=true`, `available=true`, `current_version` (N-1), `new_version` (N), and non-empty `download` URL.
+2. **Given** the same site, **When** `wp-core-update {}` is called, **Then** WordPress upgrades to N, `updated=true`, `from_version=N-1`, `to_version=N`.
+3. **Given** the site is now on the latest version, **When** `wp-core-update {}` is re-called, **Then** the response is `{success:true, updated:false, from_version:N, to_version:N, message:"No core update available."}`.
+4. **Given** `wp-core-update {"version": "99.99.99"}` (nonexistent) is called, **Then** the response is a clean error naming the requested version, no partial update occurs.
+5. **Given** `DISALLOW_FILE_MODS=true` in wp-config, **When** `wp-core-update {}` is called, **Then** the response is the standard `File_Mods_Guard` envelope (`success=false, message="File modifications are disabled…"`).
+
+### User Story 2 — Time-sortable / human-readable backup filenames (Priority: P2)
+
+The admin browsing `wp-content/uploads/acrossai-backups/` sees filenames like `hello-dolly-1721260800-517.zip` instead of `backup-plugin-hello-dolly-abcXYZ12dEfG.zip`. They can:
+
+- Read what target the backup was of at a glance (`hello-dolly`, `uploads`, `mu-plugins`).
+- Sort by filename lexicographically to sort by creation time.
+- Know that two back-to-back calls in the same second don't collide (the `-517` millisecond suffix guarantees uniqueness within a second per target).
+
+**Why this priority**: Feature 041 chose `{random-12-chars}` for enumeration defense. The tradeoff is worth revisiting: directory listing is disabled by `.htaccess` on the backups dir, so enumeration-by-listing is already blocked. Enumeration-by-guessing remains a theoretical concern, accepted per the user request.
+
+**Independent Test**: Call `zip-create {target_type:"plugin", target:"hello-dolly"}` twice back-to-back; verify (a) both files exist, (b) filenames match the shape `hello-dolly-\d{10}-\d{3}\.zip`, (c) both filenames differ (different `ms` suffix).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-042-001**: A new Category folder `includes/Abilities/Core/` MUST exist, with a `Category_Registrar.php` registering the slug `acrossai-abilities-manager-core` and label `Acrossai Abilities Manager – Core` (mojibake `â` character preserved to match the existing 17 Category_Registrar labels).
+- **FR-042-002**: A new ability `acrossai-abilities-manager/wp-core-update-check` MUST exist under the Core category, tab_group `core`, sub_group `lifecycle`. Read-only (`annotations.readonly=true`). Empty input schema. Output MUST include `current_version`, `available`, `new_version`, `locale`, `response`, `partial_version`, `download`, `php_version`, `mysql_version`, `message`.
+- **FR-042-003**: A new ability `acrossai-abilities-manager/wp-core-update` MUST exist under the Core category. Input schema accepts optional `version` (string) and optional `locale` (string); both defaulted (locale → `get_locale()`; version → first `response=upgrade` offer).
+- **FR-042-004**: `wp-core-update` MUST wrap `Core_Upgrader::upgrade()` — no bundled updater code, no custom HTTP fetch, no custom integrity verification.
+- **FR-042-005**: `wp-core-update`'s `permission_callback` MUST require BOTH `manage_options` AND `update_core`. Its `execute()` MUST additionally short-circuit via `File_Mods_Guard::blocked_response('install')` and MUST include a multisite guard (`is_multisite() && !current_user_can('update_core')` → clean error).
+- **FR-042-006**: `wp-core-update` MUST report `from_version` (before the upgrade) and `to_version` (after) using `get_bloginfo('version')`; re-running on a site with no available update MUST return `updated=false` with a clean success envelope (idempotent).
+- **FR-042-007**: `Backups_Storage::random_backup_filename()` MUST emit the filename `{slug}-{unix-timestamp}-{ms}.zip` where `{slug}` is `sanitize_key()` of `$target` (falling back to `$target_type`, ultimate fallback `backup`), `{unix-timestamp}` is `(int) floor(microtime(true))`, and `{ms}` is `(int) floor(($now - $unix) * 1000)` padded to 3 digits.
+- **FR-042-008**: Both new abilities MUST be instantiated in `AcrossAI_Core_Abilities_Bootstrap::register_abilities()` next to the existing SiteHealth abilities; the Core Category_Registrar MUST be registered in `register_category_callbacks()`.
+
+### Non-Functional Requirements
+
+- **NFR-042-001**: Both new abilities MUST match the exact class shape used by `Plugins/Update_Check` and `Plugins/Plugin_Update` (namespace, `use` ordering, `defined( 'ABSPATH' ) || exit;` line, class docblock, `ability()` array key order, `meta.acrossai` block layout). No creative shape drift.
+- **NFR-042-002**: All new code MUST pass PHPStan L8 zero errors and PHPCS strict WPCS zero errors.
+- **NFR-042-003**: Test coverage MUST use the source-inspection pattern established by Feature 046 / Feature 041 — no full WP runtime.
+
+## Success Criteria
+
+- **SC-042-001**: A new "Core" tab appears on the Ability Library page with both abilities visible under Core → Lifecycle.
+- **SC-042-002**: `composer run phpstan` zero errors at L8, `composer run phpcs` zero errors, `composer test` all pass (target: 153 tests / 504 assertions after adding 9 new 042 tests).
+- **SC-042-003**: `zip-create` against `hello-dolly` returns a `file_path` matching `wp-content/uploads/acrossai-backups/hello-dolly-\d{10}-\d{3}\.zip` with NO `backup-plugin-` prefix and NO 12-char random alphanumeric block.
+- **SC-042-004**: Two back-to-back `zip-create` calls against the same target produce two distinct filenames.
+- **SC-042-005**: `wp-core-update` on a site pinned to an older WP version upgrades to the latest and reports `updated=true` with `from_version` != `to_version`.
+- **SC-042-006**: `DISALLOW_FILE_MODS=true` short-circuits `wp-core-update` with the `File_Mods_Guard` envelope; `wp-core-update-check` still works (read-only).
+
+## Out of Scope
+
+- WP core downgrade path (upgrader class only supports upgrades; no `WP_Downgrader` in core).
+- Multisite bulk-network-upgrade path (`Core_Upgrader::upgrade()` runs on the current site; network upgrades stay a separate future ability).
+- Backup filename change to Zip_Upload's `filename_hint`-derived slugs (piggy-backs on the same helper; already covered because the helper change is internal).
+- Full-site backup ability (still per-target; deferred to a future feature).

--- a/specs/042-core-category-and-wp-core-update/tasks.md
+++ b/specs/042-core-category-and-wp-core-update/tasks.md
@@ -1,0 +1,74 @@
+---
+
+description: "Task list for Feature 042 — Core category (WP core update) + backup filename scheme change"
+---
+
+# Tasks: Feature 042
+
+**Input**: Design documents from `/specs/042-core-category-and-wp-core-update/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [memory-synthesis.md](./memory-synthesis.md), [security-constraints.md](./security-constraints.md), [architecture-review.md](./architecture-review.md)
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Parallelizable (different files, no dependencies)
+- **[Story]**: US1 (WP core update through Abilities API) / US2 (time-sortable backup filenames)
+
+---
+
+## Phase 1: Setup
+
+- [x] T001 Cut branch `042-core-category-and-wp-core-update` from `main` at `0e8e03b` (release 0.0.10).
+- [x] T002 Pattern-parity read of `Plugins/Update_Check.php`, `Plugins/Plugin_Update.php`, `Themes/Theme_Update.php`, `FileManager/Category_Registrar.php` before writing any new ability code.
+
+---
+
+## Phase 2: US2 — Backup filename scheme (Priority: P2, no runtime dependencies)
+
+- [x] T003 [US2] Rewrite `Backups_Storage::random_backup_filename()` — drop the `backup-` prefix seed and the 12-char `wp_generate_password(12, false)` random suffix; emit `{slug}-{unix-timestamp}-{ms}.zip` where `{slug}` comes from a private `filename_slug_segment()` helper (target → target_type → literal `backup`) and `{unix}` + `{ms}` come from a private `filename_time_segments()` helper reading `microtime(true)`.
+
+---
+
+## Phase 3: US1 — WP core update abilities (Priority: P1)
+
+- [x] T004 [US1] Create `includes/Abilities/Core/Category_Registrar.php` mirroring `FileManager/Category_Registrar.php`. Slug `acrossai-abilities-manager-core`, label preserves mojibake `â` character to match the 17 existing Category_Registrar labels.
+- [x] T005 [US1] Create `includes/Abilities/Core/Wp_Core_Update_Check.php` — read-only, `manage_options`-gated, wraps `get_core_updates()`. Output flattens the first offer into JSON-friendly fields.
+- [x] T006 [US1] Create `includes/Abilities/Core/Wp_Core_Update.php` — wraps `Core_Upgrader::upgrade()`. Requires BOTH `manage_options` AND `update_core`. Guards on `File_Mods_Guard::blocked_response('install')` + multisite guard. Optional `version` + `locale` inputs.
+
+---
+
+## Phase 4: Bootstrap wiring
+
+- [x] T007 Wire `Core\Category_Registrar::instance()` into `AcrossAI_Core_Abilities_Bootstrap::register_category_callbacks()`.
+- [x] T008 Add `new Core\Wp_Core_Update_Check();` and `new Core\Wp_Core_Update();` to `AcrossAI_Core_Abilities_Bootstrap::register_abilities()` next to the existing SiteHealth abilities.
+
+---
+
+## Phase 5: Tests
+
+- [x] T009 Create `tests/phpunit/abilities/Test_Feature_042_Core_Update.php` — 9 source-inspection tests: filename scheme drops old prefix + suffix, uses slug+unix+ms, has ultimate fallback; Core Category_Registrar shape; Wp_Core_Update_Check shape + read-only annotation; Wp_Core_Update guards (Core_Upgrader / File_Mods_Guard / multisite guard / WP_Ajax_Upgrader_Skin); permission_callback ANDs manage_options with update_core; optional version + locale accepted; bootstrap wires category + both abilities.
+- [x] T010 Register `feature-042-unit` testsuite in `phpunit.xml.dist`.
+
+---
+
+## Phase 6: Quality gates
+
+- [ ] T011 `composer run phpstan` (level 8) — zero errors
+- [ ] T012 `composer run phpcs` — zero errors
+- [ ] T013 `composer test` — full suite green (target: 153 tests / 504 assertions after 9 new 042 tests)
+
+---
+
+## Phase 7: Spec-kit artifacts
+
+- [x] T014 Backfill Feature 041 spec-kit folder at `specs/041-backup-restore-abilities-and-updates/` (7 files: spec / plan / tasks / checklists/requirements / security-constraints / memory-synthesis / architecture-review). Fixes section in spec + tasks documents the 0.0.10 include_hidden fix.
+- [x] T015 Author Feature 042 spec-kit folder at `specs/042-core-category-and-wp-core-update/` (7 files).
+
+---
+
+## Phase 8: Ship 0.0.11
+
+- [ ] T016 Open feature PR (042 branch → main). Merge.
+- [ ] T017 Cut `release-0.0.11` branch with version bump across `acrossai-abilities-manager.php`, `includes/Main.php`, `README.txt`. Add Changelog + Upgrade Notice entries.
+- [ ] T018 Open release PR (release-0.0.11 → main). Merge.
+- [ ] T019 Tag `0.0.11`, cut GitHub release.
+- [ ] T020 Run `/speckit.memory-md.capture-from-diff` against the shipped diff. Confirm the proposed memory entries; save the confirmed ones.

--- a/tests/phpunit/abilities/Test_Feature_042_Core_Update.php
+++ b/tests/phpunit/abilities/Test_Feature_042_Core_Update.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Structural tests for the Feature 042 Core-category work.
+ *
+ * Covers:
+ *   - Backups_Storage filename scheme change ({slug}-{unix}-{ms}.zip).
+ *   - Core/Category_Registrar shape parity with other Category_Registrars.
+ *   - Wp_Core_Update_Check + Wp_Core_Update ability scaffolding + guards.
+ *   - Bootstrap wiring for the Core category and its two abilities.
+ *
+ * Source-inspection only, mirroring the Test_Feature_041_Backup_Abilities
+ * suite: the plugin's stub bootstrap can't safely construct the full plugin.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Feature_042_Core_Update.
+ */
+class Test_Feature_042_Core_Update extends WP_UnitTestCase {
+
+	/**
+	 * Absolute paths to every source file exercised by these tests.
+	 *
+	 * @var array<string,string>
+	 */
+	private array $sources = array();
+
+	/**
+	 * Load every source file once per test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$plugin_root = dirname( __DIR__, 3 );
+
+		$this->sources = array(
+			'category_registrar'   => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Core/Category_Registrar.php'
+			),
+			'wp_core_update_check' => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Core/Wp_Core_Update_Check.php'
+			),
+			'wp_core_update'       => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Core/Wp_Core_Update.php'
+			),
+			'backups_storage'      => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Utilities/Backups_Storage.php'
+			),
+			'bootstrap'            => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php'
+			),
+		);
+	}
+
+	// =========================================================================
+	// Filename scheme change — Backups_Storage::random_backup_filename()
+	// =========================================================================
+
+	/**
+	 * The helper no longer prepends the legacy `backup-` prefix and no longer
+	 * calls `wp_generate_password()` for a 12-char random suffix.
+	 *
+	 * @return void
+	 */
+	public function test_filename_scheme_drops_backup_prefix_and_random_suffix(): void {
+		$src = $this->sources['backups_storage'];
+		$this->assertStringNotContainsString(
+			"array( 'backup' )",
+			$src,
+			'random_backup_filename must not seed the parts array with "backup" anymore.'
+		);
+		$this->assertStringNotContainsString(
+			'wp_generate_password( 12',
+			$src,
+			'random_backup_filename must not emit a 12-char random suffix anymore.'
+		);
+	}
+
+	/**
+	 * The new scheme composes `{slug}-{unix}-{ms}.zip` — driven by
+	 * microtime(true) + two helpers.
+	 *
+	 * @return void
+	 */
+	public function test_filename_scheme_uses_slug_unix_ms(): void {
+		$src = $this->sources['backups_storage'];
+		$this->assertStringContainsString(
+			'microtime( true )',
+			$src,
+			'random_backup_filename must derive the timestamp + ms from microtime(true).'
+		);
+		$this->assertStringContainsString(
+			'filename_slug_segment',
+			$src,
+			'random_backup_filename must delegate slug resolution to filename_slug_segment().'
+		);
+		$this->assertStringContainsString(
+			'filename_time_segments',
+			$src,
+			'random_backup_filename must delegate time resolution to filename_time_segments().'
+		);
+		$this->assertMatchesRegularExpression(
+			"/\\\$slug\s*\\.\s*'-'\s*\\.\s*\\\$unix\s*\\.\s*'-'\s*\\.\s*\\\$ms\s*\\.\s*'\\.zip'/",
+			$src,
+			'The final concatenation must be {slug}-{unix}-{ms}.zip.'
+		);
+	}
+
+	/**
+	 * When both $target and $target_type are empty, the slug segment must
+	 * fall back to a sane default so the filename never becomes `-{ts}.zip`.
+	 *
+	 * @return void
+	 */
+	public function test_filename_slug_segment_has_ultimate_fallback(): void {
+		$src = $this->sources['backups_storage'];
+		$this->assertMatchesRegularExpression(
+			"/return\s*'backup'\s*;/",
+			$src,
+			'filename_slug_segment must fall back to "backup" when both target and type are empty.'
+		);
+	}
+
+	// =========================================================================
+	// Core Category_Registrar
+	// =========================================================================
+
+	/**
+	 * The Core/Category_Registrar mirrors the shape of every other
+	 * Category_Registrar (final singleton class, `register()` method calling
+	 * wp_register_ability_category()).
+	 *
+	 * @return void
+	 */
+	public function test_core_category_registrar_shape(): void {
+		$src = $this->sources['category_registrar'];
+		$this->assertStringContainsString( 'final class Category_Registrar', $src );
+		$this->assertStringContainsString( 'public static function instance(): self', $src );
+		$this->assertStringContainsString( 'public function register(): void', $src );
+		$this->assertStringContainsString(
+			"'acrossai-abilities-manager-core'",
+			$src,
+			'Category slug must be acrossai-abilities-manager-core.'
+		);
+		$this->assertStringContainsString(
+			'wp_register_ability_category',
+			$src
+		);
+	}
+
+	// =========================================================================
+	// Wp_Core_Update_Check
+	// =========================================================================
+
+	/**
+	 * The check ability is read-only, gates via manage_options only, and
+	 * uses WP core's get_core_updates() from wp-admin/includes/update.php.
+	 *
+	 * @return void
+	 */
+	public function test_wp_core_update_check_shape(): void {
+		$src = $this->sources['wp_core_update_check'];
+		$this->assertStringContainsString( 'extends Ability_Definition', $src );
+		$this->assertStringContainsString(
+			"'acrossai-abilities-manager/wp-core-update-check'",
+			$src,
+			'Ability name must be acrossai-abilities-manager/wp-core-update-check.'
+		);
+		$this->assertStringContainsString(
+			"'acrossai-abilities-manager-core'",
+			$src,
+			'Ability category must point at the new Core category slug.'
+		);
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$src
+		);
+		$this->assertStringContainsString( 'get_core_updates', $src );
+		$this->assertStringContainsString(
+			"wp-admin/includes/update.php",
+			$src,
+			'Must require WP core update.php.'
+		);
+		$this->assertStringContainsString(
+			"'readonly'    => true",
+			$src,
+			'Check ability annotations must declare readonly=true.'
+		);
+	}
+
+	// =========================================================================
+	// Wp_Core_Update
+	// =========================================================================
+
+	/**
+	 * The update ability wraps WP core's Core_Upgrader and honours DISALLOW_FILE_MODS.
+	 *
+	 * @return void
+	 */
+	public function test_wp_core_update_uses_core_upgrader_and_guards(): void {
+		$src = $this->sources['wp_core_update'];
+		$this->assertStringContainsString( 'extends Ability_Definition', $src );
+		$this->assertStringContainsString(
+			"'acrossai-abilities-manager/wp-core-update'",
+			$src
+		);
+		$this->assertStringContainsString(
+			"'acrossai-abilities-manager-core'",
+			$src
+		);
+		$this->assertStringContainsString(
+			'File_Mods_Guard::blocked_response',
+			$src,
+			'Wp_Core_Update must invoke File_Mods_Guard::blocked_response(install).'
+		);
+		$this->assertMatchesRegularExpression(
+			"/File_Mods_Guard::blocked_response\(\s*'install'\s*\)/",
+			$src
+		);
+		$this->assertStringContainsString(
+			'Core_Upgrader',
+			$src,
+			'Wp_Core_Update must wrap WP core Core_Upgrader.'
+		);
+		$this->assertStringContainsString(
+			'->upgrade(',
+			$src,
+			'Wp_Core_Update must call ->upgrade( $update ).'
+		);
+		$this->assertStringContainsString(
+			'WP_Ajax_Upgrader_Skin',
+			$src,
+			'Wp_Core_Update must use the WP_Ajax_Upgrader_Skin (same as Plugin_Update / Theme_Update).'
+		);
+		$this->assertStringContainsString(
+			'is_multisite()',
+			$src,
+			'Wp_Core_Update must contain a multisite guard.'
+		);
+	}
+
+	/**
+	 * The update ability's permission_callback gates on BOTH manage_options
+	 * AND update_core — matching WP core's own admin gate.
+	 *
+	 * @return void
+	 */
+	public function test_wp_core_update_requires_both_caps(): void {
+		$src = $this->sources['wp_core_update'];
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\).*current_user_can\(\s*'update_core'\s*\)/s",
+			$src,
+			'Wp_Core_Update permission_callback must AND manage_options with update_core.'
+		);
+	}
+
+	/**
+	 * The update ability accepts both an optional `version` pin and an
+	 * optional `locale` override (per the Clarifications decision).
+	 *
+	 * @return void
+	 */
+	public function test_wp_core_update_accepts_optional_version_and_locale(): void {
+		$src = $this->sources['wp_core_update'];
+		$this->assertStringContainsString( "'version'", $src );
+		$this->assertStringContainsString( "'locale'", $src );
+		$this->assertStringContainsString( 'find_core_update', $src );
+		// Version is optional — must NOT be inside `required`.
+		$this->assertStringNotContainsString(
+			"'required'             => array( 'version' )",
+			$src
+		);
+	}
+
+	// =========================================================================
+	// Bootstrap wiring
+	// =========================================================================
+
+	/**
+	 * The core bootstrap registers the Core Category_Registrar callback and
+	 * instantiates both new abilities.
+	 *
+	 * @return void
+	 */
+	public function test_bootstrap_wires_core_category_and_abilities(): void {
+		$src = $this->sources['bootstrap'];
+		$this->assertStringContainsString(
+			"Core\\Category_Registrar::instance(), 'register'",
+			$src,
+			'Bootstrap must register the Core Category_Registrar callback.'
+		);
+		$this->assertStringContainsString(
+			'new Core\\Wp_Core_Update_Check()',
+			$src,
+			'Bootstrap must instantiate Wp_Core_Update_Check.'
+		);
+		$this->assertStringContainsString(
+			'new Core\\Wp_Core_Update()',
+			$src,
+			'Bootstrap must instantiate Wp_Core_Update.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new **Core** Category folder (18th sub-partition of the Custom Ability Registration module) with two abilities that let AI / MCP clients check for and apply WordPress core updates through the Abilities API — a gap that existed since Feature 046's absorbed inventory shipped (Update_Check reported availability but no ability could actually apply a core update).

Also rewrites `Backups_Storage::random_backup_filename()`: 0.0.9's opaque `backup-{type}-{slug}-{random-12}.zip` becomes `{slug}-{unix}-{ms}.zip` for readability + lexicographic-sort = chronological-sort. The 3-digit ms suffix from `microtime(true)` prevents same-second collisions.

### New Core category

- `Core/Category_Registrar.php` — final singleton mirroring `FileManager/Category_Registrar.php`. Slug `acrossai-abilities-manager-core`.
- `Core/Wp_Core_Update_Check.php` — read-only. Wraps `get_core_updates()`; flattens the first offer into JSON-friendly fields.
- `Core/Wp_Core_Update.php` — wraps WP core `Core_Upgrader::upgrade()`. Optional `version` (+ optional `locale`) inputs; no args = update to latest offer. Requires BOTH `manage_options` AND `update_core`. Guards on `File_Mods_Guard` + multisite bailout. Result-interpretation ladder identical to `Plugin_Update` / `Theme_Update`. No custom HTTP, no bundled updater code.

### Filename scheme change

`Backups_Storage::random_backup_filename()` rewrite. Signature unchanged; both callers (`Zip_Create`, `Zip_Upload`) untouched. Two private helpers extracted (`filename_slug_segment`, `filename_time_segments`). Slug fallback chain: `target → target_type → literal 'backup'`.

### Spec-kit

- `specs/042-core-category-and-wp-core-update/` — 7 files (spec / plan / tasks / checklists / security-constraints / memory-synthesis / architecture-review).
- `specs/041-backup-restore-abilities-and-updates/` — **full backfill** for Feature 041 with a `Fixes` section documenting the 0.0.10 include_hidden regression fix (PRs #73 / #74). Matches the Feature 053 backfill pattern already in `git log`.

## Test plan

- [x] `composer run phpstan` (level 8) — zero errors
- [x] `composer run phpcs` — zero errors
- [x] `composer test` — 153 tests / 504 assertions (up from 144 / 468 on 0.0.10; +9 tests / +36 assertions)
- [ ] Manual e2e: Core tab visible on the Ability Library page under Plugins / Themes / FileManager / etc.
- [ ] Manual e2e: `wp-core-update-check` on a site pinned to an older WP returns `available=true` with populated `new_version` + `download`
- [ ] Manual e2e: `wp-core-update` with no args upgrades the site; `to_version` reflects `get_bloginfo('version')` after the call
- [ ] Manual e2e: `wp-core-update {"version":"99.99.99"}` returns clean error, no partial update
- [ ] Manual e2e: `DISALLOW_FILE_MODS=true` short-circuits `wp-core-update`; `wp-core-update-check` still works
- [ ] Manual e2e: two back-to-back `zip-create` calls against the same target produce two distinct filenames matching `{slug}-\d{10}-\d{3}\.zip`

## Post-merge

Release-0.0.11 PR + tag + GitHub release + `/speckit.memory-md.capture-from-diff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)