### PR TITLE
Feature 055 — implement all 31 backlog abilities (0.0.13)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.12
+Stable tag: 0.0.13
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -99,6 +99,13 @@ No data is sent to any external server without explicit user action.
 
 == Changelog ==
 
+= 0.0.13 =
+* **31 new abilities across 10 domains — 187 → 218.** Ships the entire backlog surfaced by the external AI-tool inventory audit. Two new categories are added: `acrossai-abilities-manager-admin-menu` (5 abilities) and `acrossai-abilities-manager-content-search` (11 abilities). Single-item additions land in existing categories: `users-current-access` (Users), `taxonomy-set-term-image` (Taxonomies), `comments-bulk-update` (Comments), `media-rename-file` (Media), `navigation-get-context` + `navigation-list-locations` (Menus), `content-update-block` + `content-autosaves-inspect` (Content), `site-editor-get-context` + `site-editor-refresh-context` + `site-structure-list-reusable-blocks` + `site-structure-list-block-areas` (Block), `site-maintenance-report` (SiteHealth), `plugin-lifecycle-get-plugin` (Plugins), `theme-lifecycle-get-theme` (Themes).
+* **New option-backed lifecycle event log.** `plugin-lifecycle-get-plugin` and `theme-lifecycle-get-theme` return `last_activated_at` / `last_deactivated_at` / `last_updated_at` timestamps from a rolling event log (`acrossai_abilities_manager_lifecycle_log` option, capped at 50 events per plugin/theme). Events are recorded from 0.0.13 forward — pre-0.0.13 lifecycle history is not backfilled and those timestamps read `0` until the next event fires.
+* **New option-backed internal-link suggestion store.** The 5 `content-internal-link-*` abilities (create, list, review, apply, policy) plus `content-audit-internal-links` persist to `acrossai_abilities_manager_link_suggestions` (option-backed, capped at 500 total suggestions). Zero external HTTP; zero new database tables.
+* **No breaking changes.** No existing ability slug / input schema / output schema / permission callback is altered. Every previously-registered ability still resolves to the same class.
+* **Safety notes.** `media-rename-file` refuses filenames with a directory separator, null byte, or leading dot; enforces realpath containment inside the attachment's original upload sub-directory; refuses to clobber an existing target. `comments-bulk-update` requires `moderate_comments` and caps at 100 comment ids per call. `content-internal-link-suggestion-apply` requires `edit_others_posts`, re-validates the target as same-site, and only mutates on first-occurrence substring match.
+
 = 0.0.12 =
 * **New — WordPress core rollback ability under the Core category.** `acrossai-abilities-manager/wp-core-rollback` rolls back WordPress core to an earlier offered version via WP core's `Core_Upgrader::upgrade()` — the same class the WordPress dashboard uses for forward updates. Fetches the offer list from the WP.org Core API 1.7 endpoint (`https://api.wordpress.org/core/version-check/1.7/`) via `wp_remote_get()`, picks the requested version, and hands the offer directly to the upgrader. Uses only WordPress functions; no bundled updater code. Requires BOTH `manage_options` AND `update_core`; honours `DISALLOW_FILE_MODS` via `File_Mods_Guard`; multisite-guarded; refuses when the target version is equal to or newer than the currently-installed version (steers callers to `wp-core-update`). The per-locale offer list is cached in a site transient with a day-long TTL. Annotated `destructive=true` — rolling WordPress back is a real production operation and clients should surface it accordingly. Inspired by Andy Fragen's [core-rollback](https://github.com/afragen/core-rollback) plugin (MIT-licensed). See PR [#77](https://github.com/acrossai-co/acrossai-abilities-manager/pull/77).
 * **First outbound HTTP request from the plugin.** Historically the plugin has made zero outbound HTTP requests on its own (the Add-ons page delegates to the WordPress plugin installer's own contact with WordPress.org; other abilities operate on the local site). `wp-core-rollback` introduces the plugin's first direct outbound request — to `api.wordpress.org/core/version-check/1.7/`. The URL is a hardcoded class constant (no SSRF surface), the request has a 15-second timeout, and only the sanitized locale is derived from user input. The per-locale offer list is cached in a site transient with a day-long TTL, so the request rate is bounded to at most one call per day per locale per site.
@@ -163,6 +170,9 @@ No data is sent to any external server without explicit user action.
 * MCP server listing via MCP Adapter integration.
 
 == Upgrade Notice ==
+
+= 0.0.13 =
+Adds 31 new abilities across 10 domains (187 → 218). Two new categories join the Ability Library: Admin Menu (5 abilities) and Content Search (11 abilities). Introduces two option-backed data stores: a lifecycle event log for plugin/theme activate/deactivate/update timestamps, and an internal-link suggestion queue capped at 500 entries. Zero new REST endpoints, zero new capability requirements beyond the operation-specific caps already enforced by WP core (moderate_comments, upload_files, edit_others_posts). Zero external HTTP; zero new database tables. No breaking changes to existing abilities. Safe upgrade.
 
 = 0.0.12 =
 Adds a third ability to the Core tab — `wp-core-rollback` — that rolls back WordPress core to an earlier version via WP core's `Core_Upgrader::upgrade()`, the same class the dashboard uses for forward updates. Requires both `manage_options` and `update_core`; honours `DISALLOW_FILE_MODS`; refuses when the target version isn't strictly older than the currently-installed version. Introduces the plugin's first outbound HTTP request (to `api.wordpress.org/core/version-check/1.7/`), rate-bounded to at most one request per day per locale per site via a site-transient cache. No breaking changes; no database, REST, or capability changes to existing abilities. Safe upgrade.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.12
+ * Version:           0.0.13
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -80,6 +80,9 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		$loader->add_action( 'wp_abilities_api_categories_init', Cron\Category_Registrar::instance(), 'register' );
 		$loader->add_action( 'wp_abilities_api_categories_init', SiteHealth\Category_Registrar::instance(), 'register' );
 		$loader->add_action( 'wp_abilities_api_categories_init', Core\Category_Registrar::instance(), 'register' );
+		// Feature 055 — two new categories.
+		$loader->add_action( 'wp_abilities_api_categories_init', AdminMenu\Category_Registrar::instance(), 'register' );
+		$loader->add_action( 'wp_abilities_api_categories_init', ContentSearch\Category_Registrar::instance(), 'register' );
 	}
 
 	/**
@@ -290,6 +293,42 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Core\Wp_Core_Update_Check();
 		new Core\Wp_Core_Update();
 		new Core\Wp_Core_Rollback();
+
+		// Feature 055 — 31 new abilities across 10 domains.
+		new Users\Current_Access();
+		new Taxonomies\Set_Term_Image();
+		new Comments\Comments_Bulk_Update();
+		new Media\Media_Rename_File();
+		new Menus\Navigation_Get_Context();
+		new Menus\Navigation_List_Locations();
+		new Content\Content_Update_Block();
+		new Content\Content_Autosaves_Inspect();
+		new Block\Site_Editor_Get_Context();
+		new Block\Site_Editor_Refresh_Context();
+		new Block\Reusable_Blocks_List();
+		new Block\Block_Areas_List();
+		new SiteHealth\Site_Maintenance_Report();
+		new Plugins\Plugin_Lifecycle_Get_Plugin();
+		new Themes\Theme_Lifecycle_Get_Theme();
+		new AdminMenu\Admin_Menu_Get_Context();
+		new AdminMenu\Admin_Menu_Refresh_Context();
+		new AdminMenu\Admin_Menu_List_Pages();
+		new AdminMenu\Admin_Menu_Get_Navigation_Target();
+		new AdminMenu\Admin_Menu_List_Settings();
+		new ContentSearch\Content_Index_Refresh_Batch();
+		new ContentSearch\Content_Search_Items();
+		new ContentSearch\Content_Search_Chunks();
+		new ContentSearch\Content_Find_Related();
+		new ContentSearch\Content_Find_Internal_Links();
+		new ContentSearch\Internal_Link_Policy();
+		new ContentSearch\Internal_Link_Suggestions_Create();
+		new ContentSearch\Internal_Link_Suggestions_List();
+		new ContentSearch\Internal_Link_Suggestion_Review();
+		new ContentSearch\Internal_Link_Suggestion_Apply();
+		new ContentSearch\Content_Audit_Internal_Links();
+
+		// Feature 055 — register the option-backed lifecycle event log.
+		Utilities\Lifecycle_Event_Log::register_hooks();
 
 		// Extras the companion Main.php also ran alongside the ability
 		// instantiations. See docs/planning/046-absorb-core-abilities-into-manager.md

--- a/includes/Abilities/AdminMenu/Admin_Menu_Get_Context.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_Get_Context.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Feature 055 — snapshot of the current admin-menu context.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\AdminMenu
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\AdminMenu;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return the current WP-admin screen context: base, id, post_type,
+ * top-level menu slug (if resolvable), and the current caller's role set.
+ */
+class Admin_Menu_Get_Context extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/admin-menu-get-context',
+			'args' => array(
+				'label'               => __( 'Get Admin Menu Context', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return the current WP-admin screen context: base, id, post_type, top-level menu slug (if resolvable via $_GET[page]), current caller\'s roles, and admin URL. Reads get_current_screen() when available; falls back to sanitized $_GET data otherwise.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-admin-menu',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'screen_id'      => array( 'type' => 'string' ),
+						'screen_base'    => array( 'type' => 'string' ),
+						'post_type'      => array( 'type' => 'string' ),
+						'page_slug'      => array( 'type' => 'string' ),
+						'admin_base_url' => array( 'type' => 'string' ),
+						'user_roles'     => array( 'type' => 'array' ),
+						'message'        => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'admin-menu',
+						'sub_group_label' => __( 'Admin Menu', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+
+		$screen_id   = '';
+		$screen_base = '';
+		$post_type   = '';
+		if ( function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+			if ( $screen instanceof \WP_Screen ) {
+				$screen_id   = (string) $screen->id;
+				$screen_base = (string) $screen->base;
+				$post_type   = (string) $screen->post_type;
+			}
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$page_slug = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( (string) $_GET['page'] ) ) : '';
+
+		$user = wp_get_current_user();
+		$roles = $user instanceof \WP_User ? array_values( array_map( 'strval', (array) $user->roles ) ) : array();
+
+		return array(
+			'success'        => true,
+			'screen_id'      => $screen_id,
+			'screen_base'    => $screen_base,
+			'post_type'      => $post_type,
+			'page_slug'      => $page_slug,
+			'admin_base_url' => admin_url(),
+			'user_roles'     => $roles,
+			'message'        => __( 'Admin menu context snapshot.', 'acrossai-abilities-manager' ),
+		);
+	}
+}

--- a/includes/Abilities/AdminMenu/Admin_Menu_Get_Navigation_Target.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_Get_Navigation_Target.php
@@ -96,7 +96,13 @@ class Admin_Menu_Get_Navigation_Target extends Ability_Definition {
 	public function execute( array $input = array() ): array {
 		global $menu, $submenu;
 
-		$intent = strtolower( trim( (string) ( $input['intent'] ?? '' ) ) );
+		// Feature 055 hardening — hard-cap intent length (a 100 KB input
+		// would still hit the tokeniser regardless of the JSON schema).
+		$intent_raw = sanitize_text_field( (string) ( $input['intent'] ?? '' ) );
+		if ( strlen( $intent_raw ) > 500 ) {
+			$intent_raw = substr( $intent_raw, 0, 500 );
+		}
+		$intent = strtolower( trim( $intent_raw ) );
 		if ( '' === $intent ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/AdminMenu/Admin_Menu_Get_Navigation_Target.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_Get_Navigation_Target.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Feature 055 — resolve natural-language routing hints to admin URLs.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\AdminMenu
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\AdminMenu;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve a caller-supplied hint like "settings > reading" or
+ * "media library" into the closest matching admin URL by scoring
+ * against the current admin-menu tree.
+ *
+ * Scoring: token-overlap between the sanitised hint and each menu /
+ * submenu's title + slug. Returns the top hit with a confidence score
+ * in [0, 1].
+ */
+class Admin_Menu_Get_Navigation_Target extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/admin-menu-get-navigation-target',
+			'args' => array(
+				'label'               => __( 'Get Admin Menu Navigation Target', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Resolve a natural-language hint (e.g. "settings > reading", "media library") to the closest matching admin URL by scoring token-overlap against the current admin-menu tree. Returns the top hit with a confidence in [0, 1] plus the top three alternates.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-admin-menu',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'intent' => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+					),
+					'required'             => array( 'intent' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'resolved_slug'  => array( 'type' => 'string' ),
+						'resolved_url'   => array( 'type' => 'string' ),
+						'resolved_title' => array( 'type' => 'string' ),
+						'confidence'     => array( 'type' => 'number' ),
+						'alternates'     => array( 'type' => 'array' ),
+						'message'        => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'admin-menu',
+						'sub_group_label' => __( 'Admin Menu', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		global $menu, $submenu;
+
+		$intent = strtolower( trim( (string) ( $input['intent'] ?? '' ) ) );
+		if ( '' === $intent ) {
+			return array(
+				'success' => false,
+				'message' => __( 'intent is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Split on whitespace and punctuation.
+		$tokens = array_values( array_filter( preg_split( '/[\s>\-_\/]+/u', $intent ) ?: array(), static fn( $t ): bool => '' !== $t ) );
+		if ( array() === $tokens ) {
+			return array(
+				'success' => false,
+				'message' => __( 'intent contains no useful tokens.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$candidates = array();
+		if ( is_array( $menu ) ) {
+			foreach ( $menu as $entry ) {
+				if ( ! is_array( $entry ) ) {
+					continue;
+				}
+				$title = strtolower( wp_strip_all_tags( (string) ( $entry[0] ?? '' ) ) );
+				$slug  = strtolower( (string) ( $entry[2] ?? '' ) );
+				if ( '' === $slug ) {
+					continue;
+				}
+				$candidates[] = array(
+					'title' => $title,
+					'slug'  => $slug,
+					'url'   => menu_page_url( $slug, false ),
+				);
+				if ( isset( $submenu[ $entry[2] ] ) && is_array( $submenu[ $entry[2] ] ) ) {
+					foreach ( $submenu[ $entry[2] ] as $sub_entry ) {
+						if ( ! is_array( $sub_entry ) ) {
+							continue;
+						}
+						$sub_title = strtolower( wp_strip_all_tags( (string) ( $sub_entry[0] ?? '' ) ) );
+						$sub_slug  = (string) ( $sub_entry[2] ?? '' );
+						if ( '' === $sub_slug ) {
+							continue;
+						}
+						$candidates[] = array(
+							'title' => $sub_title,
+							'slug'  => strtolower( $sub_slug ),
+							'url'   => menu_page_url( $sub_slug, false ),
+						);
+					}
+				}
+			}
+		}
+
+		if ( array() === $candidates ) {
+			return array(
+				'success' => false,
+				'message' => __( 'No admin menu entries available in this request context.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$scored = array();
+		foreach ( $candidates as $cand ) {
+			$corpus = $cand['title'] . ' ' . $cand['slug'];
+			$hits   = 0;
+			foreach ( $tokens as $tok ) {
+				if ( false !== strpos( $corpus, $tok ) ) {
+					++$hits;
+				}
+			}
+			$score    = count( $tokens ) > 0 ? $hits / count( $tokens ) : 0.0;
+			$scored[] = array_merge( $cand, array( 'score' => $score ) );
+		}
+
+		usort(
+			$scored,
+			static fn( $a, $b ): int => $b['score'] <=> $a['score']
+		);
+
+		$top        = $scored[0];
+		$alternates = array_slice( $scored, 1, 3 );
+
+		return array(
+			'success'        => true,
+			'resolved_slug'  => (string) $top['slug'],
+			'resolved_url'   => (string) $top['url'],
+			'resolved_title' => (string) $top['title'],
+			'confidence'     => (float) $top['score'],
+			'alternates'     => array_map(
+				static fn( $c ): array => array(
+					'title' => (string) $c['title'],
+					'slug'  => (string) $c['slug'],
+					'url'   => (string) $c['url'],
+					'score' => (float) $c['score'],
+				),
+				$alternates
+			),
+			/* translators: 1: intent, 2: resolved slug */
+			'message'        => sprintf( __( 'Resolved "%1$s" to "%2$s".', 'acrossai-abilities-manager' ), $intent, $top['slug'] ),
+		);
+	}
+}

--- a/includes/Abilities/AdminMenu/Admin_Menu_List_Pages.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_List_Pages.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Feature 055 — enumerate every registered admin menu page + submenu.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\AdminMenu
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\AdminMenu;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List every top-level admin menu entry plus its submenus. Reads the
+ * `$menu` / `$submenu` globals populated by WordPress core after the
+ * `admin_menu` hook has fired.
+ *
+ * If invoked outside the admin request lifecycle (e.g. via a public REST
+ * caller) the globals may be empty — this ability returns an empty result
+ * with a clear message instead of erroring.
+ */
+class Admin_Menu_List_Pages extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/admin-menu-list-pages',
+			'args' => array(
+				'label'               => __( 'List Admin Menu Pages', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Enumerate every top-level admin menu entry plus its submenus. Reads the WP core $menu / $submenu globals populated after the admin_menu hook. Returns an empty result with a clear message when invoked outside the admin request lifecycle.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-admin-menu',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'items'   => array( 'type' => 'array' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'admin-menu',
+						'sub_group_label' => __( 'Admin Menu', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+		global $menu, $submenu;
+
+		// Force admin menu construction if not already built.
+		if ( ! did_action( 'admin_menu' ) && function_exists( 'do_action' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/menu.php';
+		}
+
+		$items = array();
+		if ( is_array( $menu ) ) {
+			foreach ( $menu as $entry ) {
+				if ( ! is_array( $entry ) ) {
+					continue;
+				}
+				$title      = wp_strip_all_tags( (string) ( $entry[0] ?? '' ) );
+				$capability = (string) ( $entry[1] ?? '' );
+				$slug       = (string) ( $entry[2] ?? '' );
+				if ( '' === $slug ) {
+					continue;
+				}
+				$sub = array();
+				if ( isset( $submenu[ $slug ] ) && is_array( $submenu[ $slug ] ) ) {
+					foreach ( $submenu[ $slug ] as $sub_entry ) {
+						if ( ! is_array( $sub_entry ) ) {
+							continue;
+						}
+						$sub[] = array(
+							'title'      => wp_strip_all_tags( (string) ( $sub_entry[0] ?? '' ) ),
+							'capability' => (string) ( $sub_entry[1] ?? '' ),
+							'slug'       => (string) ( $sub_entry[2] ?? '' ),
+						);
+					}
+				}
+				$items[] = array(
+					'title'      => $title,
+					'capability' => $capability,
+					'slug'       => $slug,
+					'url'        => menu_page_url( $slug, false ),
+					'submenu'    => $sub,
+				);
+			}
+		}
+
+		return array(
+			'success' => true,
+			'items'   => $items,
+			/* translators: %d: item count */
+			'message' => sprintf( __( '%d top-level admin menu entries.', 'acrossai-abilities-manager' ), count( $items ) ),
+		);
+	}
+}

--- a/includes/Abilities/AdminMenu/Admin_Menu_List_Pages.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_List_Pages.php
@@ -92,16 +92,28 @@ class Admin_Menu_List_Pages extends Ability_Definition {
 			require_once ABSPATH . 'wp-admin/includes/menu.php';
 		}
 
+		// Feature 055 hardening — hard-cap title length so a registrar can't
+		// bloat responses; sanitize + limit every emitted field.
+		$title_max = 200;
+		$sanitize_title = static function ( string $raw ) use ( $title_max ): string {
+			$t = sanitize_text_field( wp_strip_all_tags( $raw ) );
+			return strlen( $t ) > $title_max ? rtrim( substr( $t, 0, $title_max ) ) . '...' : $t;
+		};
+
 		$items = array();
 		if ( is_array( $menu ) ) {
 			foreach ( $menu as $entry ) {
 				if ( ! is_array( $entry ) ) {
 					continue;
 				}
-				$title      = wp_strip_all_tags( (string) ( $entry[0] ?? '' ) );
-				$capability = (string) ( $entry[1] ?? '' );
-				$slug       = (string) ( $entry[2] ?? '' );
+				$title      = $sanitize_title( (string) ( $entry[0] ?? '' ) );
+				$capability = sanitize_key( (string) ( $entry[1] ?? '' ) );
+				$slug       = sanitize_text_field( (string) ( $entry[2] ?? '' ) );
 				if ( '' === $slug ) {
+					continue;
+				}
+				// Only surface menu entries the current user could actually reach.
+				if ( '' !== $capability && ! current_user_can( $capability ) ) {
 					continue;
 				}
 				$sub = array();
@@ -110,10 +122,15 @@ class Admin_Menu_List_Pages extends Ability_Definition {
 						if ( ! is_array( $sub_entry ) ) {
 							continue;
 						}
+						$sub_cap  = sanitize_key( (string) ( $sub_entry[1] ?? '' ) );
+						$sub_slug = sanitize_text_field( (string) ( $sub_entry[2] ?? '' ) );
+						if ( '' !== $sub_cap && ! current_user_can( $sub_cap ) ) {
+							continue;
+						}
 						$sub[] = array(
-							'title'      => wp_strip_all_tags( (string) ( $sub_entry[0] ?? '' ) ),
-							'capability' => (string) ( $sub_entry[1] ?? '' ),
-							'slug'       => (string) ( $sub_entry[2] ?? '' ),
+							'title'      => $sanitize_title( (string) ( $sub_entry[0] ?? '' ) ),
+							'capability' => $sub_cap,
+							'slug'       => $sub_slug,
 						);
 					}
 				}
@@ -121,7 +138,7 @@ class Admin_Menu_List_Pages extends Ability_Definition {
 					'title'      => $title,
 					'capability' => $capability,
 					'slug'       => $slug,
-					'url'        => menu_page_url( $slug, false ),
+					'url'        => esc_url_raw( (string) menu_page_url( $slug, false ) ),
 					'submenu'    => $sub,
 				);
 			}

--- a/includes/Abilities/AdminMenu/Admin_Menu_List_Settings.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_List_Settings.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Feature 055 — enumerate Settings API sections + fields.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\AdminMenu
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\AdminMenu;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List every Settings API section + field per settings page. Reads the
+ * `$wp_settings_sections` / `$wp_settings_fields` globals populated by
+ * `add_settings_section()` / `add_settings_field()` calls.
+ */
+class Admin_Menu_List_Settings extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/admin-menu-list-settings',
+			'args' => array(
+				'label'               => __( 'List Admin Settings', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List every Settings API section + field per settings page. Reads the WP core $wp_settings_sections / $wp_settings_fields globals. Filter with the optional `page` input.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-admin-menu',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'page' => array( 'type' => 'string' ),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'items'   => array( 'type' => 'array' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'admin-menu',
+						'sub_group_label' => __( 'Admin Menu', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		global $wp_settings_sections, $wp_settings_fields;
+
+		$page_filter = isset( $input['page'] ) ? sanitize_key( (string) $input['page'] ) : '';
+
+		$items = array();
+
+		if ( is_array( $wp_settings_sections ) ) {
+			foreach ( $wp_settings_sections as $page => $sections ) {
+				if ( '' !== $page_filter && (string) $page !== $page_filter ) {
+					continue;
+				}
+				if ( ! is_array( $sections ) ) {
+					continue;
+				}
+				foreach ( $sections as $section_id => $section ) {
+					$section_title = is_array( $section ) ? wp_strip_all_tags( (string) ( $section['title'] ?? '' ) ) : '';
+					$fields        = array();
+					if ( isset( $wp_settings_fields[ $page ][ $section_id ] ) && is_array( $wp_settings_fields[ $page ][ $section_id ] ) ) {
+						foreach ( $wp_settings_fields[ $page ][ $section_id ] as $field_id => $field ) {
+							$fields[] = array(
+								'id'    => (string) $field_id,
+								'label' => is_array( $field ) ? wp_strip_all_tags( (string) ( $field['title'] ?? '' ) ) : '',
+							);
+						}
+					}
+					$items[] = array(
+						'page'    => (string) $page,
+						'section' => (string) $section_id,
+						'title'   => $section_title,
+						'fields'  => $fields,
+					);
+				}
+			}
+		}
+
+		return array(
+			'success' => true,
+			'items'   => $items,
+			/* translators: %d: section count */
+			'message' => sprintf( __( '%d settings section(s) found.', 'acrossai-abilities-manager' ), count( $items ) ),
+		);
+	}
+}

--- a/includes/Abilities/AdminMenu/Admin_Menu_List_Settings.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_List_Settings.php
@@ -86,6 +86,13 @@ class Admin_Menu_List_Settings extends Ability_Definition {
 
 		$page_filter = isset( $input['page'] ) ? sanitize_key( (string) $input['page'] ) : '';
 
+		// Feature 055 hardening — hard-cap title lengths on emitted fields.
+		$max = 200;
+		$cap = static function ( string $raw ) use ( $max ): string {
+			$t = sanitize_text_field( wp_strip_all_tags( $raw ) );
+			return strlen( $t ) > $max ? rtrim( substr( $t, 0, $max ) ) . '...' : $t;
+		};
+
 		$items = array();
 
 		if ( is_array( $wp_settings_sections ) ) {
@@ -97,19 +104,19 @@ class Admin_Menu_List_Settings extends Ability_Definition {
 					continue;
 				}
 				foreach ( $sections as $section_id => $section ) {
-					$section_title = is_array( $section ) ? wp_strip_all_tags( (string) ( $section['title'] ?? '' ) ) : '';
+					$section_title = is_array( $section ) ? $cap( (string) ( $section['title'] ?? '' ) ) : '';
 					$fields        = array();
 					if ( isset( $wp_settings_fields[ $page ][ $section_id ] ) && is_array( $wp_settings_fields[ $page ][ $section_id ] ) ) {
 						foreach ( $wp_settings_fields[ $page ][ $section_id ] as $field_id => $field ) {
 							$fields[] = array(
-								'id'    => (string) $field_id,
-								'label' => is_array( $field ) ? wp_strip_all_tags( (string) ( $field['title'] ?? '' ) ) : '',
+								'id'    => sanitize_text_field( (string) $field_id ),
+								'label' => is_array( $field ) ? $cap( (string) ( $field['title'] ?? '' ) ) : '',
 							);
 						}
 					}
 					$items[] = array(
-						'page'    => (string) $page,
-						'section' => (string) $section_id,
+						'page'    => sanitize_text_field( (string) $page ),
+						'section' => sanitize_text_field( (string) $section_id ),
 						'title'   => $section_title,
 						'fields'  => $fields,
 					);

--- a/includes/Abilities/AdminMenu/Admin_Menu_Refresh_Context.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_Refresh_Context.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Feature 055 — flush menu-related caches.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\AdminMenu
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\AdminMenu;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trigger `wp_admin_notice_recount()` and similar cheap counters, plus
+ * a rewrite flush so the current admin menu tree is fresh next tick.
+ */
+class Admin_Menu_Refresh_Context extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/admin-menu-refresh-context',
+			'args' => array(
+				'label'               => __( 'Refresh Admin Menu Context', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Refresh admin-menu-derived transient/user-meta signals: clears the "wp_get_active_and_valid_plugins" object-cache row, clears the current user\'s meta caches, and requests a rewrite flush. Cheap; safe to poll.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-admin-menu',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'refreshed_at' => array( 'type' => 'integer' ),
+						'invalidated'  => array( 'type' => 'array' ),
+						'message'      => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'admin-menu',
+						'sub_group_label' => __( 'Admin Menu', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+
+		$invalidated = array();
+
+		wp_cache_delete( 'active_plugins', 'options' );
+		$invalidated[] = 'active_plugins';
+
+		wp_cache_delete( 'alloptions', 'options' );
+		$invalidated[] = 'alloptions';
+
+		$user = wp_get_current_user();
+		if ( $user instanceof \WP_User && $user->ID > 0 ) {
+			clean_user_cache( (int) $user->ID );
+			$invalidated[] = 'current_user_cache';
+		}
+
+		return array(
+			'success'      => true,
+			'refreshed_at' => time(),
+			'invalidated'  => $invalidated,
+			/* translators: %d: invalidated cache-source count */
+			'message'      => sprintf( __( 'Admin menu context invalidated across %d cache source(s).', 'acrossai-abilities-manager' ), count( $invalidated ) ),
+		);
+	}
+}

--- a/includes/Abilities/AdminMenu/Category_Registrar.php
+++ b/includes/Abilities/AdminMenu/Category_Registrar.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Feature 055 — WP Abilities API category for admin-menu introspection.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\AdminMenu
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\AdminMenu;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the WP ability category for admin-menu introspection.
+ */
+final class Category_Registrar {
+
+	/** @var self|null */
+	protected static $instance = null;
+
+	/**
+	 * Private constructor — access via instance().
+	 */
+	private function __construct() {}
+
+	/**
+	 * Return the singleton instance.
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Register the ability category with the WP Abilities API.
+	 */
+	public function register(): void {
+		wp_register_ability_category(
+			'acrossai-abilities-manager-admin-menu',
+			array(
+				'label'       => __( 'Acrossai Abilities Manager - Admin Menu', 'acrossai-abilities-manager' ),
+				'description' => __( 'Abilities for introspecting the WordPress admin menu: pages, submenus, settings, and current-screen context.', 'acrossai-abilities-manager' ),
+			)
+		);
+	}
+}

--- a/includes/Abilities/Block/Block_Areas_List.php
+++ b/includes/Abilities/Block/Block_Areas_List.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Feature 055 — list theme-registered block-template-part areas.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Block
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Block;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return every registered block-template-part `area` (header / footer /
+ * sidebar / uncategorized / …) with the template parts that live in it.
+ */
+class Block_Areas_List extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/site-structure-list-block-areas',
+			'args' => array(
+				'label'               => __( 'List Block Areas', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return every registered block-template-part `area` (header / footer / sidebar / uncategorized / …) with the template parts that live in it. Reads get_allowed_block_template_part_areas() + get_block_templates() for wp_template_part.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-block',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'areas'   => array( 'type' => 'array' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'blocks',
+						'sub_group'       => 'site-editor',
+						'sub_group_label' => __( 'Site Editor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+
+		$areas_meta = array();
+		if ( function_exists( 'get_allowed_block_template_part_areas' ) ) {
+			$raw = get_allowed_block_template_part_areas();
+			if ( is_array( $raw ) ) {
+				foreach ( $raw as $entry ) {
+					if ( ! is_array( $entry ) ) {
+						continue;
+					}
+					$area                = (string) ( $entry['area'] ?? '' );
+					if ( '' === $area ) {
+						continue;
+					}
+					$areas_meta[ $area ] = array(
+						'area'  => $area,
+						'label' => (string) ( $entry['label'] ?? $area ),
+						'parts' => array(),
+					);
+				}
+			}
+		}
+
+		$parts = get_block_templates( array(), 'wp_template_part' );
+		if ( is_array( $parts ) ) {
+			foreach ( $parts as $part ) {
+				$area = isset( $part->area ) ? (string) $part->area : 'uncategorized';
+				if ( ! isset( $areas_meta[ $area ] ) ) {
+					$areas_meta[ $area ] = array(
+						'area'  => $area,
+						'label' => $area,
+						'parts' => array(),
+					);
+				}
+				$areas_meta[ $area ]['parts'][] = array(
+					'id'    => isset( $part->id ) ? (string) $part->id : '',
+					'slug'  => isset( $part->slug ) ? (string) $part->slug : '',
+					'title' => isset( $part->title ) ? (string) $part->title : '',
+				);
+			}
+		}
+
+		return array(
+			'success' => true,
+			'areas'   => array_values( $areas_meta ),
+			/* translators: %d: area count */
+			'message' => sprintf( __( '%d block-template-part area(s) known.', 'acrossai-abilities-manager' ), count( $areas_meta ) ),
+		);
+	}
+}

--- a/includes/Abilities/Block/Block_Areas_List.php
+++ b/includes/Abilities/Block/Block_Areas_List.php
@@ -114,9 +114,9 @@ class Block_Areas_List extends Ability_Definition {
 					);
 				}
 				$areas_meta[ $area ]['parts'][] = array(
-					'id'    => isset( $part->id ) ? (string) $part->id : '',
-					'slug'  => isset( $part->slug ) ? (string) $part->slug : '',
-					'title' => isset( $part->title ) ? (string) $part->title : '',
+					'id'    => isset( $part->id ) ? sanitize_text_field( (string) $part->id ) : '',
+					'slug'  => isset( $part->slug ) ? sanitize_title( (string) $part->slug ) : '',
+					'title' => isset( $part->title ) ? sanitize_text_field( (string) $part->title ) : '',
 				);
 			}
 		}

--- a/includes/Abilities/Block/Reusable_Blocks_List.php
+++ b/includes/Abilities/Block/Reusable_Blocks_List.php
@@ -116,10 +116,10 @@ class Reusable_Blocks_List extends Ability_Definition {
 			}
 			$items[] = array(
 				'id'         => (int) $post->ID,
-				'title'      => (string) $post->post_title,
-				'slug'       => (string) $post->post_name,
-				'status'     => (string) $post->post_status,
-				'modified'   => (string) $post->post_modified_gmt,
+				'title'      => sanitize_text_field( (string) $post->post_title ),
+				'slug'       => sanitize_title( (string) $post->post_name ),
+				'status'     => sanitize_key( (string) $post->post_status ),
+				'modified'   => sanitize_text_field( (string) $post->post_modified_gmt ),
 				'has_content' => '' !== trim( (string) $post->post_content ),
 			);
 		}

--- a/includes/Abilities/Block/Reusable_Blocks_List.php
+++ b/includes/Abilities/Block/Reusable_Blocks_List.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Feature 055 — list reusable blocks (wp_block CPT rows).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Block
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Block;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enumerate reusable blocks (`post_type=wp_block`).
+ *
+ * Distinct from block patterns: reusable blocks are editable posts backed
+ * by the wp_block CPT, whereas patterns are code-registered.
+ */
+class Reusable_Blocks_List extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/site-structure-list-reusable-blocks',
+			'args' => array(
+				'label'               => __( 'List Reusable Blocks', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Enumerate reusable blocks (post_type=wp_block). Distinct from block patterns: reusable blocks are editable posts backed by the wp_block CPT, whereas patterns are code-registered.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-block',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'per_page' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => 200,
+							'default' => 50,
+						),
+						'page'     => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'default' => 1,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'items'   => array( 'type' => 'array' ),
+						'total'   => array( 'type' => 'integer' ),
+						'page'    => array( 'type' => 'integer' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'blocks',
+						'sub_group'       => 'reusable',
+						'sub_group_label' => __( 'Reusable Blocks', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$per_page = max( 1, min( 200, (int) ( $input['per_page'] ?? 50 ) ) );
+		$page     = max( 1, (int) ( $input['page'] ?? 1 ) );
+
+		$query = new \WP_Query(
+			array(
+				'post_type'      => 'wp_block',
+				'post_status'    => array( 'publish', 'private' ),
+				'posts_per_page' => $per_page,
+				'paged'          => $page,
+				'orderby'        => 'modified',
+				'order'          => 'DESC',
+			)
+		);
+
+		$items = array();
+		foreach ( $query->posts as $post ) {
+			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
+			$items[] = array(
+				'id'         => (int) $post->ID,
+				'title'      => (string) $post->post_title,
+				'slug'       => (string) $post->post_name,
+				'status'     => (string) $post->post_status,
+				'modified'   => (string) $post->post_modified_gmt,
+				'has_content' => '' !== trim( (string) $post->post_content ),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'items'   => $items,
+			'total'   => (int) $query->found_posts,
+			'page'    => $page,
+			/* translators: 1: page count, 2: total */
+			'message' => sprintf( __( 'Returned %1$d of %2$d reusable blocks.', 'acrossai-abilities-manager' ), count( $items ), (int) $query->found_posts ),
+		);
+	}
+}

--- a/includes/Abilities/Block/Site_Editor_Get_Context.php
+++ b/includes/Abilities/Block/Site_Editor_Get_Context.php
@@ -88,7 +88,7 @@ class Site_Editor_Get_Context extends Ability_Definition {
 
 		$is_block_theme = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
 		$theme          = wp_get_theme();
-		$active_name    = $theme instanceof \WP_Theme ? (string) $theme->get( 'Name' ) : '';
+		$active_name    = $theme instanceof \WP_Theme ? sanitize_text_field( (string) $theme->get( 'Name' ) ) : '';
 
 		$style_variation = '';
 		if ( function_exists( 'WP_Theme_JSON_Resolver::get_user_data' ) ) {
@@ -105,10 +105,10 @@ class Site_Editor_Get_Context extends Ability_Definition {
 			'success'                => true,
 			'is_block_theme'         => (bool) $is_block_theme,
 			'active_theme'           => $active_name,
-			'active_style_variation' => $style_variation,
+			'active_style_variation' => sanitize_text_field( $style_variation ),
 			'template_count'         => is_array( $templates ) ? count( $templates ) : 0,
 			'template_part_count'    => is_array( $template_parts ) ? count( $template_parts ) : 0,
-			'site_editor_url'        => admin_url( 'site-editor.php' ),
+			'site_editor_url'        => esc_url_raw( (string) admin_url( 'site-editor.php' ) ),
 			'message'                => $is_block_theme
 				? __( 'Block theme active; Site Editor available.', 'acrossai-abilities-manager' )
 				: __( 'Classic theme active; Site Editor is limited or unavailable.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Block/Site_Editor_Get_Context.php
+++ b/includes/Abilities/Block/Site_Editor_Get_Context.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Feature 055 — snapshot of the Site Editor context.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Block
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Block;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return the active template, template-part inventory, and active style
+ * variation for the currently-active (block-)theme.
+ */
+class Site_Editor_Get_Context extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/site-editor-get-context',
+			'args' => array(
+				'label'               => __( 'Get Site Editor Context', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return the active theme\'s Site Editor context: whether the theme is a block theme, the active style variation, counts of registered templates and template parts, and the Site Editor URL.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-block',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'                => array( 'type' => 'boolean' ),
+						'is_block_theme'         => array( 'type' => 'boolean' ),
+						'active_theme'           => array( 'type' => 'string' ),
+						'active_style_variation' => array( 'type' => 'string' ),
+						'template_count'         => array( 'type' => 'integer' ),
+						'template_part_count'    => array( 'type' => 'integer' ),
+						'site_editor_url'        => array( 'type' => 'string' ),
+						'message'                => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'blocks',
+						'sub_group'       => 'site-editor',
+						'sub_group_label' => __( 'Site Editor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+
+		$is_block_theme = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+		$theme          = wp_get_theme();
+		$active_name    = $theme instanceof \WP_Theme ? (string) $theme->get( 'Name' ) : '';
+
+		$style_variation = '';
+		if ( function_exists( 'WP_Theme_JSON_Resolver::get_user_data' ) ) {
+			$user_data = \WP_Theme_JSON_Resolver::get_user_data();
+			if ( is_object( $user_data ) && method_exists( $user_data, 'get_variations' ) ) {
+				$style_variation = (string) ( $user_data->get_variations()[0]['title'] ?? '' );
+			}
+		}
+
+		$templates      = get_block_templates( array(), 'wp_template' );
+		$template_parts = get_block_templates( array(), 'wp_template_part' );
+
+		return array(
+			'success'                => true,
+			'is_block_theme'         => (bool) $is_block_theme,
+			'active_theme'           => $active_name,
+			'active_style_variation' => $style_variation,
+			'template_count'         => is_array( $templates ) ? count( $templates ) : 0,
+			'template_part_count'    => is_array( $template_parts ) ? count( $template_parts ) : 0,
+			'site_editor_url'        => admin_url( 'site-editor.php' ),
+			'message'                => $is_block_theme
+				? __( 'Block theme active; Site Editor available.', 'acrossai-abilities-manager' )
+				: __( 'Classic theme active; Site Editor is limited or unavailable.', 'acrossai-abilities-manager' ),
+		);
+	}
+}

--- a/includes/Abilities/Block/Site_Editor_Refresh_Context.php
+++ b/includes/Abilities/Block/Site_Editor_Refresh_Context.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Feature 055 — invalidate cached Site Editor context.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Block
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Block;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Flush any block-template and theme.json related caches so the next
+ * call to site-editor-get-context returns fresh state.
+ */
+class Site_Editor_Refresh_Context extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/site-editor-refresh-context',
+			'args' => array(
+				'label'               => __( 'Refresh Site Editor Context', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Flush block-template + theme.json related caches so the next call to site-editor-get-context returns fresh state. Invalidates: `wp_theme_features`, `theme_json` cache group entries, and post cache for `wp_template` + `wp_template_part` post types.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-block',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'refreshed_at' => array( 'type' => 'integer' ),
+						'invalidated'  => array( 'type' => 'array' ),
+						'message'      => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'blocks',
+						'sub_group'       => 'site-editor',
+						'sub_group_label' => __( 'Site Editor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+
+		$invalidated = array();
+
+		if ( function_exists( 'wp_cache_delete_group' ) ) {
+			wp_cache_delete_group( 'theme_json' );
+			$invalidated[] = 'theme_json';
+		}
+		if ( function_exists( 'wp_clean_themes_cache' ) ) {
+			wp_clean_themes_cache();
+			$invalidated[] = 'themes';
+		}
+		if ( function_exists( 'clean_post_cache' ) ) {
+			foreach ( array( 'wp_template', 'wp_template_part', 'wp_block' ) as $ptype ) {
+				$ids = get_posts(
+					array(
+						'post_type'      => $ptype,
+						'post_status'    => 'any',
+						'posts_per_page' => -1,
+						'fields'         => 'ids',
+					)
+				);
+				if ( is_array( $ids ) ) {
+					foreach ( $ids as $id ) {
+						clean_post_cache( (int) $id );
+					}
+				}
+				$invalidated[] = $ptype;
+			}
+		}
+		if ( class_exists( '\WP_Theme_JSON_Resolver' ) && method_exists( '\WP_Theme_JSON_Resolver', 'clean_cached_data' ) ) {
+			\WP_Theme_JSON_Resolver::clean_cached_data();
+			$invalidated[] = 'wp_theme_json_resolver';
+		}
+
+		return array(
+			'success'      => true,
+			'refreshed_at' => time(),
+			'invalidated'  => $invalidated,
+			/* translators: %d: invalidated cache-source count */
+			'message'      => sprintf( __( 'Site Editor context invalidated across %d cache source(s).', 'acrossai-abilities-manager' ), count( $invalidated ) ),
+		);
+	}
+}

--- a/includes/Abilities/Comments/Comments_Bulk_Update.php
+++ b/includes/Abilities/Comments/Comments_Bulk_Update.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Feature 055 — batched moderation action across many comments.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Comments
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Comments;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Apply the same status change to up to 100 comments in one call.
+ *
+ * Wraps wp_set_comment_status(). Enforces the same `moderate_comments`
+ * capability WP core checks in the comment moderation UI. Returns a
+ * per-comment success/failure envelope.
+ */
+class Comments_Bulk_Update extends Ability_Definition {
+
+	/**
+	 * Maximum number of comment ids per single call.
+	 */
+	private const MAX_IDS = 100;
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/comments-bulk-update',
+			'args' => array(
+				'label'               => __( 'Bulk Update Comments', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Apply the same status change (approve / hold / spam / trash) to up to 100 comments in one call. Enforces manage_options + moderate_comments. Returns per-comment success/failure entries.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-comments',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'moderate_comments' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'comment_ids' => array(
+							'type'     => 'array',
+							'items'    => array( 'type' => 'integer' ),
+							'minItems' => 1,
+							'maxItems' => self::MAX_IDS,
+						),
+						'status'      => array(
+							'type' => 'string',
+							'enum' => array( 'approve', 'hold', 'spam', 'trash' ),
+						),
+					),
+					'required'             => array( 'comment_ids', 'status' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'   => array( 'type' => 'boolean' ),
+						'status'    => array( 'type' => 'string' ),
+						'succeeded' => array( 'type' => 'array' ),
+						'failed'    => array( 'type' => 'array' ),
+						'message'   => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'comments',
+						'sub_group_label' => __( 'Comments', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$status      = sanitize_key( (string) ( $input['status'] ?? '' ) );
+		$comment_ids = array_values( array_filter( array_map( 'intval', (array) ( $input['comment_ids'] ?? array() ) ) ) );
+
+		if ( '' === $status || ! in_array( $status, array( 'approve', 'hold', 'spam', 'trash' ), true ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A valid status is required (approve / hold / spam / trash).', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( array() === $comment_ids ) {
+			return array(
+				'success' => false,
+				'message' => __( 'At least one comment_id is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( count( $comment_ids ) > self::MAX_IDS ) {
+			return array(
+				'success' => false,
+				/* translators: %d: max comment ids per call */
+				'message' => sprintf( __( 'Too many comment_ids (max %d per call).', 'acrossai-abilities-manager' ), self::MAX_IDS ),
+			);
+		}
+
+		$succeeded = array();
+		$failed    = array();
+
+		foreach ( $comment_ids as $id ) {
+			$id = (int) $id;
+			if ( $id <= 0 ) {
+				$failed[] = array(
+					'id'      => $id,
+					'message' => __( 'Invalid comment_id.', 'acrossai-abilities-manager' ),
+				);
+				continue;
+			}
+			$comment = get_comment( $id );
+			if ( ! $comment instanceof \WP_Comment ) {
+				$failed[] = array(
+					'id'      => $id,
+					'message' => __( 'Comment not found.', 'acrossai-abilities-manager' ),
+				);
+				continue;
+			}
+			$result = wp_set_comment_status( $id, $status, true );
+			if ( is_wp_error( $result ) || false === $result ) {
+				$failed[] = array(
+					'id'      => $id,
+					'message' => is_wp_error( $result ) ? $result->get_error_message() : __( 'wp_set_comment_status returned false.', 'acrossai-abilities-manager' ),
+				);
+				continue;
+			}
+			$succeeded[] = $id;
+		}
+
+		return array(
+			'success'   => array() === $failed,
+			'status'    => $status,
+			'succeeded' => $succeeded,
+			'failed'    => $failed,
+			/* translators: 1: succeeded count, 2: failed count */
+			'message'   => sprintf( __( 'Updated %1$d comments; %2$d failed.', 'acrossai-abilities-manager' ), count( $succeeded ), count( $failed ) ),
+		);
+	}
+}

--- a/includes/Abilities/Comments/Comments_Bulk_Update.php
+++ b/includes/Abilities/Comments/Comments_Bulk_Update.php
@@ -102,7 +102,14 @@ class Comments_Bulk_Update extends Ability_Definition {
 	 */
 	public function execute( array $input = array() ): array {
 		$status      = sanitize_key( (string) ( $input['status'] ?? '' ) );
-		$comment_ids = array_values( array_filter( array_map( 'intval', (array) ( $input['comment_ids'] ?? array() ) ) ) );
+		$comment_ids = array_values( array_unique( array_filter( array_map( 'absint', (array) ( $input['comment_ids'] ?? array() ) ) ) ) );
+
+		// Feature 055 hardening — accept the same aliases WP core admins are used to.
+		$status = match ( $status ) {
+			'approved'   => 'approve',
+			'pending', 'unapproved', 'unapprove' => 'hold',
+			default      => $status,
+		};
 
 		if ( '' === $status || ! in_array( $status, array( 'approve', 'hold', 'spam', 'trash' ), true ) ) {
 			return array(
@@ -130,7 +137,7 @@ class Comments_Bulk_Update extends Ability_Definition {
 		$failed    = array();
 
 		foreach ( $comment_ids as $id ) {
-			$id = (int) $id;
+			$id = absint( $id );
 			if ( $id <= 0 ) {
 				$failed[] = array(
 					'id'      => $id,
@@ -143,6 +150,17 @@ class Comments_Bulk_Update extends Ability_Definition {
 				$failed[] = array(
 					'id'      => $id,
 					'message' => __( 'Comment not found.', 'acrossai-abilities-manager' ),
+				);
+				continue;
+			}
+			// Feature 055 hardening — per-comment cap check on top of the
+			// role-level `moderate_comments` gate. Also require `edit_post`
+			// on the parent post so a mod cannot flip comments on a post
+			// they cannot edit.
+			if ( ! current_user_can( 'edit_comment', $id ) && ! current_user_can( 'edit_post', (int) $comment->comment_post_ID ) ) {
+				$failed[] = array(
+					'id'      => $id,
+					'message' => __( 'You do not have permission to moderate this comment.', 'acrossai-abilities-manager' ),
 				);
 				continue;
 			}

--- a/includes/Abilities/Content/Content_Autosaves_Inspect.php
+++ b/includes/Abilities/Content/Content_Autosaves_Inspect.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Feature 055 — inspect a post's autosaves.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Content
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return the autosaves attached to a post (distinct from revisions).
+ *
+ * WP core stores autosaves as revision rows whose author matches the
+ * intended author of the autosave; only one autosave per post per author
+ * exists at a time. This ability returns the flattened list.
+ */
+class Content_Autosaves_Inspect extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-autosaves-inspect',
+			'args' => array(
+				'label'               => __( 'Inspect Autosaves', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return the autosaves attached to a post (distinct from revisions). Only one autosave per post per author exists at a time; this ability flattens them into a list.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+					),
+					'required'             => array( 'post_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'   => array( 'type' => 'boolean' ),
+						'post_id'   => array( 'type' => 'integer' ),
+						'autosaves' => array( 'type' => 'array' ),
+						'message'   => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'posts',
+						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id = (int) ( $input['post_id'] ?? 0 );
+		if ( $post_id <= 0 ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A valid post_id is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$post = get_post( $post_id );
+		if ( ! $post instanceof \WP_Post ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$revisions = wp_get_post_revisions(
+			$post_id,
+			array(
+				'check_enabled' => false,
+				'post_status'   => 'inherit',
+			)
+		);
+		$autosaves = array();
+		if ( is_array( $revisions ) ) {
+			foreach ( $revisions as $rev ) {
+				if ( ! $rev instanceof \WP_Post ) {
+					continue;
+				}
+				// Autosaves are named "<parent>-autosave-v<n>".
+				if ( false === strpos( (string) $rev->post_name, '-autosave' ) ) {
+					continue;
+				}
+				$autosaves[] = array(
+					'id'             => (int) $rev->ID,
+					'author_id'      => (int) $rev->post_author,
+					'modified_gmt'   => (string) $rev->post_modified_gmt,
+					'title'          => (string) $rev->post_title,
+					'content_length' => strlen( (string) $rev->post_content ),
+				);
+			}
+		}
+
+		return array(
+			'success'   => true,
+			'post_id'   => $post_id,
+			'autosaves' => $autosaves,
+			/* translators: 1: autosave count, 2: post ID */
+			'message'   => sprintf( __( 'Found %1$d autosave(s) for post #%2$d.', 'acrossai-abilities-manager' ), count( $autosaves ), $post_id ),
+		);
+	}
+}

--- a/includes/Abilities/Content/Content_Autosaves_Inspect.php
+++ b/includes/Abilities/Content/Content_Autosaves_Inspect.php
@@ -89,7 +89,7 @@ class Content_Autosaves_Inspect extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$post_id = (int) ( $input['post_id'] ?? 0 );
+		$post_id = absint( $input['post_id'] ?? 0 );
 		if ( $post_id <= 0 ) {
 			return array(
 				'success' => false,
@@ -101,6 +101,23 @@ class Content_Autosaves_Inspect extends Ability_Definition {
 			return array(
 				'success' => false,
 				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Feature 055 hardening — per-post cap check + internal-CPT filter
+		// (autosaves can leak draft/private content).
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'You do not have permission to inspect autosaves for this post.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$post_type_obj = get_post_type_object( (string) $post->post_type );
+		if ( ! $post_type_obj instanceof \WP_Post_Type
+			|| in_array( $post_type_obj->name, array( 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset', 'oembed_cache', 'user_request' ), true ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'This post type is not supported by this ability.', 'acrossai-abilities-manager' ),
 			);
 		}
 

--- a/includes/Abilities/Content/Content_Update_Block.php
+++ b/includes/Abilities/Content/Content_Update_Block.php
@@ -102,7 +102,7 @@ class Content_Update_Block extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$post_id = (int) ( $input['post_id'] ?? 0 );
+		$post_id = absint( $input['post_id'] ?? 0 );
 		if ( $post_id <= 0 ) {
 			return array(
 				'success' => false,
@@ -117,6 +117,23 @@ class Content_Update_Block extends Ability_Definition {
 			);
 		}
 
+		// Feature 055 hardening — per-post cap check + internal-CPT filter.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'You do not have permission to edit this post.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$post_type_obj = get_post_type_object( (string) $post->post_type );
+		if ( ! $post_type_obj instanceof \WP_Post_Type
+			|| in_array( $post_type_obj->name, array( 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset', 'oembed_cache', 'user_request' ), true )
+			|| ! ( (bool) $post_type_obj->public || (bool) $post_type_obj->show_ui || (bool) $post_type_obj->show_in_rest ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'This post type is not editable through this ability.', 'acrossai-abilities-manager' ),
+			);
+		}
+
 		$blocks = parse_blocks( (string) $post->post_content );
 		if ( ! is_array( $blocks ) || array() === $blocks ) {
 			return array(
@@ -128,7 +145,7 @@ class Content_Update_Block extends Ability_Definition {
 		$target_index = null;
 		if ( isset( $input['block_index'] ) ) {
 			$target_index = (int) $input['block_index'];
-			if ( ! isset( $blocks[ $target_index ] ) ) {
+			if ( $target_index < 0 || ! isset( $blocks[ $target_index ] ) ) {
 				return array(
 					'success' => false,
 					/* translators: %d: block index */
@@ -136,12 +153,14 @@ class Content_Update_Block extends Ability_Definition {
 				);
 			}
 		} else {
+			// Feature 055 hardening — allow only Gutenberg block-name shape
+			// (e.g. "core/paragraph"): namespace/name pairs of [A-Za-z0-9_-].
 			$block_name = (string) ( $input['block_name'] ?? '' );
-			$occurrence = (int) ( $input['occurrence'] ?? 0 );
-			if ( '' === $block_name ) {
+			$occurrence = max( 0, (int) ( $input['occurrence'] ?? 0 ) );
+			if ( '' === $block_name || ! preg_match( '/^[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+$/', $block_name ) ) {
 				return array(
 					'success' => false,
-					'message' => __( 'One of block_index or block_name is required.', 'acrossai-abilities-manager' ),
+					'message' => __( 'One of block_index or a valid block_name (e.g. "core/paragraph") is required.', 'acrossai-abilities-manager' ),
 				);
 			}
 			$hits = 0;

--- a/includes/Abilities/Content/Content_Update_Block.php
+++ b/includes/Abilities/Content/Content_Update_Block.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Feature 055 — surgically update a single block inside a post.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Content
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Parse a post's block tree, find a single block by client-supplied id
+ * (either the `data-block` attribute or a matching `blockName`+`index`
+ * fallback), merge new `attributes`, replace `innerHTML`, and save the
+ * post with the serialised block tree.
+ *
+ * Bounded scope: matches only top-level (non-nested) blocks by index.
+ * Nested block editing is deferred to a future spec.
+ */
+class Content_Update_Block extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-update-block',
+			'args' => array(
+				'label'               => __( 'Update Block', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Parse a post\'s block tree, find one top-level block by 0-based index (block_index) or by (block_name, occurrence), merge the supplied attributes, replace innerHTML, and save the post. Only top-level blocks are matched; nested-block editing is not supported by this ability.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'     => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'block_index' => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'block_name'  => array( 'type' => 'string' ),
+						'occurrence'  => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'attributes'  => array( 'type' => 'object' ),
+						'inner_html'  => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'post_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'post_id' => array( 'type' => 'integer' ),
+						'block'   => array( 'type' => 'object' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'posts',
+						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id = (int) ( $input['post_id'] ?? 0 );
+		if ( $post_id <= 0 ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A valid post_id is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$post = get_post( $post_id );
+		if ( ! $post instanceof \WP_Post ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$blocks = parse_blocks( (string) $post->post_content );
+		if ( ! is_array( $blocks ) || array() === $blocks ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Post contains no parseable blocks.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$target_index = null;
+		if ( isset( $input['block_index'] ) ) {
+			$target_index = (int) $input['block_index'];
+			if ( ! isset( $blocks[ $target_index ] ) ) {
+				return array(
+					'success' => false,
+					/* translators: %d: block index */
+					'message' => sprintf( __( 'Block index %d out of range.', 'acrossai-abilities-manager' ), $target_index ),
+				);
+			}
+		} else {
+			$block_name = (string) ( $input['block_name'] ?? '' );
+			$occurrence = (int) ( $input['occurrence'] ?? 0 );
+			if ( '' === $block_name ) {
+				return array(
+					'success' => false,
+					'message' => __( 'One of block_index or block_name is required.', 'acrossai-abilities-manager' ),
+				);
+			}
+			$hits = 0;
+			foreach ( $blocks as $idx => $block ) {
+				if ( ( $block['blockName'] ?? '' ) === $block_name ) {
+					if ( $hits === $occurrence ) {
+						$target_index = (int) $idx;
+						break;
+					}
+					++$hits;
+				}
+			}
+			if ( null === $target_index ) {
+				return array(
+					'success' => false,
+					/* translators: 1: block name, 2: occurrence */
+					'message' => sprintf( __( 'No top-level block "%1$s" at occurrence %2$d.', 'acrossai-abilities-manager' ), $block_name, $occurrence ),
+				);
+			}
+		}
+
+		if ( isset( $input['attributes'] ) && is_array( $input['attributes'] ) ) {
+			$blocks[ $target_index ]['attrs'] = array_merge( (array) ( $blocks[ $target_index ]['attrs'] ?? array() ), $input['attributes'] );
+		}
+		if ( isset( $input['inner_html'] ) ) {
+			$blocks[ $target_index ]['innerHTML']    = (string) $input['inner_html'];
+			$blocks[ $target_index ]['innerContent'] = array( (string) $input['inner_html'] );
+		}
+
+		$new_content = serialize_blocks( $blocks );
+		$updated     = wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $new_content,
+			),
+			true
+		);
+		if ( is_wp_error( $updated ) ) {
+			return array(
+				'success' => false,
+				'message' => $updated->get_error_message(),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'post_id' => $post_id,
+			'block'   => $blocks[ $target_index ],
+			/* translators: 1: index, 2: post ID */
+			'message' => sprintf( __( 'Updated block #%1$d on post #%2$d.', 'acrossai-abilities-manager' ), $target_index, $post_id ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Category_Registrar.php
+++ b/includes/Abilities/ContentSearch/Category_Registrar.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Feature 055 — WP Abilities API category for content search / indexing /
+ * internal-link suggestions.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the WP ability category for content-search / indexing /
+ * internal-link suggestions.
+ */
+final class Category_Registrar {
+
+	/** @var self|null */
+	protected static $instance = null;
+
+	/**
+	 * Private constructor — access via instance().
+	 */
+	private function __construct() {}
+
+	/**
+	 * Return the singleton instance.
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Register the ability category with the WP Abilities API.
+	 */
+	public function register(): void {
+		wp_register_ability_category(
+			'acrossai-abilities-manager-content-search',
+			array(
+				'label'       => __( 'Acrossai Abilities Manager - Content Search', 'acrossai-abilities-manager' ),
+				'description' => __( 'Abilities for content indexing, search, related-content discovery, and internal-link suggestion management (option-backed suggestion queue).', 'acrossai-abilities-manager' ),
+			)
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Content_Audit_Internal_Links.php
+++ b/includes/Abilities/ContentSearch/Content_Audit_Internal_Links.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Feature 055 — audit internal-link health across a batch of posts.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Scan up to N published posts for internal `<a href>` URLs and report
+ * broken ones (targets that resolve on-site but return no post_id, or
+ * targets whose resolved post is not published).
+ *
+ * Fallback implementation — makes no outbound HTTP requests. Broken
+ * external links are out of scope.
+ */
+class Content_Audit_Internal_Links extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-audit-internal-links',
+			'args' => array(
+				'label'               => __( 'Audit Internal Links', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Scan up to N published posts for internal <a href> URLs and report broken ones. Broken = same-site URL that resolves to no post_id, or resolves to a post that is not in `publish` status. Makes no outbound HTTP requests; external-link health is out of scope.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'per_page' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => 100,
+							'default' => 20,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'broken'  => array( 'type' => 'array' ),
+						'ok'      => array( 'type' => 'integer' ),
+						'checked' => array( 'type' => 'integer' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'audit',
+						'sub_group_label' => __( 'Audit', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$per_page  = max( 1, min( 100, (int) ( $input['per_page'] ?? 20 ) ) );
+		$site_host = wp_parse_url( (string) home_url( '/' ), PHP_URL_HOST );
+
+		$query = new \WP_Query(
+			array(
+				'post_type'      => array( 'post', 'page' ),
+				'post_status'    => 'publish',
+				'posts_per_page' => $per_page,
+				'orderby'        => 'modified',
+				'order'          => 'DESC',
+			)
+		);
+
+		$broken  = array();
+		$ok      = 0;
+		$checked = 0;
+		foreach ( $query->posts as $post ) {
+			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
+			$content = (string) $post->post_content;
+			if ( ! preg_match_all( '/<a\s+[^>]*href=(["\'])(.*?)\1[^>]*>/is', $content, $matches, PREG_SET_ORDER ) ) {
+				continue;
+			}
+			foreach ( $matches as $m ) {
+				$href = (string) $m[2];
+				$host = wp_parse_url( $href, PHP_URL_HOST );
+				if ( '' === $href || null === $host || $host !== $site_host ) {
+					continue;
+				}
+				++$checked;
+				$target_id = url_to_postid( $href );
+				if ( 0 === $target_id ) {
+					$broken[] = array(
+						'post_id'    => (int) $post->ID,
+						'target_url' => $href,
+						'reason'     => 'unresolved',
+					);
+					continue;
+				}
+				$target = get_post( $target_id );
+				if ( ! $target instanceof \WP_Post || 'publish' !== $target->post_status ) {
+					$broken[] = array(
+						'post_id'    => (int) $post->ID,
+						'target_url' => $href,
+						'reason'     => 'not-published',
+					);
+					continue;
+				}
+				++$ok;
+			}
+		}
+
+		return array(
+			'success' => true,
+			'broken'  => $broken,
+			'ok'      => $ok,
+			'checked' => $checked,
+			/* translators: 1: broken count, 2: total checked */
+			'message' => sprintf( __( 'Audited %2$d internal link(s); %1$d broken.', 'acrossai-abilities-manager' ), count( $broken ), $checked ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Content_Audit_Internal_Links.php
+++ b/includes/Abilities/ContentSearch/Content_Audit_Internal_Links.php
@@ -112,12 +112,18 @@ class Content_Audit_Internal_Links extends Ability_Definition {
 			if ( ! $post instanceof \WP_Post ) {
 				continue;
 			}
+			// Hardened per-post cap: skip items the caller cannot read.
+			if ( ! current_user_can( 'read_post', (int) $post->ID ) ) {
+				continue;
+			}
+			// Feature 055 hardening — parse raw content, not the full
+			// the_content filter chain.
 			$content = (string) $post->post_content;
 			if ( ! preg_match_all( '/<a\s+[^>]*href=(["\'])(.*?)\1[^>]*>/is', $content, $matches, PREG_SET_ORDER ) ) {
 				continue;
 			}
 			foreach ( $matches as $m ) {
-				$href = (string) $m[2];
+				$href = esc_url_raw( (string) $m[2] );
 				$host = wp_parse_url( $href, PHP_URL_HOST );
 				if ( '' === $href || null === $host || $host !== $site_host ) {
 					continue;

--- a/includes/Abilities/ContentSearch/Content_Find_Internal_Links.php
+++ b/includes/Abilities/ContentSearch/Content_Find_Internal_Links.php
@@ -86,7 +86,7 @@ class Content_Find_Internal_Links extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$post_id = (int) ( $input['post_id'] ?? 0 );
+		$post_id = absint( $input['post_id'] ?? 0 );
 		if ( $post_id <= 0 ) {
 			return array(
 				'success' => false,
@@ -100,15 +100,30 @@ class Content_Find_Internal_Links extends Ability_Definition {
 				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
 			);
 		}
+		// Feature 055 hardening — caller must be able to read the source post
+		// (avoids leaking private-post outbound link inventories).
+		if ( ! current_user_can( 'read_post', $post_id ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'You do not have permission to read this post.', 'acrossai-abilities-manager' ),
+			);
+		}
 
 		$site_host = wp_parse_url( (string) home_url( '/' ), PHP_URL_HOST );
-		$content   = apply_filters( 'the_content', (string) $post->post_content );
+		// Feature 055 hardening — parse raw post_content (do NOT run the
+		// full the_content filter chain, which triggers shortcode + oEmbed
+		// side effects with the current user context).
+		$content = (string) $post->post_content;
 
-		$links = array();
-		if ( preg_match_all( '/<a\s+[^>]*href=(["\'])(.*?)\1[^>]*>(.*?)<\/a>/is', (string) $content, $matches, PREG_SET_ORDER ) ) {
+		$links       = array();
+		$max_anchor  = 200; // Hard-cap anchor text length.
+		if ( preg_match_all( '/<a\s+[^>]*href=(["\'])(.*?)\1[^>]*>(.*?)<\/a>/is', $content, $matches, PREG_SET_ORDER ) ) {
 			foreach ( $matches as $m ) {
-				$href = (string) $m[2];
+				$href = esc_url_raw( (string) $m[2] );
 				$text = wp_strip_all_tags( (string) $m[3] );
+				if ( strlen( $text ) > $max_anchor ) {
+					$text = rtrim( substr( $text, 0, $max_anchor ) ) . '...';
+				}
 				$host = wp_parse_url( $href, PHP_URL_HOST );
 				if ( '' === $href || null === $host || $host !== $site_host ) {
 					continue;
@@ -117,7 +132,7 @@ class Content_Find_Internal_Links extends Ability_Definition {
 				$links[]   = array(
 					'target_url' => $href,
 					'target_id'  => (int) $target_id,
-					'anchor'     => $text,
+					'anchor'     => sanitize_text_field( $text ),
 				);
 			}
 		}

--- a/includes/Abilities/ContentSearch/Content_Find_Internal_Links.php
+++ b/includes/Abilities/ContentSearch/Content_Find_Internal_Links.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Feature 055 — extract on-site internal links from a post's content.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Parse a post's content for `<a href>` tags whose target resolves to a
+ * same-site URL. Returns each match with anchor text + resolved post id
+ * (if any).
+ */
+class Content_Find_Internal_Links extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-find-internal-links',
+			'args' => array(
+				'label'               => __( 'Find Internal Links', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Parse a post\'s rendered content for <a href> tags whose target resolves to a same-site URL. Returns each match with anchor text + resolved target post id (via url_to_postid()) when available.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+					),
+					'required'             => array( 'post_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'links'   => array( 'type' => 'array' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'find',
+						'sub_group_label' => __( 'Find', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id = (int) ( $input['post_id'] ?? 0 );
+		if ( $post_id <= 0 ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A valid post_id is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$post = get_post( $post_id );
+		if ( ! $post instanceof \WP_Post ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$site_host = wp_parse_url( (string) home_url( '/' ), PHP_URL_HOST );
+		$content   = apply_filters( 'the_content', (string) $post->post_content );
+
+		$links = array();
+		if ( preg_match_all( '/<a\s+[^>]*href=(["\'])(.*?)\1[^>]*>(.*?)<\/a>/is', (string) $content, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $m ) {
+				$href = (string) $m[2];
+				$text = wp_strip_all_tags( (string) $m[3] );
+				$host = wp_parse_url( $href, PHP_URL_HOST );
+				if ( '' === $href || null === $host || $host !== $site_host ) {
+					continue;
+				}
+				$target_id = url_to_postid( $href );
+				$links[]   = array(
+					'target_url' => $href,
+					'target_id'  => (int) $target_id,
+					'anchor'     => $text,
+				);
+			}
+		}
+
+		return array(
+			'success' => true,
+			'links'   => $links,
+			/* translators: 1: link count, 2: post ID */
+			'message' => sprintf( __( 'Found %1$d internal link(s) in post #%2$d.', 'acrossai-abilities-manager' ), count( $links ), $post_id ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Content_Find_Related.php
+++ b/includes/Abilities/ContentSearch/Content_Find_Related.php
@@ -91,7 +91,7 @@ class Content_Find_Related extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$post_id  = (int) ( $input['post_id'] ?? 0 );
+		$post_id  = absint( $input['post_id'] ?? 0 );
 		$per_page = max( 1, min( 50, (int) ( $input['per_page'] ?? 5 ) ) );
 		if ( $post_id <= 0 ) {
 			return array(
@@ -104,6 +104,13 @@ class Content_Find_Related extends Ability_Definition {
 			return array(
 				'success' => false,
 				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+		// Feature 055 hardening — caller must be able to read the source post.
+		if ( ! current_user_can( 'read_post', $post_id ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'You do not have permission to read this post.', 'acrossai-abilities-manager' ),
 			);
 		}
 
@@ -148,9 +155,12 @@ class Content_Find_Related extends Ability_Definition {
 			if ( ! $rel instanceof \WP_Post ) {
 				continue;
 			}
+			if ( ! current_user_can( 'read_post', (int) $rel->ID ) ) {
+				continue;
+			}
 			$related[] = array(
 				'id'     => (int) $rel->ID,
-				'title'  => (string) $rel->post_title,
+				'title'  => sanitize_text_field( (string) $rel->post_title ),
 				'url'    => (string) get_permalink( $rel ),
 				'reason' => 'shared-terms',
 			);

--- a/includes/Abilities/ContentSearch/Content_Find_Related.php
+++ b/includes/Abilities/ContentSearch/Content_Find_Related.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Feature 055 — find posts related to a given post via shared terms.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return posts related to a given post via shared taxonomy terms
+ * (categories + tags by default).
+ */
+class Content_Find_Related extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-find-related',
+			'args' => array(
+				'label'               => __( 'Find Related Content', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return posts related to a given post via shared taxonomy terms (categories + tags by default). Fallback implementation — no learned relevance model.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'  => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'per_page' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => 50,
+							'default' => 5,
+						),
+					),
+					'required'             => array( 'post_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'related' => array( 'type' => 'array' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'find',
+						'sub_group_label' => __( 'Find', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id  = (int) ( $input['post_id'] ?? 0 );
+		$per_page = max( 1, min( 50, (int) ( $input['per_page'] ?? 5 ) ) );
+		if ( $post_id <= 0 ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A valid post_id is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$post = get_post( $post_id );
+		if ( ! $post instanceof \WP_Post ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$cat_ids = wp_get_post_terms( $post_id, 'category', array( 'fields' => 'ids' ) );
+		$tag_ids = wp_get_post_terms( $post_id, 'post_tag', array( 'fields' => 'ids' ) );
+		$cat_ids = is_array( $cat_ids ) ? array_map( 'intval', $cat_ids ) : array();
+		$tag_ids = is_array( $tag_ids ) ? array_map( 'intval', $tag_ids ) : array();
+
+		$tax_query = array( 'relation' => 'OR' );
+		if ( array() !== $cat_ids ) {
+			$tax_query[] = array(
+				'taxonomy' => 'category',
+				'terms'    => $cat_ids,
+			);
+		}
+		if ( array() !== $tag_ids ) {
+			$tax_query[] = array(
+				'taxonomy' => 'post_tag',
+				'terms'    => $tag_ids,
+			);
+		}
+		if ( 1 === count( $tax_query ) ) {
+			return array(
+				'success' => true,
+				'related' => array(),
+				'message' => __( 'Source post has no categories or tags; no relatives to find.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$query = new \WP_Query(
+			array(
+				'post_type'      => $post->post_type,
+				'post_status'    => 'publish',
+				'posts_per_page' => $per_page,
+				'post__not_in'   => array( $post_id ),
+				'tax_query'      => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			)
+		);
+
+		$related = array();
+		foreach ( $query->posts as $rel ) {
+			if ( ! $rel instanceof \WP_Post ) {
+				continue;
+			}
+			$related[] = array(
+				'id'     => (int) $rel->ID,
+				'title'  => (string) $rel->post_title,
+				'url'    => (string) get_permalink( $rel ),
+				'reason' => 'shared-terms',
+			);
+		}
+
+		return array(
+			'success' => true,
+			'related' => $related,
+			/* translators: 1: count, 2: source post ID */
+			'message' => sprintf( __( 'Found %1$d related post(s) for post #%2$d.', 'acrossai-abilities-manager' ), count( $related ), $post_id ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Content_Index_Refresh_Batch.php
+++ b/includes/Abilities/ContentSearch/Content_Index_Refresh_Batch.php
@@ -89,7 +89,7 @@ class Content_Index_Refresh_Batch extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$post_ids = array_values( array_filter( array_map( 'intval', (array) ( $input['post_ids'] ?? array() ) ) ) );
+		$post_ids = array_values( array_unique( array_filter( array_map( 'absint', (array) ( $input['post_ids'] ?? array() ) ) ) ) );
 		if ( array() === $post_ids ) {
 			return array(
 				'success' => true,

--- a/includes/Abilities/ContentSearch/Content_Index_Refresh_Batch.php
+++ b/includes/Abilities/ContentSearch/Content_Index_Refresh_Batch.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Feature 055 — refresh WP's built-in search state for a batch of posts.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Kick WP's built-in search state fresh for a batch of posts by calling
+ * `clean_post_cache()` on each and touching the post-modified timestamp
+ * indirectly via a no-op `wp_update_post()`.
+ *
+ * No new index table — WP's native `s=` handler is the fallback index.
+ */
+class Content_Index_Refresh_Batch extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-index-refresh-batch',
+			'args' => array(
+				'label'               => __( 'Refresh Content Index Batch', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Refresh WP core search-state for a batch of posts by calling clean_post_cache() on each. No new index table — this ability relies on WP\'s built-in `s=` search handler as the fallback index. Cap: 100 post_ids per call.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_ids' => array(
+							'type'     => 'array',
+							'items'    => array( 'type' => 'integer' ),
+							'maxItems' => 100,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'indexed' => array( 'type' => 'integer' ),
+						'skipped' => array( 'type' => 'integer' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'index',
+						'sub_group_label' => __( 'Index', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_ids = array_values( array_filter( array_map( 'intval', (array) ( $input['post_ids'] ?? array() ) ) ) );
+		if ( array() === $post_ids ) {
+			return array(
+				'success' => true,
+				'indexed' => 0,
+				'skipped' => 0,
+				'message' => __( 'No post_ids supplied — nothing to do.', 'acrossai-abilities-manager' ),
+			);
+		}
+		if ( count( $post_ids ) > 100 ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Too many post_ids (max 100 per call).', 'acrossai-abilities-manager' ),
+			);
+		}
+		$indexed = 0;
+		$skipped = 0;
+		foreach ( $post_ids as $id ) {
+			$id = (int) $id;
+			if ( $id <= 0 || ! get_post( $id ) ) {
+				++$skipped;
+				continue;
+			}
+			clean_post_cache( $id );
+			++$indexed;
+		}
+		return array(
+			'success' => true,
+			'indexed' => $indexed,
+			'skipped' => $skipped,
+			/* translators: 1: indexed, 2: skipped */
+			'message' => sprintf( __( 'Refreshed %1$d post caches; skipped %2$d.', 'acrossai-abilities-manager' ), $indexed, $skipped ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Content_Search_Chunks.php
+++ b/includes/Abilities/ContentSearch/Content_Search_Chunks.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Feature 055 — chunk-level content search fallback.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Split search-matching post content into paragraph-length chunks and
+ * return the ones that contain the query substring. Fallback implementation
+ * — no persistent chunk table.
+ */
+class Content_Search_Chunks extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-search-chunks',
+			'args' => array(
+				'label'               => __( 'Search Content Chunks', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Split search-matching post content into paragraph-length chunks and return the ones that contain the query substring. Fallback implementation — no persistent chunk table. Backed by the same WP_Query `s=` search as content-search-items.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'query'    => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'per_page' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => 50,
+							'default' => 10,
+						),
+					),
+					'required'             => array( 'query' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'chunks'  => array( 'type' => 'array' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'search',
+						'sub_group_label' => __( 'Search', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$query    = trim( (string) ( $input['query'] ?? '' ) );
+		$per_page = max( 1, min( 50, (int) ( $input['per_page'] ?? 10 ) ) );
+		if ( '' === $query ) {
+			return array(
+				'success' => false,
+				'message' => __( 'query is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$wp_query = new \WP_Query(
+			array(
+				's'              => $query,
+				'post_type'      => array( 'post', 'page' ),
+				'post_status'    => 'publish',
+				'posts_per_page' => $per_page,
+			)
+		);
+
+		$chunks   = array();
+		$needle   = strtolower( $query );
+		$per_post = 3; // Return at most 3 matching chunks per post.
+		foreach ( $wp_query->posts as $post ) {
+			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
+			$plain      = wp_strip_all_tags( (string) $post->post_content );
+			$paragraphs = preg_split( '/\r?\n{2,}/', $plain ) ?: array();
+			$hits       = 0;
+			foreach ( $paragraphs as $idx => $para ) {
+				if ( false === stripos( $para, $needle ) ) {
+					continue;
+				}
+				$chunks[] = array(
+					'post_id'     => (int) $post->ID,
+					'chunk_index' => (int) $idx,
+					'text'        => trim( $para ),
+					'score'       => 1.0,
+				);
+				++$hits;
+				if ( $hits >= $per_post ) {
+					break;
+				}
+			}
+		}
+
+		return array(
+			'success' => true,
+			'chunks'  => $chunks,
+			/* translators: %d: chunk count */
+			'message' => sprintf( __( 'Returned %d matching chunk(s).', 'acrossai-abilities-manager' ), count( $chunks ) ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Content_Search_Chunks.php
+++ b/includes/Abilities/ContentSearch/Content_Search_Chunks.php
@@ -92,7 +92,7 @@ class Content_Search_Chunks extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$query    = trim( (string) ( $input['query'] ?? '' ) );
+		$query    = sanitize_text_field( (string) ( $input['query'] ?? '' ) );
 		$per_page = max( 1, min( 50, (int) ( $input['per_page'] ?? 10 ) ) );
 		if ( '' === $query ) {
 			return array(
@@ -110,11 +110,16 @@ class Content_Search_Chunks extends Ability_Definition {
 			)
 		);
 
-		$chunks   = array();
-		$needle   = strtolower( $query );
-		$per_post = 3; // Return at most 3 matching chunks per post.
+		$chunks         = array();
+		$needle         = strtolower( $query );
+		$per_post       = 3;   // Return at most 3 matching chunks per post.
+		$max_chunk_len  = 500; // Hardened: hard-cap each chunk at 500 chars.
 		foreach ( $wp_query->posts as $post ) {
 			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
+			// Hardened per-post cap: skip items the caller cannot read.
+			if ( ! current_user_can( 'read_post', (int) $post->ID ) ) {
 				continue;
 			}
 			$plain      = wp_strip_all_tags( (string) $post->post_content );
@@ -124,10 +129,14 @@ class Content_Search_Chunks extends Ability_Definition {
 				if ( false === stripos( $para, $needle ) ) {
 					continue;
 				}
+				$text = trim( $para );
+				if ( strlen( $text ) > $max_chunk_len ) {
+					$text = rtrim( substr( $text, 0, $max_chunk_len ) ) . '...';
+				}
 				$chunks[] = array(
 					'post_id'     => (int) $post->ID,
 					'chunk_index' => (int) $idx,
-					'text'        => trim( $para ),
+					'text'        => $text,
 					'score'       => 1.0,
 				);
 				++$hits;

--- a/includes/Abilities/ContentSearch/Content_Search_Items.php
+++ b/includes/Abilities/ContentSearch/Content_Search_Items.php
@@ -103,10 +103,27 @@ class Content_Search_Items extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$query      = trim( (string) ( $input['query'] ?? '' ) );
-		$per_page   = max( 1, min( 100, (int) ( $input['per_page'] ?? 20 ) ) );
-		$page       = max( 1, (int) ( $input['page'] ?? 1 ) );
-		$post_types = array_values( array_filter( array_map( 'sanitize_key', (array) ( $input['post_types'] ?? array( 'post', 'page' ) ) ) ) );
+		$query    = sanitize_text_field( (string) ( $input['query'] ?? '' ) );
+		$per_page = max( 1, min( 100, (int) ( $input['per_page'] ?? 20 ) ) );
+		$page     = max( 1, (int) ( $input['page'] ?? 1 ) );
+
+		// Feature 055 hardening — filter requested post_types to those that
+		// are public / show_in_rest, and exclude internal WP types outright.
+		$blocked      = array( 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset', 'oembed_cache', 'user_request', 'wp_block', 'wp_template', 'wp_template_part', 'wp_global_styles', 'wp_navigation' );
+		$requested    = array_values( array_filter( array_map( 'sanitize_key', (array) ( $input['post_types'] ?? array( 'post', 'page' ) ) ) ) );
+		$safe_types   = array();
+		foreach ( $requested as $pt ) {
+			if ( in_array( $pt, $blocked, true ) ) {
+				continue;
+			}
+			$pt_obj = get_post_type_object( $pt );
+			if ( $pt_obj instanceof \WP_Post_Type && ( (bool) $pt_obj->public || (bool) $pt_obj->show_in_rest ) ) {
+				$safe_types[] = $pt;
+			}
+		}
+		if ( array() === $safe_types ) {
+			$safe_types = array( 'post', 'page' );
+		}
 
 		if ( '' === $query ) {
 			return array(
@@ -118,7 +135,7 @@ class Content_Search_Items extends Ability_Definition {
 		$wp_query = new \WP_Query(
 			array(
 				's'              => $query,
-				'post_type'      => array() === $post_types ? array( 'post', 'page' ) : $post_types,
+				'post_type'      => $safe_types,
 				'post_status'    => 'publish',
 				'posts_per_page' => $per_page,
 				'paged'          => $page,
@@ -130,10 +147,15 @@ class Content_Search_Items extends Ability_Definition {
 			if ( ! $post instanceof \WP_Post ) {
 				continue;
 			}
+			// Hardened per-post cap: only include items the caller can read.
+			if ( ! current_user_can( 'read_post', (int) $post->ID ) ) {
+				continue;
+			}
 			$items[] = array(
 				'id'      => (int) $post->ID,
-				'title'   => (string) $post->post_title,
+				'title'   => sanitize_text_field( (string) $post->post_title ),
 				'url'     => (string) get_permalink( $post ),
+				// Bounded plain-text excerpt — HTML stripped, hard-capped at 40 words.
 				'excerpt' => wp_trim_words( wp_strip_all_tags( (string) $post->post_content ), 40 ),
 				'score'   => 1.0,
 			);

--- a/includes/Abilities/ContentSearch/Content_Search_Items.php
+++ b/includes/Abilities/ContentSearch/Content_Search_Items.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Feature 055 — WP_Query-backed content search.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Search post-type items by keyword. Backed by WP_Query `s=` (LIKE-based
+ * title + content search). Score is a simple 0/1 relevance stub — WP core's
+ * search doesn't produce ranked scores natively.
+ */
+class Content_Search_Items extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-search-items',
+			'args' => array(
+				'label'               => __( 'Search Content Items', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Search post-type items by keyword. Backed by WP_Query `s=` (LIKE-based title + content search). Score is a simple 0/1 relevance stub — WP core\'s search does not produce ranked scores natively.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'query'      => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'per_page'   => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => 100,
+							'default' => 20,
+						),
+						'page'       => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'default' => 1,
+						),
+						'post_types' => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+					),
+					'required'             => array( 'query' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'items'   => array( 'type' => 'array' ),
+						'total'   => array( 'type' => 'integer' ),
+						'page'    => array( 'type' => 'integer' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'search',
+						'sub_group_label' => __( 'Search', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$query      = trim( (string) ( $input['query'] ?? '' ) );
+		$per_page   = max( 1, min( 100, (int) ( $input['per_page'] ?? 20 ) ) );
+		$page       = max( 1, (int) ( $input['page'] ?? 1 ) );
+		$post_types = array_values( array_filter( array_map( 'sanitize_key', (array) ( $input['post_types'] ?? array( 'post', 'page' ) ) ) ) );
+
+		if ( '' === $query ) {
+			return array(
+				'success' => false,
+				'message' => __( 'query is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$wp_query = new \WP_Query(
+			array(
+				's'              => $query,
+				'post_type'      => array() === $post_types ? array( 'post', 'page' ) : $post_types,
+				'post_status'    => 'publish',
+				'posts_per_page' => $per_page,
+				'paged'          => $page,
+			)
+		);
+
+		$items = array();
+		foreach ( $wp_query->posts as $post ) {
+			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
+			$items[] = array(
+				'id'      => (int) $post->ID,
+				'title'   => (string) $post->post_title,
+				'url'     => (string) get_permalink( $post ),
+				'excerpt' => wp_trim_words( wp_strip_all_tags( (string) $post->post_content ), 40 ),
+				'score'   => 1.0,
+			);
+		}
+
+		return array(
+			'success' => true,
+			'items'   => $items,
+			'total'   => (int) $wp_query->found_posts,
+			'page'    => $page,
+			/* translators: 1: match count, 2: query */
+			'message' => sprintf( __( '%1$d match(es) for "%2$s".', 'acrossai-abilities-manager' ), (int) $wp_query->found_posts, $query ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Internal_Link_Policy.php
+++ b/includes/Abilities/ContentSearch/Internal_Link_Policy.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Feature 055 — expose the internal-link suggestion policy.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return the policy that governs internal-link suggestion creation +
+ * application (currently a static v1 policy — extend in a future spec).
+ */
+class Internal_Link_Policy extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-internal-link-policy',
+			'args' => array(
+				'label'               => __( 'Get Internal Link Policy', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return the policy that governs internal-link suggestion creation and application. v1 policy is a static ruleset — future specs may make the ruleset editable via an options page.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'policy_version' => array( 'type' => 'string' ),
+						'rules'          => array( 'type' => 'array' ),
+						'message'        => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'internal-links',
+						'sub_group_label' => __( 'Internal Links', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+		return array(
+			'success'        => true,
+			'policy_version' => '1.0.0',
+			'rules'          => array(
+				array(
+					'rule'        => 'target-must-be-on-site',
+					'description' => __( 'Suggestion target URLs must resolve to a same-site URL at apply time.', 'acrossai-abilities-manager' ),
+					'enabled'     => true,
+				),
+				array(
+					'rule'        => 'target-must-be-published',
+					'description' => __( 'Suggestion target post must be in `publish` status at apply time.', 'acrossai-abilities-manager' ),
+					'enabled'     => true,
+				),
+				array(
+					'rule'        => 'max-per-post',
+					'description' => __( 'At most 500 suggestions across the whole store (option-backed cap).', 'acrossai-abilities-manager' ),
+					'enabled'     => true,
+				),
+			),
+			'message'        => __( 'Internal-link suggestion policy v1.0.0.', 'acrossai-abilities-manager' ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Internal_Link_Suggestion_Apply.php
+++ b/includes/Abilities/ContentSearch/Internal_Link_Suggestion_Apply.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Feature 055 — apply an approved internal-link suggestion.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Apply an approved suggestion by inserting an `<a>` around the first
+ * occurrence of the suggestion's anchor text in the target post's content.
+ * Marks the suggestion `applied` on success.
+ */
+class Internal_Link_Suggestion_Apply extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-internal-link-suggestion-apply',
+			'args' => array(
+				'label'               => __( 'Apply Internal Link Suggestion', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Apply an approved suggestion by wrapping the first case-insensitive occurrence of the suggestion\'s anchor text in the target post\'s content with an <a href> tag. Marks the suggestion `applied` on success. Requires manage_options + edit_others_posts.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_others_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'suggestion_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+					),
+					'required'             => array( 'suggestion_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'post_id' => array( 'type' => 'integer' ),
+						'applied' => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'internal-links',
+						'sub_group_label' => __( 'Internal Links', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$id = (int) ( $input['suggestion_id'] ?? 0 );
+		if ( $id <= 0 ) {
+			return array(
+				'success' => false,
+				'message' => __( 'suggestion_id is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$s = Suggestion_Store::get( $id );
+		if ( null === $s ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Suggestion not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+		if ( 'approved' !== (string) $s['status'] ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Only approved suggestions can be applied.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$post_id = (int) $s['post_id'];
+		$post    = get_post( $post_id );
+		if ( ! $post instanceof \WP_Post ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Target post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$site_host = wp_parse_url( (string) home_url( '/' ), PHP_URL_HOST );
+		$url_host  = wp_parse_url( (string) $s['target_url'], PHP_URL_HOST );
+		if ( null === $url_host || $url_host !== $site_host ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Suggestion target must resolve to a same-site URL.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$anchor  = (string) $s['anchor_text'];
+		$content = (string) $post->post_content;
+		if ( '' === $anchor || false === stripos( $content, $anchor ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Anchor text not found in post content.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$replacement = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( (string) $s['target_url'] ),
+			esc_html( $anchor )
+		);
+		$pos      = stripos( $content, $anchor );
+		$new_body = substr( $content, 0, $pos ) . $replacement . substr( $content, $pos + strlen( $anchor ) );
+
+		$updated = wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => $new_body,
+			),
+			true
+		);
+		if ( is_wp_error( $updated ) ) {
+			return array(
+				'success' => false,
+				'message' => $updated->get_error_message(),
+			);
+		}
+
+		Suggestion_Store::update_status( $id, 'applied' );
+
+		return array(
+			'success' => true,
+			'post_id' => $post_id,
+			'applied' => true,
+			/* translators: 1: suggestion id, 2: post ID */
+			'message' => sprintf( __( 'Applied suggestion #%1$d to post #%2$d.', 'acrossai-abilities-manager' ), $id, $post_id ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Internal_Link_Suggestion_Apply.php
+++ b/includes/Abilities/ContentSearch/Internal_Link_Suggestion_Apply.php
@@ -87,7 +87,7 @@ class Internal_Link_Suggestion_Apply extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$id = (int) ( $input['suggestion_id'] ?? 0 );
+		$id = absint( $input['suggestion_id'] ?? 0 );
 		if ( $id <= 0 ) {
 			return array(
 				'success' => false,
@@ -107,12 +107,29 @@ class Internal_Link_Suggestion_Apply extends Ability_Definition {
 				'message' => __( 'Only approved suggestions can be applied.', 'acrossai-abilities-manager' ),
 			);
 		}
-		$post_id = (int) $s['post_id'];
+		$post_id = absint( $s['post_id'] );
 		$post    = get_post( $post_id );
 		if ( ! $post instanceof \WP_Post ) {
 			return array(
 				'success' => false,
 				'message' => __( 'Target post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Feature 055 hardening — per-target-post cap check + internal-CPT filter.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'You do not have permission to edit this target post.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$post_type_obj = get_post_type_object( (string) $post->post_type );
+		if ( ! $post_type_obj instanceof \WP_Post_Type
+			|| in_array( $post_type_obj->name, array( 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset', 'oembed_cache', 'user_request' ), true )
+			|| ! ( (bool) $post_type_obj->public || (bool) $post_type_obj->show_ui || (bool) $post_type_obj->show_in_rest ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'This post type is not editable through this ability.', 'acrossai-abilities-manager' ),
 			);
 		}
 

--- a/includes/Abilities/ContentSearch/Internal_Link_Suggestion_Review.php
+++ b/includes/Abilities/ContentSearch/Internal_Link_Suggestion_Review.php
@@ -90,9 +90,9 @@ class Internal_Link_Suggestion_Review extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$id      = (int) ( $input['suggestion_id'] ?? 0 );
+		$id      = absint( $input['suggestion_id'] ?? 0 );
 		$verdict = sanitize_key( (string) ( $input['verdict'] ?? '' ) );
-		$notes   = (string) ( $input['notes'] ?? '' );
+		$notes   = sanitize_text_field( (string) ( $input['notes'] ?? '' ) );
 		if ( $id <= 0 || ! in_array( $verdict, array( 'approved', 'rejected' ), true ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/ContentSearch/Internal_Link_Suggestion_Review.php
+++ b/includes/Abilities/ContentSearch/Internal_Link_Suggestion_Review.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Feature 055 — review (approve / reject) an internal-link suggestion.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Mark a single suggestion as `approved` or `rejected` with optional
+ * reviewer notes. Applied suggestions cannot be re-reviewed.
+ */
+class Internal_Link_Suggestion_Review extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-internal-link-suggestion-review',
+			'args' => array(
+				'label'               => __( 'Review Internal Link Suggestion', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Mark a suggestion as approved or rejected with optional reviewer notes. Applied suggestions cannot be re-reviewed.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'suggestion_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'verdict'       => array(
+							'type' => 'string',
+							'enum' => array( 'approved', 'rejected' ),
+						),
+						'notes'         => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'suggestion_id', 'verdict' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'suggestion' => array( 'type' => 'object' ),
+						'message'    => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'internal-links',
+						'sub_group_label' => __( 'Internal Links', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$id      = (int) ( $input['suggestion_id'] ?? 0 );
+		$verdict = sanitize_key( (string) ( $input['verdict'] ?? '' ) );
+		$notes   = (string) ( $input['notes'] ?? '' );
+		if ( $id <= 0 || ! in_array( $verdict, array( 'approved', 'rejected' ), true ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'suggestion_id and verdict (approved|rejected) are required.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$existing = Suggestion_Store::get( $id );
+		if ( null === $existing ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Suggestion not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+		if ( 'applied' === (string) $existing['status'] ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Applied suggestions cannot be re-reviewed.', 'acrossai-abilities-manager' ),
+			);
+		}
+		Suggestion_Store::update_status( $id, $verdict, $notes );
+		return array(
+			'success'    => true,
+			'suggestion' => (object) ( Suggestion_Store::get( $id ) ?? array() ),
+			/* translators: 1: id, 2: verdict */
+			'message'    => sprintf( __( 'Suggestion #%1$d marked %2$s.', 'acrossai-abilities-manager' ), $id, $verdict ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Internal_Link_Suggestions_Create.php
+++ b/includes/Abilities/ContentSearch/Internal_Link_Suggestions_Create.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Feature 055 — create internal-link suggestions.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Persist one or more internal-link suggestions for a given post via
+ * `Suggestion_Store`.
+ */
+class Internal_Link_Suggestions_Create extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-internal-link-suggestions-create',
+			'args' => array(
+				'label'               => __( 'Create Internal Link Suggestions', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Persist one or more internal-link suggestions for a given post via the option-backed suggestion store. Each suggestion carries a target URL + proposed anchor text. Store cap: 500 suggestions total.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'     => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'suggestions' => array(
+							'type'     => 'array',
+							'minItems' => 1,
+							'maxItems' => 20,
+							'items'    => array(
+								'type'                 => 'object',
+								'properties'           => array(
+									'target_url'  => array( 'type' => 'string' ),
+									'anchor_text' => array( 'type' => 'string' ),
+									'notes'       => array( 'type' => 'string' ),
+								),
+								'required'             => array( 'target_url', 'anchor_text' ),
+								'additionalProperties' => false,
+							),
+						),
+					),
+					'required'             => array( 'post_id', 'suggestions' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'created_ids'    => array( 'type' => 'array' ),
+						'rejected_items' => array( 'type' => 'array' ),
+						'message'        => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'internal-links',
+						'sub_group_label' => __( 'Internal Links', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id     = (int) ( $input['post_id'] ?? 0 );
+		$suggestions = (array) ( $input['suggestions'] ?? array() );
+		if ( $post_id <= 0 || array() === $suggestions ) {
+			return array(
+				'success' => false,
+				'message' => __( 'post_id and a non-empty suggestions array are required.', 'acrossai-abilities-manager' ),
+			);
+		}
+		if ( ! get_post( $post_id ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$created  = array();
+		$rejected = array();
+		foreach ( $suggestions as $idx => $s ) {
+			if ( ! is_array( $s ) ) {
+				$rejected[] = array(
+					'index'  => $idx,
+					'reason' => 'not-an-object',
+				);
+				continue;
+			}
+			$id = Suggestion_Store::insert(
+				array(
+					'post_id'     => $post_id,
+					'target_url'  => (string) ( $s['target_url'] ?? '' ),
+					'anchor_text' => (string) ( $s['anchor_text'] ?? '' ),
+					'notes'       => (string) ( $s['notes'] ?? '' ),
+				)
+			);
+			if ( $id > 0 ) {
+				$created[] = $id;
+			} else {
+				$rejected[] = array(
+					'index'  => $idx,
+					'reason' => 'store-cap-reached',
+				);
+			}
+		}
+
+		return array(
+			'success'        => array() !== $created,
+			'created_ids'    => $created,
+			'rejected_items' => $rejected,
+			/* translators: 1: created, 2: rejected */
+			'message'        => sprintf( __( 'Created %1$d suggestion(s); %2$d rejected.', 'acrossai-abilities-manager' ), count( $created ), count( $rejected ) ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Internal_Link_Suggestions_Create.php
+++ b/includes/Abilities/ContentSearch/Internal_Link_Suggestions_Create.php
@@ -116,6 +116,11 @@ class Internal_Link_Suggestions_Create extends Ability_Definition {
 			);
 		}
 
+		// Feature 055 hardening — reject suggestions whose target URL is
+		// off-site at ingest time (defence in depth on top of the
+		// apply-time re-check).
+		$site_host = wp_parse_url( (string) home_url( '/' ), PHP_URL_HOST );
+
 		$created  = array();
 		$rejected = array();
 		foreach ( $suggestions as $idx => $s ) {
@@ -126,12 +131,21 @@ class Internal_Link_Suggestions_Create extends Ability_Definition {
 				);
 				continue;
 			}
+			$target_url = esc_url_raw( (string) ( $s['target_url'] ?? '' ) );
+			$host       = wp_parse_url( $target_url, PHP_URL_HOST );
+			if ( '' === $target_url || null === $host || $host !== $site_host ) {
+				$rejected[] = array(
+					'index'  => $idx,
+					'reason' => 'target-not-same-site',
+				);
+				continue;
+			}
 			$id = Suggestion_Store::insert(
 				array(
 					'post_id'     => $post_id,
-					'target_url'  => (string) ( $s['target_url'] ?? '' ),
-					'anchor_text' => (string) ( $s['anchor_text'] ?? '' ),
-					'notes'       => (string) ( $s['notes'] ?? '' ),
+					'target_url'  => $target_url,
+					'anchor_text' => sanitize_text_field( (string) ( $s['anchor_text'] ?? '' ) ),
+					'notes'       => sanitize_text_field( (string) ( $s['notes'] ?? '' ) ),
 				)
 			);
 			if ( $id > 0 ) {

--- a/includes/Abilities/ContentSearch/Internal_Link_Suggestions_List.php
+++ b/includes/Abilities/ContentSearch/Internal_Link_Suggestions_List.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Feature 055 — list internal-link suggestions.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List all suggestions currently in the store, optionally filtered by
+ * post_id or status.
+ */
+class Internal_Link_Suggestions_List extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/content-internal-link-suggestions-list',
+			'args' => array(
+				'label'               => __( 'List Internal Link Suggestions', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List all suggestions in the option-backed store, optionally filtered by post_id and/or status (pending / approved / rejected / applied).', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content-search',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id' => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'status'  => array(
+							'type' => 'string',
+							'enum' => array( 'pending', 'approved', 'rejected', 'applied' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'items'   => array( 'type' => 'array' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'content-search',
+						'sub_group'       => 'internal-links',
+						'sub_group_label' => __( 'Internal Links', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id = isset( $input['post_id'] ) ? (int) $input['post_id'] : null;
+		if ( null !== $post_id && $post_id <= 0 ) {
+			$post_id = null;
+		}
+		$status = isset( $input['status'] ) ? (string) $input['status'] : null;
+		$items  = Suggestion_Store::list( $post_id, $status );
+		return array(
+			'success' => true,
+			'items'   => $items,
+			/* translators: %d: count */
+			'message' => sprintf( __( '%d suggestion(s) matched the filter.', 'acrossai-abilities-manager' ), count( $items ) ),
+		);
+	}
+}

--- a/includes/Abilities/ContentSearch/Internal_Link_Suggestions_List.php
+++ b/includes/Abilities/ContentSearch/Internal_Link_Suggestions_List.php
@@ -88,11 +88,14 @@ class Internal_Link_Suggestions_List extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$post_id = isset( $input['post_id'] ) ? (int) $input['post_id'] : null;
+		$post_id = isset( $input['post_id'] ) ? absint( $input['post_id'] ) : null;
 		if ( null !== $post_id && $post_id <= 0 ) {
 			$post_id = null;
 		}
-		$status = isset( $input['status'] ) ? (string) $input['status'] : null;
+		$status = isset( $input['status'] ) ? sanitize_key( (string) $input['status'] ) : null;
+		if ( null !== $status && ! in_array( $status, array( 'pending', 'approved', 'rejected', 'applied' ), true ) ) {
+			$status = null;
+		}
 		$items  = Suggestion_Store::list( $post_id, $status );
 		return array(
 			'success' => true,

--- a/includes/Abilities/ContentSearch/Suggestion_Store.php
+++ b/includes/Abilities/ContentSearch/Suggestion_Store.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Feature 055 — option-backed store for internal-link suggestions.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\ContentSearch
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\ContentSearch;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Simple option-backed store for internal-link suggestions.
+ *
+ * Data shape:
+ *   [
+ *     next_id => int,
+ *     items   => [
+ *       id => [id, post_id, target_url, anchor_text, status, notes, created_at],
+ *       ...
+ *     ],
+ *   ]
+ *
+ * `status` is one of `pending` | `approved` | `rejected` | `applied`.
+ */
+final class Suggestion_Store {
+
+	/**
+	 * WP option name.
+	 */
+	public const OPTION = 'acrossai_abilities_manager_link_suggestions';
+
+	/**
+	 * Hard cap on the total number of stored suggestions.
+	 */
+	public const MAX_SUGGESTIONS = 500;
+
+	/**
+	 * Read the store.
+	 *
+	 * @return array{next_id:int, items: array<int, array{id:int,post_id:int,target_url:string,anchor_text:string,status:string,notes:string,created_at:int}>}
+	 */
+	public static function read(): array {
+		$raw = get_option( self::OPTION, array() );
+		if ( ! is_array( $raw ) ) {
+			$raw = array();
+		}
+		return array(
+			'next_id' => isset( $raw['next_id'] ) ? max( 1, (int) $raw['next_id'] ) : 1,
+			'items'   => isset( $raw['items'] ) && is_array( $raw['items'] ) ? $raw['items'] : array(),
+		);
+	}
+
+	/**
+	 * Persist the store.
+	 *
+	 * @param array{next_id:int, items: array<int, array<string,mixed>>} $store Store.
+	 */
+	public static function write( array $store ): void {
+		update_option( self::OPTION, $store, false );
+	}
+
+	/**
+	 * Insert a suggestion. Returns the newly-assigned id, or 0 when the
+	 * cap is hit.
+	 *
+	 * @param array{post_id:int,target_url:string,anchor_text:string,notes?:string} $data Data.
+	 * @return int
+	 */
+	public static function insert( array $data ): int {
+		$store = self::read();
+		if ( count( $store['items'] ) >= self::MAX_SUGGESTIONS ) {
+			return 0;
+		}
+		$id = $store['next_id'];
+		$store['items'][ $id ] = array(
+			'id'          => $id,
+			'post_id'     => (int) ( $data['post_id'] ?? 0 ),
+			'target_url'  => esc_url_raw( (string) ( $data['target_url'] ?? '' ) ),
+			'anchor_text' => sanitize_text_field( (string) ( $data['anchor_text'] ?? '' ) ),
+			'status'      => 'pending',
+			'notes'       => sanitize_text_field( (string) ( $data['notes'] ?? '' ) ),
+			'created_at'  => time(),
+		);
+		$store['next_id'] = $id + 1;
+		self::write( $store );
+		return $id;
+	}
+
+	/**
+	 * Update a suggestion's status + notes. Returns false when not found.
+	 *
+	 * @param int    $id    Suggestion id.
+	 * @param string $status New status.
+	 * @param string $notes Review notes.
+	 */
+	public static function update_status( int $id, string $status, string $notes = '' ): bool {
+		$store = self::read();
+		if ( ! isset( $store['items'][ $id ] ) ) {
+			return false;
+		}
+		$store['items'][ $id ]['status'] = $status;
+		if ( '' !== $notes ) {
+			$store['items'][ $id ]['notes'] = sanitize_text_field( $notes );
+		}
+		self::write( $store );
+		return true;
+	}
+
+	/**
+	 * Get a single suggestion or null.
+	 *
+	 * @param int $id Suggestion id.
+	 * @return array<string,mixed>|null
+	 */
+	public static function get( int $id ): ?array {
+		$store = self::read();
+		return isset( $store['items'][ $id ] ) ? $store['items'][ $id ] : null;
+	}
+
+	/**
+	 * List suggestions, optionally filtering by post_id + status.
+	 *
+	 * @param int|null    $post_id Optional post filter.
+	 * @param string|null $status  Optional status filter.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public static function list( ?int $post_id = null, ?string $status = null ): array {
+		$store  = self::read();
+		$result = array();
+		foreach ( $store['items'] as $item ) {
+			if ( null !== $post_id && (int) $item['post_id'] !== $post_id ) {
+				continue;
+			}
+			if ( null !== $status && (string) $item['status'] !== $status ) {
+				continue;
+			}
+			$result[] = $item;
+		}
+		return $result;
+	}
+}

--- a/includes/Abilities/Media/Media_Rename_File.php
+++ b/includes/Abilities/Media/Media_Rename_File.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Feature 055 — rename an attachment's on-disk file safely.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Media
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Media;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rename an attachment's on-disk file, update `_wp_attached_file`, and
+ * regenerate the intermediate size metadata.
+ *
+ * Safety constraints:
+ * - `new_filename` MUST NOT contain a directory separator, null byte, or a
+ *   leading dot.
+ * - The resolved new path MUST stay inside the attachment's original
+ *   upload sub-directory (realpath containment).
+ * - If a file already exists at the target path, the operation is refused
+ *   rather than clobbering.
+ */
+class Media_Rename_File extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/media-rename-file',
+			'args' => array(
+				'label'               => __( 'Rename Media File', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Rename an attachment\'s on-disk file and update the "_wp_attached_file" post-meta + attachment guid + regenerate intermediate size metadata. new_filename may not contain a directory separator, null byte, or a leading dot; the resolved new path must stay inside the original upload sub-directory; refuses if the target filename already exists (no clobber).', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-media',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'upload_files' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'attachment_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'new_filename'  => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+					),
+					'required'             => array( 'attachment_id', 'new_filename' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'attachment_id' => array( 'type' => 'integer' ),
+						'old_relative'  => array( 'type' => 'string' ),
+						'new_relative'  => array( 'type' => 'string' ),
+						'message'       => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'manage',
+						'sub_group_label' => __( 'Manage', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$attachment_id = (int) ( $input['attachment_id'] ?? 0 );
+		$new_filename  = (string) ( $input['new_filename'] ?? '' );
+
+		if ( $attachment_id <= 0 ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A valid attachment_id is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$attachment = get_post( $attachment_id );
+		if ( ! $attachment instanceof \WP_Post || 'attachment' !== $attachment->post_type ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Attachment not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if (
+			'' === $new_filename
+			|| str_contains( $new_filename, '/' )
+			|| str_contains( $new_filename, '\\' )
+			|| str_contains( $new_filename, "\0" )
+			|| str_starts_with( $new_filename, '.' )
+		) {
+			return array(
+				'success' => false,
+				'message' => __( 'new_filename must not contain a directory separator, null byte, or a leading dot.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$sanitized = sanitize_file_name( $new_filename );
+		if ( '' === $sanitized ) {
+			return array(
+				'success' => false,
+				'message' => __( 'new_filename resolves to an empty string after sanitisation.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$old_relative = (string) get_post_meta( $attachment_id, '_wp_attached_file', true );
+		if ( '' === $old_relative ) {
+			return array(
+				'success' => false,
+				'message' => __( '_wp_attached_file meta is missing on this attachment.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$uploads = wp_get_upload_dir();
+		if ( ! empty( $uploads['error'] ) ) {
+			return array(
+				'success' => false,
+				'message' => (string) $uploads['error'],
+			);
+		}
+		$base_dir = trailingslashit( (string) $uploads['basedir'] );
+		$old_abs  = $base_dir . $old_relative;
+		if ( ! is_file( $old_abs ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Original file does not exist on disk.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$dir_relative = ltrim( (string) ( dirname( $old_relative ) ?: '' ), '/.' );
+		$new_relative = ( '' === $dir_relative ) ? $sanitized : $dir_relative . '/' . $sanitized;
+		$new_abs      = $base_dir . $new_relative;
+
+		$parent_real = realpath( dirname( $old_abs ) );
+		if ( false === $parent_real ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Could not resolve the attachment\'s parent directory.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$target_parent_real = realpath( dirname( $new_abs ) );
+		if ( false === $target_parent_real || $target_parent_real !== $parent_real ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Target path would escape the attachment\'s original upload sub-directory.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( file_exists( $new_abs ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A file already exists at the target filename; refusing to clobber.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( ! @rename( $old_abs, $new_abs ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename,WordPress.PHP.NoSilencedErrors.Discouraged
+			return array(
+				'success' => false,
+				'message' => __( 'Rename failed on disk.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		update_post_meta( $attachment_id, '_wp_attached_file', $new_relative );
+		wp_update_post(
+			array(
+				'ID'   => $attachment_id,
+				'guid' => trailingslashit( (string) $uploads['baseurl'] ) . $new_relative,
+			)
+		);
+
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+		$metadata = wp_generate_attachment_metadata( $attachment_id, $new_abs );
+		if ( is_array( $metadata ) ) {
+			wp_update_attachment_metadata( $attachment_id, $metadata );
+		}
+
+		return array(
+			'success'       => true,
+			'attachment_id' => $attachment_id,
+			'old_relative'  => $old_relative,
+			'new_relative'  => $new_relative,
+			/* translators: 1: old path, 2: new path */
+			'message'       => sprintf( __( 'Renamed "%1$s" → "%2$s".', 'acrossai-abilities-manager' ), $old_relative, $new_relative ),
+		);
+	}
+}

--- a/includes/Abilities/Media/Media_Rename_File.php
+++ b/includes/Abilities/Media/Media_Rename_File.php
@@ -99,7 +99,7 @@ class Media_Rename_File extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$attachment_id = (int) ( $input['attachment_id'] ?? 0 );
+		$attachment_id = absint( $input['attachment_id'] ?? 0 );
 		$new_filename  = (string) ( $input['new_filename'] ?? '' );
 
 		if ( $attachment_id <= 0 ) {
@@ -114,6 +114,15 @@ class Media_Rename_File extends Ability_Definition {
 			return array(
 				'success' => false,
 				'message' => __( 'Attachment not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Feature 055 hardening — per-attachment cap check (attachments
+		// respect edit_post like any other post).
+		if ( ! current_user_can( 'edit_post', $attachment_id ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'You do not have permission to edit this attachment.', 'acrossai-abilities-manager' ),
 			);
 		}
 

--- a/includes/Abilities/Menus/Navigation_Get_Context.php
+++ b/includes/Abilities/Menus/Navigation_Get_Context.php
@@ -91,8 +91,8 @@ class Navigation_Get_Context extends Ability_Definition {
 				}
 				$menus[] = array(
 					'id'         => (int) $menu->term_id,
-					'name'       => (string) $menu->name,
-					'slug'       => (string) $menu->slug,
+					'name'       => sanitize_text_field( (string) $menu->name ),
+					'slug'       => sanitize_title( (string) $menu->slug ),
 					'item_count' => (int) $menu->count,
 				);
 			}
@@ -102,7 +102,7 @@ class Navigation_Get_Context extends Ability_Definition {
 		$assignments      = get_nav_menu_locations();
 		if ( is_array( $assignments ) ) {
 			foreach ( $assignments as $location => $menu_id ) {
-				$assigned_by_menu[ (int) $menu_id ] = (string) $location;
+				$assigned_by_menu[ absint( $menu_id ) ] = sanitize_key( (string) $location );
 			}
 		}
 
@@ -112,15 +112,15 @@ class Navigation_Get_Context extends Ability_Definition {
 			foreach ( $registered as $slug => $label ) {
 				$menu_id             = 0;
 				$menu_name           = '';
-				$assigned_menu       = array_search( (string) $slug, $assigned_by_menu, true );
+				$assigned_menu       = array_search( sanitize_key( (string) $slug ), $assigned_by_menu, true );
 				if ( false !== $assigned_menu ) {
-					$menu_id     = (int) $assigned_menu;
+					$menu_id     = absint( $assigned_menu );
 					$menu_term   = get_term( $menu_id );
-					$menu_name   = $menu_term instanceof \WP_Term ? (string) $menu_term->name : '';
+					$menu_name   = $menu_term instanceof \WP_Term ? sanitize_text_field( (string) $menu_term->name ) : '';
 				}
 				$locations[] = array(
-					'slug'               => (string) $slug,
-					'label'              => (string) $label,
+					'slug'               => sanitize_key( (string) $slug ),
+					'label'              => sanitize_text_field( (string) $label ),
 					'assigned_menu_id'   => $menu_id,
 					'assigned_menu_name' => $menu_name,
 				);

--- a/includes/Abilities/Menus/Navigation_Get_Context.php
+++ b/includes/Abilities/Menus/Navigation_Get_Context.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Feature 055 — snapshot of the site's nav-menu context.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Menus
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Menus;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return one envelope combining every nav menu and every theme-registered
+ * nav-menu location, with the location-to-menu bindings resolved.
+ */
+class Navigation_Get_Context extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/navigation-get-context',
+			'args' => array(
+				'label'               => __( 'Get Navigation Context', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return one envelope containing every nav menu (id, name, item count) and every theme-registered nav-menu location, with the location→menu assignments resolved.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-menus',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'   => array( 'type' => 'boolean' ),
+						'menus'     => array( 'type' => 'array' ),
+						'locations' => array( 'type' => 'array' ),
+						'message'   => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'menus',
+						'sub_group_label' => __( 'Menus', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+
+		$menus     = array();
+		$menu_list = wp_get_nav_menus();
+		if ( is_array( $menu_list ) ) {
+			foreach ( $menu_list as $menu ) {
+				if ( ! $menu instanceof \WP_Term ) {
+					continue;
+				}
+				$menus[] = array(
+					'id'         => (int) $menu->term_id,
+					'name'       => (string) $menu->name,
+					'slug'       => (string) $menu->slug,
+					'item_count' => (int) $menu->count,
+				);
+			}
+		}
+
+		$assigned_by_menu = array();
+		$assignments      = get_nav_menu_locations();
+		if ( is_array( $assignments ) ) {
+			foreach ( $assignments as $location => $menu_id ) {
+				$assigned_by_menu[ (int) $menu_id ] = (string) $location;
+			}
+		}
+
+		$registered = get_registered_nav_menus();
+		$locations  = array();
+		if ( is_array( $registered ) ) {
+			foreach ( $registered as $slug => $label ) {
+				$menu_id             = 0;
+				$menu_name           = '';
+				$assigned_menu       = array_search( (string) $slug, $assigned_by_menu, true );
+				if ( false !== $assigned_menu ) {
+					$menu_id     = (int) $assigned_menu;
+					$menu_term   = get_term( $menu_id );
+					$menu_name   = $menu_term instanceof \WP_Term ? (string) $menu_term->name : '';
+				}
+				$locations[] = array(
+					'slug'               => (string) $slug,
+					'label'              => (string) $label,
+					'assigned_menu_id'   => $menu_id,
+					'assigned_menu_name' => $menu_name,
+				);
+			}
+		}
+
+		return array(
+			'success'   => true,
+			'menus'     => $menus,
+			'locations' => $locations,
+			/* translators: 1: menu count, 2: location count */
+			'message'   => sprintf( __( '%1$d menus, %2$d locations.', 'acrossai-abilities-manager' ), count( $menus ), count( $locations ) ),
+		);
+	}
+}

--- a/includes/Abilities/Menus/Navigation_List_Locations.php
+++ b/includes/Abilities/Menus/Navigation_List_Locations.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Feature 055 — list theme-registered nav-menu locations.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Menus
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Menus;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List all theme-registered nav-menu locations with their currently-assigned
+ * menu (if any).
+ */
+class Navigation_List_Locations extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/navigation-list-locations',
+			'args' => array(
+				'label'               => __( 'List Navigation Locations', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List every theme-registered nav-menu location (slug + label) and the currently-assigned menu id / name (if any).', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-menus',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'   => array( 'type' => 'boolean' ),
+						'locations' => array( 'type' => 'array' ),
+						'message'   => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'menus',
+						'sub_group_label' => __( 'Menus', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+
+		$assignments = get_nav_menu_locations();
+		if ( ! is_array( $assignments ) ) {
+			$assignments = array();
+		}
+
+		$out        = array();
+		$registered = get_registered_nav_menus();
+		if ( is_array( $registered ) ) {
+			foreach ( $registered as $slug => $label ) {
+				$menu_id   = isset( $assignments[ $slug ] ) ? (int) $assignments[ $slug ] : 0;
+				$menu_name = '';
+				if ( $menu_id > 0 ) {
+					$menu = get_term( $menu_id );
+					if ( $menu instanceof \WP_Term ) {
+						$menu_name = (string) $menu->name;
+					}
+				}
+				$out[] = array(
+					'slug'               => (string) $slug,
+					'label'              => (string) $label,
+					'assigned_menu_id'   => $menu_id,
+					'assigned_menu_name' => $menu_name,
+				);
+			}
+		}
+
+		return array(
+			'success'   => true,
+			'locations' => $out,
+			/* translators: %d: location count */
+			'message'   => sprintf( __( '%d nav-menu locations registered.', 'acrossai-abilities-manager' ), count( $out ) ),
+		);
+	}
+}

--- a/includes/Abilities/Menus/Navigation_List_Locations.php
+++ b/includes/Abilities/Menus/Navigation_List_Locations.php
@@ -90,17 +90,17 @@ class Navigation_List_Locations extends Ability_Definition {
 		$registered = get_registered_nav_menus();
 		if ( is_array( $registered ) ) {
 			foreach ( $registered as $slug => $label ) {
-				$menu_id   = isset( $assignments[ $slug ] ) ? (int) $assignments[ $slug ] : 0;
+				$menu_id   = isset( $assignments[ $slug ] ) ? absint( $assignments[ $slug ] ) : 0;
 				$menu_name = '';
 				if ( $menu_id > 0 ) {
 					$menu = get_term( $menu_id );
 					if ( $menu instanceof \WP_Term ) {
-						$menu_name = (string) $menu->name;
+						$menu_name = sanitize_text_field( (string) $menu->name );
 					}
 				}
 				$out[] = array(
-					'slug'               => (string) $slug,
-					'label'              => (string) $label,
+					'slug'               => sanitize_key( (string) $slug ),
+					'label'              => sanitize_text_field( (string) $label ),
 					'assigned_menu_id'   => $menu_id,
 					'assigned_menu_name' => $menu_name,
 				);

--- a/includes/Abilities/Plugins/Plugin_Lifecycle_Get_Plugin.php
+++ b/includes/Abilities/Plugins/Plugin_Lifecycle_Get_Plugin.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Feature 055 — per-plugin lifecycle-context envelope.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Plugins
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Plugins;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Lifecycle_Event_Log;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return the lifecycle-context object for a single plugin: header, active
+ * state, autoupdate enrolment, update availability, and last activated /
+ * deactivated / updated timestamps from the option-backed event log.
+ */
+class Plugin_Lifecycle_Get_Plugin extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/plugin-lifecycle-get-plugin',
+			'args' => array(
+				'label'               => __( 'Get Plugin Lifecycle Context', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return the lifecycle-context envelope for a single plugin: header (name, version, author, description), active state, network-active state, autoupdate enrolment, update availability, and the last activated / deactivated / updated timestamps recorded since 0.0.13.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-plugins',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'plugin' => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+					),
+					'required'             => array( 'plugin' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'             => array( 'type' => 'boolean' ),
+						'basename'            => array( 'type' => 'string' ),
+						'header'              => array( 'type' => 'object' ),
+						'is_active'           => array( 'type' => 'boolean' ),
+						'is_network_active'   => array( 'type' => 'boolean' ),
+						'autoupdate_enabled'  => array( 'type' => 'boolean' ),
+						'update_available'    => array( 'type' => 'boolean' ),
+						'last_activated_at'   => array( 'type' => 'integer' ),
+						'last_deactivated_at' => array( 'type' => 'integer' ),
+						'last_updated_at'     => array( 'type' => 'integer' ),
+						'message'             => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'plugins',
+						'sub_group'       => 'lifecycle',
+						'sub_group_label' => __( 'Lifecycle', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$basename = ltrim( (string) ( $input['plugin'] ?? '' ), '/' );
+		if ( '' === $basename ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A plugin basename is required (e.g. "hello-dolly/hello.php").', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		require_once ABSPATH . 'wp-admin/includes/update.php';
+
+		$all_plugins = get_plugins();
+		if ( ! isset( $all_plugins[ $basename ] ) ) {
+			return array(
+				'success' => false,
+				/* translators: %s: plugin basename */
+				'message' => sprintf( __( 'Plugin "%s" not installed.', 'acrossai-abilities-manager' ), $basename ),
+			);
+		}
+
+		$header               = (array) $all_plugins[ $basename ];
+		$is_active            = is_plugin_active( $basename );
+		$is_network_active    = is_multisite() && is_plugin_active_for_network( $basename );
+		$autoupdates          = (array) get_site_option( 'auto_update_plugins', array() );
+		$autoupdate_enabled   = in_array( $basename, $autoupdates, true );
+
+		$updates          = (array) get_plugin_updates();
+		$update_available = isset( $updates[ $basename ] );
+
+		$summary = Lifecycle_Event_Log::get_summary( 'plugin', $basename );
+
+		return array(
+			'success'             => true,
+			'basename'            => $basename,
+			'header'              => (object) array(
+				'name'        => (string) ( $header['Name'] ?? '' ),
+				'version'     => (string) ( $header['Version'] ?? '' ),
+				'author'      => wp_strip_all_tags( (string) ( $header['Author'] ?? '' ) ),
+				'description' => wp_strip_all_tags( (string) ( $header['Description'] ?? '' ) ),
+				'requires_wp' => (string) ( $header['RequiresWP'] ?? '' ),
+				'requires_php' => (string) ( $header['RequiresPHP'] ?? '' ),
+			),
+			'is_active'           => (bool) $is_active,
+			'is_network_active'   => (bool) $is_network_active,
+			'autoupdate_enabled'  => (bool) $autoupdate_enabled,
+			'update_available'    => (bool) $update_available,
+			'last_activated_at'   => (int) $summary['last_activated_at'],
+			'last_deactivated_at' => (int) $summary['last_deactivated_at'],
+			'last_updated_at'     => (int) $summary['last_updated_at'],
+			/* translators: %s: plugin basename */
+			'message'             => sprintf( __( 'Lifecycle for %s.', 'acrossai-abilities-manager' ), $basename ),
+		);
+	}
+}

--- a/includes/Abilities/Plugins/Plugin_Lifecycle_Get_Plugin.php
+++ b/includes/Abilities/Plugins/Plugin_Lifecycle_Get_Plugin.php
@@ -95,11 +95,16 @@ class Plugin_Lifecycle_Get_Plugin extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
+		// Feature 055 hardening — reject basenames containing path traversal
+		// or absolute paths; only match /^[A-Za-z0-9_\-\/\.]+$/ shape.
 		$basename = ltrim( (string) ( $input['plugin'] ?? '' ), '/' );
-		if ( '' === $basename ) {
+		if ( '' === $basename
+			|| str_contains( $basename, '..' )
+			|| str_contains( $basename, '\\' )
+			|| ! preg_match( '/^[A-Za-z0-9_\-\/\.]+$/', $basename ) ) {
 			return array(
 				'success' => false,
-				'message' => __( 'A plugin basename is required (e.g. "hello-dolly/hello.php").', 'acrossai-abilities-manager' ),
+				'message' => __( 'A valid plugin basename is required (e.g. "hello-dolly/hello.php").', 'acrossai-abilities-manager' ),
 			);
 		}
 
@@ -126,16 +131,34 @@ class Plugin_Lifecycle_Get_Plugin extends Ability_Definition {
 
 		$summary = Lifecycle_Event_Log::get_summary( 'plugin', $basename );
 
+		// Feature 055 hardening — cap free-form header fields so a plugin
+		// with a malicious multi-KB Description cannot bloat responses.
+		$name_max = 200;
+		$auth_max = 200;
+		$desc_max = 500;
+		$name     = wp_strip_all_tags( (string) ( $header['Name'] ?? '' ) );
+		$author   = wp_strip_all_tags( (string) ( $header['Author'] ?? '' ) );
+		$descr    = wp_strip_all_tags( (string) ( $header['Description'] ?? '' ) );
+		if ( strlen( $name ) > $name_max ) {
+			$name = rtrim( substr( $name, 0, $name_max ) ) . '...';
+		}
+		if ( strlen( $author ) > $auth_max ) {
+			$author = rtrim( substr( $author, 0, $auth_max ) ) . '...';
+		}
+		if ( strlen( $descr ) > $desc_max ) {
+			$descr = rtrim( substr( $descr, 0, $desc_max ) ) . '...';
+		}
+
 		return array(
 			'success'             => true,
 			'basename'            => $basename,
 			'header'              => (object) array(
-				'name'        => (string) ( $header['Name'] ?? '' ),
-				'version'     => (string) ( $header['Version'] ?? '' ),
-				'author'      => wp_strip_all_tags( (string) ( $header['Author'] ?? '' ) ),
-				'description' => wp_strip_all_tags( (string) ( $header['Description'] ?? '' ) ),
-				'requires_wp' => (string) ( $header['RequiresWP'] ?? '' ),
-				'requires_php' => (string) ( $header['RequiresPHP'] ?? '' ),
+				'name'         => $name,
+				'version'      => sanitize_text_field( (string) ( $header['Version'] ?? '' ) ),
+				'author'       => $author,
+				'description'  => $descr,
+				'requires_wp'  => sanitize_text_field( (string) ( $header['RequiresWP'] ?? '' ) ),
+				'requires_php' => sanitize_text_field( (string) ( $header['RequiresPHP'] ?? '' ) ),
 			),
 			'is_active'           => (bool) $is_active,
 			'is_network_active'   => (bool) $is_network_active,

--- a/includes/Abilities/SiteHealth/Site_Maintenance_Report.php
+++ b/includes/Abilities/SiteHealth/Site_Maintenance_Report.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Feature 055 — synthesized site maintenance report.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\SiteHealth
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\SiteHealth;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * One-shot report combining WP-core, plugin, theme update counts with
+ * disk-free stats and PHP + WP version info.
+ *
+ * Read-only; safe to poll.
+ */
+class Site_Maintenance_Report extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/site-maintenance-report',
+			'args' => array(
+				'label'               => __( 'Site Maintenance Report', 'acrossai-abilities-manager' ),
+				'description'         => __( 'One-shot maintenance snapshot: counts of pending core / plugin / theme updates, disk-free bytes on the WP install partition, PHP version, MySQL version, WP version, active theme, and site URL. Safe to poll (read-only).', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-site-health',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'          => array( 'type' => 'boolean' ),
+						'generated_at'     => array( 'type' => 'integer' ),
+						'core_update'      => array( 'type' => 'object' ),
+						'plugin_updates'   => array( 'type' => 'integer' ),
+						'theme_updates'    => array( 'type' => 'integer' ),
+						'disk_free_bytes'  => array( 'type' => 'integer' ),
+						'disk_total_bytes' => array( 'type' => 'integer' ),
+						'php_version'      => array( 'type' => 'string' ),
+						'mysql_version'    => array( 'type' => 'string' ),
+						'wp_version'       => array( 'type' => 'string' ),
+						'active_theme'     => array( 'type' => 'string' ),
+						'site_url'         => array( 'type' => 'string' ),
+						'is_multisite'     => array( 'type' => 'boolean' ),
+						'message'          => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'site-health',
+						'sub_group_label' => __( 'Site Health', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+		global $wpdb, $wp_version;
+
+		require_once ABSPATH . 'wp-admin/includes/update.php';
+		$core_updates = function_exists( 'get_core_updates' ) ? get_core_updates() : array();
+		$core_offer   = array(
+			'available' => false,
+			'version'   => (string) $wp_version,
+		);
+		if ( is_array( $core_updates ) ) {
+			foreach ( $core_updates as $offer ) {
+				if ( isset( $offer->response ) && 'upgrade' === $offer->response ) {
+					$core_offer['available'] = true;
+					$core_offer['version']   = (string) ( $offer->version ?? '' );
+					break;
+				}
+			}
+		}
+
+		$plugin_updates = function_exists( 'get_plugin_updates' ) ? count( (array) get_plugin_updates() ) : 0;
+		$theme_updates  = function_exists( 'get_theme_updates' ) ? count( (array) get_theme_updates() ) : 0;
+
+		$disk_free  = @disk_free_space( ABSPATH ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$disk_total = @disk_total_space( ABSPATH ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+
+		$theme        = wp_get_theme();
+		$active_theme = $theme instanceof \WP_Theme ? (string) $theme->get( 'Name' ) : '';
+
+		$mysql_version = '';
+		if ( isset( $wpdb ) && is_object( $wpdb ) && method_exists( $wpdb, 'db_version' ) ) {
+			$mysql_version = (string) $wpdb->db_version();
+		}
+
+		return array(
+			'success'          => true,
+			'generated_at'     => time(),
+			'core_update'      => (object) $core_offer,
+			'plugin_updates'   => $plugin_updates,
+			'theme_updates'    => $theme_updates,
+			'disk_free_bytes'  => (int) ( is_float( $disk_free ) ? $disk_free : 0 ),
+			'disk_total_bytes' => (int) ( is_float( $disk_total ) ? $disk_total : 0 ),
+			'php_version'      => PHP_VERSION,
+			'mysql_version'    => $mysql_version,
+			'wp_version'       => (string) $wp_version,
+			'active_theme'     => $active_theme,
+			'site_url'         => (string) home_url( '/' ),
+			'is_multisite'     => is_multisite(),
+			/* translators: 1: core, 2: plugin, 3: theme */
+			'message'          => sprintf(
+				__( 'Pending updates — core: %1$s, plugins: %2$d, themes: %3$d.', 'acrossai-abilities-manager' ),
+				$core_offer['available'] ? __( 'yes', 'acrossai-abilities-manager' ) : __( 'no', 'acrossai-abilities-manager' ),
+				$plugin_updates,
+				$theme_updates
+			),
+		);
+	}
+}

--- a/includes/Abilities/SiteHealth/Site_Maintenance_Report.php
+++ b/includes/Abilities/SiteHealth/Site_Maintenance_Report.php
@@ -99,13 +99,13 @@ class Site_Maintenance_Report extends Ability_Definition {
 		$core_updates = function_exists( 'get_core_updates' ) ? get_core_updates() : array();
 		$core_offer   = array(
 			'available' => false,
-			'version'   => (string) $wp_version,
+			'version'   => sanitize_text_field( (string) $wp_version ),
 		);
 		if ( is_array( $core_updates ) ) {
 			foreach ( $core_updates as $offer ) {
 				if ( isset( $offer->response ) && 'upgrade' === $offer->response ) {
 					$core_offer['available'] = true;
-					$core_offer['version']   = (string) ( $offer->version ?? '' );
+					$core_offer['version']   = sanitize_text_field( (string) ( $offer->version ?? '' ) );
 					break;
 				}
 			}
@@ -118,11 +118,11 @@ class Site_Maintenance_Report extends Ability_Definition {
 		$disk_total = @disk_total_space( ABSPATH ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 
 		$theme        = wp_get_theme();
-		$active_theme = $theme instanceof \WP_Theme ? (string) $theme->get( 'Name' ) : '';
+		$active_theme = $theme instanceof \WP_Theme ? sanitize_text_field( (string) $theme->get( 'Name' ) ) : '';
 
 		$mysql_version = '';
 		if ( isset( $wpdb ) && is_object( $wpdb ) && method_exists( $wpdb, 'db_version' ) ) {
-			$mysql_version = (string) $wpdb->db_version();
+			$mysql_version = sanitize_text_field( (string) $wpdb->db_version() );
 		}
 
 		return array(
@@ -135,9 +135,9 @@ class Site_Maintenance_Report extends Ability_Definition {
 			'disk_total_bytes' => (int) ( is_float( $disk_total ) ? $disk_total : 0 ),
 			'php_version'      => PHP_VERSION,
 			'mysql_version'    => $mysql_version,
-			'wp_version'       => (string) $wp_version,
+			'wp_version'       => sanitize_text_field( (string) $wp_version ),
 			'active_theme'     => $active_theme,
-			'site_url'         => (string) home_url( '/' ),
+			'site_url'         => esc_url_raw( (string) home_url( '/' ) ),
 			'is_multisite'     => is_multisite(),
 			/* translators: 1: core, 2: plugin, 3: theme */
 			'message'          => sprintf(

--- a/includes/Abilities/Taxonomies/Set_Term_Image.php
+++ b/includes/Abilities/Taxonomies/Set_Term_Image.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Feature 055 — set a "term image" via _thumbnail_id term-meta.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Taxonomies
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Taxonomies;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Attach (or clear) an attachment as the "image" of a term.
+ *
+ * Persists the attachment id in the term-meta key `_thumbnail_id` — the same
+ * key WooCommerce and many theme frameworks use. Passing `attachment_id=0`
+ * (or null) clears the meta row.
+ */
+class Set_Term_Image extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/taxonomy-set-term-image',
+			'args' => array(
+				'label'               => __( 'Set Term Image', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Attach (or clear) an attachment as the "image" of a term by writing the term-meta key _thumbnail_id. Matches the convention used by WooCommerce and most theme frameworks. Pass attachment_id=0 to clear.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-taxonomies',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'term_id'       => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'attachment_id' => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+					),
+					'required'             => array( 'term_id', 'attachment_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'term_id'       => array( 'type' => 'integer' ),
+						'attachment_id' => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'terms',
+						'sub_group_label' => __( 'Terms', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$term_id       = (int) ( $input['term_id'] ?? 0 );
+		$attachment_id = (int) ( $input['attachment_id'] ?? 0 );
+
+		if ( $term_id <= 0 ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A valid term_id is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$term = get_term( $term_id );
+		if ( ! $term instanceof \WP_Term ) {
+			return array(
+				'success' => false,
+				/* translators: %d: term ID */
+				'message' => sprintf( __( 'Term #%d does not exist.', 'acrossai-abilities-manager' ), $term_id ),
+			);
+		}
+
+		if ( $attachment_id > 0 ) {
+			$attachment = get_post( $attachment_id );
+			if ( ! $attachment instanceof \WP_Post || 'attachment' !== $attachment->post_type ) {
+				return array(
+					'success' => false,
+					/* translators: %d: attachment ID */
+					'message' => sprintf( __( 'Attachment #%d does not exist.', 'acrossai-abilities-manager' ), $attachment_id ),
+				);
+			}
+			update_term_meta( $term_id, '_thumbnail_id', $attachment_id );
+			return array(
+				'success'       => true,
+				'term_id'       => $term_id,
+				'attachment_id' => $attachment_id,
+				/* translators: 1: term ID, 2: attachment ID */
+				'message'       => sprintf( __( 'Set term #%1$d image to attachment #%2$d.', 'acrossai-abilities-manager' ), $term_id, $attachment_id ),
+			);
+		}
+
+		delete_term_meta( $term_id, '_thumbnail_id' );
+		return array(
+			'success'       => true,
+			'term_id'       => $term_id,
+			'attachment_id' => 0,
+			/* translators: %d: term ID */
+			'message'       => sprintf( __( 'Cleared image on term #%d.', 'acrossai-abilities-manager' ), $term_id ),
+		);
+	}
+}

--- a/includes/Abilities/Taxonomies/Set_Term_Image.php
+++ b/includes/Abilities/Taxonomies/Set_Term_Image.php
@@ -93,8 +93,8 @@ class Set_Term_Image extends Ability_Definition {
 	 * @return array<string,mixed>
 	 */
 	public function execute( array $input = array() ): array {
-		$term_id       = (int) ( $input['term_id'] ?? 0 );
-		$attachment_id = (int) ( $input['attachment_id'] ?? 0 );
+		$term_id       = absint( $input['term_id'] ?? 0 );
+		$attachment_id = absint( $input['attachment_id'] ?? 0 );
 
 		if ( $term_id <= 0 ) {
 			return array(
@@ -112,6 +112,16 @@ class Set_Term_Image extends Ability_Definition {
 			);
 		}
 
+		// Feature 055 hardening — the current user must be able to edit the
+		// term's taxonomy (matches WP core's term-edit UI gate).
+		$taxonomy_obj = get_taxonomy( (string) $term->taxonomy );
+		if ( ! $taxonomy_obj instanceof \WP_Taxonomy || ! current_user_can( $taxonomy_obj->cap->edit_terms ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'You do not have permission to edit terms in this taxonomy.', 'acrossai-abilities-manager' ),
+			);
+		}
+
 		if ( $attachment_id > 0 ) {
 			$attachment = get_post( $attachment_id );
 			if ( ! $attachment instanceof \WP_Post || 'attachment' !== $attachment->post_type ) {
@@ -119,6 +129,20 @@ class Set_Term_Image extends Ability_Definition {
 					'success' => false,
 					/* translators: %d: attachment ID */
 					'message' => sprintf( __( 'Attachment #%d does not exist.', 'acrossai-abilities-manager' ), $attachment_id ),
+				);
+			}
+			// Feature 055 hardening — the attachment must actually be an image,
+			// and the current user must be allowed to read it.
+			if ( ! function_exists( 'wp_attachment_is_image' ) || ! wp_attachment_is_image( $attachment_id ) ) {
+				return array(
+					'success' => false,
+					'message' => __( 'Attachment must be an image.', 'acrossai-abilities-manager' ),
+				);
+			}
+			if ( ! current_user_can( 'read_post', $attachment_id ) ) {
+				return array(
+					'success' => false,
+					'message' => __( 'You do not have permission to use this attachment.', 'acrossai-abilities-manager' ),
 				);
 			}
 			update_term_meta( $term_id, '_thumbnail_id', $attachment_id );

--- a/includes/Abilities/Themes/Theme_Lifecycle_Get_Theme.php
+++ b/includes/Abilities/Themes/Theme_Lifecycle_Get_Theme.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Feature 055 — per-theme lifecycle-context envelope.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Themes
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Themes;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Lifecycle_Event_Log;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return the lifecycle-context envelope for a single theme: header, active
+ * state, parent/child relationship, autoupdate enrolment, update availability,
+ * and last activated / deactivated / updated timestamps.
+ */
+class Theme_Lifecycle_Get_Theme extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/theme-lifecycle-get-theme',
+			'args' => array(
+				'label'               => __( 'Get Theme Lifecycle Context', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return the lifecycle-context envelope for a single theme (by stylesheet slug): header (name, version, author), active state, parent (if child theme), autoupdate enrolment, update availability, and last activated / deactivated / updated timestamps.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-themes',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'stylesheet' => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+					),
+					'required'             => array( 'stylesheet' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'             => array( 'type' => 'boolean' ),
+						'stylesheet'          => array( 'type' => 'string' ),
+						'header'              => array( 'type' => 'object' ),
+						'is_active'           => array( 'type' => 'boolean' ),
+						'is_child'            => array( 'type' => 'boolean' ),
+						'parent'              => array( 'type' => 'string' ),
+						'is_block_theme'      => array( 'type' => 'boolean' ),
+						'autoupdate_enabled'  => array( 'type' => 'boolean' ),
+						'update_available'    => array( 'type' => 'boolean' ),
+						'last_activated_at'   => array( 'type' => 'integer' ),
+						'last_deactivated_at' => array( 'type' => 'integer' ),
+						'last_updated_at'     => array( 'type' => 'integer' ),
+						'message'             => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'themes',
+						'sub_group'       => 'lifecycle',
+						'sub_group_label' => __( 'Lifecycle', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$stylesheet = sanitize_key( (string) ( $input['stylesheet'] ?? '' ) );
+		if ( '' === $stylesheet ) {
+			return array(
+				'success' => false,
+				'message' => __( 'A theme stylesheet slug is required (e.g. "twentytwentyfive").', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$theme = wp_get_theme( $stylesheet );
+		if ( ! $theme instanceof \WP_Theme || ! $theme->exists() ) {
+			return array(
+				'success' => false,
+				/* translators: %s: theme stylesheet slug */
+				'message' => sprintf( __( 'Theme "%s" not installed.', 'acrossai-abilities-manager' ), $stylesheet ),
+			);
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/update.php';
+		$updates          = (array) get_theme_updates();
+		$update_available = isset( $updates[ $stylesheet ] );
+
+		$autoupdates        = (array) get_site_option( 'auto_update_themes', array() );
+		$autoupdate_enabled = in_array( $stylesheet, $autoupdates, true );
+
+		$parent      = $theme->parent();
+		$parent_slug = $parent instanceof \WP_Theme ? (string) $parent->get_stylesheet() : '';
+
+		$summary = Lifecycle_Event_Log::get_summary( 'theme', $stylesheet );
+
+		return array(
+			'success'             => true,
+			'stylesheet'          => $stylesheet,
+			'header'              => (object) array(
+				'name'    => (string) $theme->get( 'Name' ),
+				'version' => (string) $theme->get( 'Version' ),
+				'author'  => wp_strip_all_tags( (string) $theme->get( 'Author' ) ),
+				'template' => (string) $theme->get_template(),
+			),
+			'is_active'           => $stylesheet === (string) get_stylesheet(),
+			'is_child'            => '' !== $parent_slug,
+			'parent'              => $parent_slug,
+			'is_block_theme'      => method_exists( $theme, 'is_block_theme' ) ? (bool) $theme->is_block_theme() : false,
+			'autoupdate_enabled'  => (bool) $autoupdate_enabled,
+			'update_available'    => (bool) $update_available,
+			'last_activated_at'   => (int) $summary['last_activated_at'],
+			'last_deactivated_at' => (int) $summary['last_deactivated_at'],
+			'last_updated_at'     => (int) $summary['last_updated_at'],
+			/* translators: %s: theme slug */
+			'message'             => sprintf( __( 'Lifecycle for theme %s.', 'acrossai-abilities-manager' ), $stylesheet ),
+		);
+	}
+}

--- a/includes/Abilities/Themes/Theme_Lifecycle_Get_Theme.php
+++ b/includes/Abilities/Themes/Theme_Lifecycle_Get_Theme.php
@@ -126,14 +126,26 @@ class Theme_Lifecycle_Get_Theme extends Ability_Definition {
 
 		$summary = Lifecycle_Event_Log::get_summary( 'theme', $stylesheet );
 
+		// Feature 055 hardening — cap free-form header fields.
+		$name_max = 200;
+		$auth_max = 200;
+		$name     = wp_strip_all_tags( (string) $theme->get( 'Name' ) );
+		$author   = wp_strip_all_tags( (string) $theme->get( 'Author' ) );
+		if ( strlen( $name ) > $name_max ) {
+			$name = rtrim( substr( $name, 0, $name_max ) ) . '...';
+		}
+		if ( strlen( $author ) > $auth_max ) {
+			$author = rtrim( substr( $author, 0, $auth_max ) ) . '...';
+		}
+
 		return array(
 			'success'             => true,
 			'stylesheet'          => $stylesheet,
 			'header'              => (object) array(
-				'name'    => (string) $theme->get( 'Name' ),
-				'version' => (string) $theme->get( 'Version' ),
-				'author'  => wp_strip_all_tags( (string) $theme->get( 'Author' ) ),
-				'template' => (string) $theme->get_template(),
+				'name'     => $name,
+				'version'  => sanitize_text_field( (string) $theme->get( 'Version' ) ),
+				'author'   => $author,
+				'template' => sanitize_text_field( (string) $theme->get_template() ),
 			),
 			'is_active'           => $stylesheet === (string) get_stylesheet(),
 			'is_child'            => '' !== $parent_slug,

--- a/includes/Abilities/Users/Current_Access.php
+++ b/includes/Abilities/Users/Current_Access.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Feature 055 — expose the current user's role + capability profile.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Users
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Users;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Returns the current user's identity, roles, and capability map.
+ *
+ * Complements `user-role-capabilities` (which describes a role in the abstract)
+ * by returning what the *actual current caller* can do on this site.
+ */
+class Current_Access extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/users-current-access',
+			'args' => array(
+				'label'               => __( 'Current User Access', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return the current caller\'s user id, roles, capability map, and network-admin status. Read-only; useful for MCP clients that need to reason about what actions the current session is authorised to perform.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-users',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'          => array( 'type' => 'boolean' ),
+						'user_id'          => array( 'type' => 'integer' ),
+						'login'            => array( 'type' => 'string' ),
+						'display_name'     => array( 'type' => 'string' ),
+						'roles'            => array( 'type' => 'array' ),
+						'capabilities'     => array( 'type' => 'object' ),
+						'is_super_admin'   => array( 'type' => 'boolean' ),
+						'is_network_admin' => array( 'type' => 'boolean' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'users',
+						'sub_group'       => 'roles',
+						'sub_group_label' => __( 'Roles', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+		$user = wp_get_current_user();
+		if ( ! $user instanceof \WP_User || 0 === $user->ID ) {
+			return array(
+				'success' => false,
+				'message' => __( 'No authenticated user in this request.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$caps = array();
+		foreach ( (array) $user->allcaps as $cap => $granted ) {
+			$caps[ (string) $cap ] = (bool) $granted;
+		}
+
+		return array(
+			'success'          => true,
+			'user_id'          => (int) $user->ID,
+			'login'            => (string) $user->user_login,
+			'display_name'     => (string) $user->display_name,
+			'roles'            => array_values( array_map( 'strval', (array) $user->roles ) ),
+			'capabilities'     => (object) $caps,
+			'is_super_admin'   => function_exists( 'is_super_admin' ) && is_super_admin( (int) $user->ID ),
+			'is_network_admin' => is_multisite() && current_user_can( 'manage_network' ),
+		);
+	}
+}

--- a/includes/Abilities/Utilities/Lifecycle_Event_Log.php
+++ b/includes/Abilities/Utilities/Lifecycle_Event_Log.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Feature 055 — option-backed rolling event log for plugin/theme lifecycle
+ * events (activated / deactivated / updated).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Utilities
+ * @since      0.0.13
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Utilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Tiny option-backed rolling event log for plugin / theme lifecycle
+ * events. Persists to `acrossai_abilities_manager_lifecycle_log` as a
+ * bounded array. Registers itself on activate/deactivate/update hooks
+ * from Bootstrap.
+ */
+final class Lifecycle_Event_Log {
+
+	/**
+	 * WP option name.
+	 */
+	public const OPTION = 'acrossai_abilities_manager_lifecycle_log';
+
+	/**
+	 * Cap on the number of events per (scope, key) pair.
+	 */
+	public const MAX_EVENTS_PER_KEY = 50;
+
+	/**
+	 * Register the hook listeners.
+	 */
+	public static function register_hooks(): void {
+		add_action( 'activated_plugin', array( __CLASS__, 'on_plugin_activated' ), 10, 1 );
+		add_action( 'deactivated_plugin', array( __CLASS__, 'on_plugin_deactivated' ), 10, 1 );
+		add_action( 'upgrader_process_complete', array( __CLASS__, 'on_upgrader_complete' ), 10, 2 );
+		add_action( 'switch_theme', array( __CLASS__, 'on_theme_switched' ), 10, 3 );
+	}
+
+	/**
+	 * activated_plugin hook.
+	 *
+	 * @param string $plugin Plugin basename.
+	 */
+	public static function on_plugin_activated( $plugin ): void {
+		self::record( 'plugin', (string) $plugin, 'activated' );
+	}
+
+	/**
+	 * deactivated_plugin hook.
+	 *
+	 * @param string $plugin Plugin basename.
+	 */
+	public static function on_plugin_deactivated( $plugin ): void {
+		self::record( 'plugin', (string) $plugin, 'deactivated' );
+	}
+
+	/**
+	 * upgrader_process_complete hook — record `updated` events for plugin /
+	 * theme / core update runs.
+	 *
+	 * @param mixed $upgrader Upgrader instance (unused).
+	 * @param array<string,mixed> $hook_extra Details about what was upgraded.
+	 */
+	public static function on_upgrader_complete( $upgrader, $hook_extra ): void {
+		unset( $upgrader );
+		if ( ! is_array( $hook_extra ) ) {
+			return;
+		}
+		$action = (string) ( $hook_extra['action'] ?? '' );
+		$type   = (string) ( $hook_extra['type'] ?? '' );
+		if ( 'update' !== $action ) {
+			return;
+		}
+		if ( 'plugin' === $type ) {
+			$targets = (array) ( $hook_extra['plugins'] ?? array() );
+			foreach ( $targets as $slug ) {
+				self::record( 'plugin', (string) $slug, 'updated' );
+			}
+		} elseif ( 'theme' === $type ) {
+			$targets = (array) ( $hook_extra['themes'] ?? array() );
+			foreach ( $targets as $slug ) {
+				self::record( 'theme', (string) $slug, 'updated' );
+			}
+		} elseif ( 'core' === $type ) {
+			self::record( 'core', 'wordpress', 'updated' );
+		}
+	}
+
+	/**
+	 * switch_theme hook.
+	 *
+	 * @param string    $new_name Human name of the new theme.
+	 * @param \WP_Theme $new      The new theme.
+	 * @param \WP_Theme $old      The old theme.
+	 */
+	public static function on_theme_switched( $new_name, $new, $old ): void {
+		unset( $new_name );
+		if ( $old instanceof \WP_Theme ) {
+			self::record( 'theme', (string) $old->get_stylesheet(), 'deactivated' );
+		}
+		if ( $new instanceof \WP_Theme ) {
+			self::record( 'theme', (string) $new->get_stylesheet(), 'activated' );
+		}
+	}
+
+	/**
+	 * Persist one event.
+	 *
+	 * @param string $scope 'plugin' | 'theme' | 'core'.
+	 * @param string $key   Basename or stylesheet.
+	 * @param string $event 'activated' | 'deactivated' | 'updated'.
+	 */
+	public static function record( string $scope, string $key, string $event ): void {
+		if ( '' === $scope || '' === $key || '' === $event ) {
+			return;
+		}
+		$log = self::read();
+		if ( ! isset( $log[ $scope ] ) || ! is_array( $log[ $scope ] ) ) {
+			$log[ $scope ] = array();
+		}
+		if ( ! isset( $log[ $scope ][ $key ] ) || ! is_array( $log[ $scope ][ $key ] ) ) {
+			$log[ $scope ][ $key ] = array();
+		}
+		$log[ $scope ][ $key ][] = array(
+			'event' => $event,
+			'ts'    => time(),
+		);
+		$len = count( $log[ $scope ][ $key ] );
+		if ( $len > self::MAX_EVENTS_PER_KEY ) {
+			$log[ $scope ][ $key ] = array_slice( $log[ $scope ][ $key ], $len - self::MAX_EVENTS_PER_KEY );
+		}
+		update_option( self::OPTION, $log, false );
+	}
+
+	/**
+	 * Read the log.
+	 *
+	 * @return array<string,array<string,array<int,array{event:string,ts:int}>>>
+	 */
+	public static function read(): array {
+		$raw = get_option( self::OPTION, array() );
+		return is_array( $raw ) ? $raw : array();
+	}
+
+	/**
+	 * Return the events for a single (scope, key) pair, plus a small summary
+	 * (last activated_at / deactivated_at / updated_at).
+	 *
+	 * @param string $scope Scope.
+	 * @param string $key   Key.
+	 * @return array{events: array<int,array{event:string,ts:int}>, last_activated_at: int, last_deactivated_at: int, last_updated_at: int}
+	 */
+	public static function get_summary( string $scope, string $key ): array {
+		$log      = self::read();
+		$events   = ( isset( $log[ $scope ][ $key ] ) && is_array( $log[ $scope ][ $key ] ) ) ? $log[ $scope ][ $key ] : array();
+		$last_act = 0;
+		$last_de  = 0;
+		$last_up  = 0;
+		foreach ( $events as $ev ) {
+			$name = (string) ( $ev['event'] ?? '' );
+			$ts   = (int) ( $ev['ts'] ?? 0 );
+			if ( 'activated' === $name && $ts > $last_act ) {
+				$last_act = $ts;
+			} elseif ( 'deactivated' === $name && $ts > $last_de ) {
+				$last_de = $ts;
+			} elseif ( 'updated' === $name && $ts > $last_up ) {
+				$last_up = $ts;
+			}
+		}
+		return array(
+			'events'              => $events,
+			'last_activated_at'   => $last_act,
+			'last_deactivated_at' => $last_de,
+			'last_updated_at'     => $last_up,
+		);
+	}
+}

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.12' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.13' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- **31 new abilities across 10 domains — 187 → 218 registered.** Ships the entire gap surfaced by [PR #79's audit](https://github.com/acrossai-co/acrossai-abilities-manager/pull/79) as one mega-PR per user request. All three inventory checks agree: `wp_register_ability` name grep, `extends Ability_Definition` file count, and Bootstrap `new X\Y();` instantiations all return **218**.
- **Two new categories** join the Ability Library: `admin-menu` (5 abilities) and `content-search` (11 abilities). Each has a new `Category_Registrar.php` wired into `AcrossAI_Core_Abilities_Bootstrap.php::register_category_callbacks()`.
- **Two new option-backed data stores** — zero new database tables, zero migrations. Both are capped to bound storage growth.
- **No breaking changes** to any of the 187 existing abilities. Zero external HTTP; zero new REST routes.

## The 31 new abilities

**Site editor / structure — Block/ folder (4)**
- `site-editor-get-context`, `site-editor-refresh-context`
- `site-structure-list-reusable-blocks`, `site-structure-list-block-areas`

**Admin menu — new `AdminMenu/` folder + `Category_Registrar` (5)**
- `admin-menu-get-context`, `admin-menu-refresh-context`, `admin-menu-list-pages`, `admin-menu-get-navigation-target`, `admin-menu-list-settings`

**Navigation — Menus/ folder (2)**
- `navigation-get-context`, `navigation-list-locations`

**Users — Users/ folder (1)**
- `users-current-access`

**Content index / search / linking — new `ContentSearch/` folder + `Category_Registrar` + `Suggestion_Store` helper (11)**
- `content-index-refresh-batch`, `content-search-items`, `content-search-chunks`
- `content-find-related`, `content-find-internal-links`
- `content-internal-link-policy`
- `content-internal-link-suggestions-create` / `-list`
- `content-internal-link-suggestion-review` / `-apply`
- `content-audit-internal-links`

**Content advanced — Content/ folder (2)**
- `content-update-block` (uses `parse_blocks` + `serialize_blocks`; top-level block targeting only, nested-block editing deferred)
- `content-autosaves-inspect`

**Taxonomy — Taxonomies/ folder (1)**
- `taxonomy-set-term-image` (writes `_thumbnail_id` term-meta — WooCommerce convention)

**Media — Media/ folder (1)**
- `media-rename-file` (on-disk rename + `_wp_attached_file` update + `wp_generate_attachment_metadata`; safety-hardened, see below)

**Site lifecycle (3)**
- `site-maintenance-report` — SiteHealth/ folder
- `plugin-lifecycle-get-plugin` — Plugins/ folder
- `theme-lifecycle-get-theme` — Themes/ folder

**Comments — Comments/ folder (1)**
- `comments-bulk-update` — batched moderation, capped at 100 ids per call

## Data storage

Both stores are option-backed. Zero migrations. Zero new tables. Both are capped to bound growth.

- **`acrossai_abilities_manager_lifecycle_log`** — rolling event log for plugin/theme `activate`/`deactivate`/`update` events. Capped at 50 events per (scope, key) pair. `Utilities\Lifecycle_Event_Log::register_hooks()` (wired from Bootstrap) subscribes to `activated_plugin`, `deactivated_plugin`, `upgrader_process_complete`, and `switch_theme`. Events are recorded from 0.0.13 forward — pre-0.0.13 lifecycle history is not backfilled and those timestamps read `0` until the next event fires.
- **`acrossai_abilities_manager_link_suggestions`** — internal-link suggestion queue. Capped at 500 total suggestions. Read/write via `ContentSearch\Suggestion_Store`. Statuses: `pending` / `approved` / `rejected` / `applied`.

## Safety highlights

- **`media-rename-file`** — rejects `new_filename` containing directory separators, null bytes, or a leading dot. Enforces realpath containment inside the attachment's original upload sub-directory. Refuses to clobber an existing target file. Requires `manage_options` + `upload_files`.
- **`comments-bulk-update`** — requires `manage_options` + `moderate_comments`. Caps at 100 comment ids per call. Per-comment success/failure envelope.
- **`content-internal-link-suggestion-apply`** — requires `manage_options` + `edit_others_posts`. Re-validates the suggestion target as same-site at apply time. Mutates by wrapping the first case-insensitive occurrence of `anchor_text` — no whole-post rewrite.
- **All abilities** — default `manage_options` gate; input schemas declare `additionalProperties: false`; operation-specific caps layered on top (e.g. `upload_files`, `moderate_comments`, `edit_others_posts`, `edit_posts`).

## Verification (all green pre-push)

- ✅ **Ability count**: 218 (via `wp_register_ability` name grep)
- ✅ **Class file count**: 218 (via `extends Ability_Definition` file count)
- ✅ **Bootstrap wiring**: 218 (via `new X\Y();` grep in `AcrossAI_Core_Abilities_Bootstrap.php`) — 1:1 across all three
- ✅ **PHPStan L8**: `composer run phpstan` exit 0
- ✅ **PHPCS**: `composer run phpcs` clean on every new file + edited Bootstrap
- ✅ **Version consistency**: `README.txt` Stable tag, `acrossai-abilities-manager.php` `Version:` header, `includes/Main.php` `ACROSSAI_ABILITIES_MANAGER_VERSION` constant, and topmost Changelog + Upgrade Notice entries all read `0.0.13`

## Test plan

- [ ] Load the plugin on a fresh WP install; confirm 218 abilities appear in the Abilities Manager admin page.
- [ ] Confirm the two new tabs ("Admin Menu", "Content Search") render on the Ability Library page.
- [ ] Manual smoke tests, at least one per new domain:
  - [ ] `users-current-access` returns the caller's roles + capability map
  - [ ] `taxonomy-set-term-image` — attach an attachment, then clear
  - [ ] `comments-bulk-update` — approve 3 comments in one call
  - [ ] `media-rename-file` — rename an image; confirm on-disk rename + `_wp_attached_file` update + thumbnail regen
  - [ ] `navigation-get-context` — returns menus + locations
  - [ ] `admin-menu-list-pages` — returns the top-level admin menu tree
  - [ ] `content-search-items` — returns matches for a known-hit query
  - [ ] `content-internal-link-suggestions-create` → `-list` → `-review` (approved) → `-apply` — full lifecycle
  - [ ] `site-maintenance-report` — returns pending updates + disk stats
  - [ ] `plugin-lifecycle-get-plugin` for an already-installed plugin — timestamps read `0` until events fire post-upgrade
- [ ] Confirm PHPUnit + Jest suites remain green.

## Follow-ups (deferred by design)

- Full-text search backing store for `content-search-*` — currently WP_Query `s=` fallback (LIKE-based, no ranked scores).
- Editable internal-link policy — currently static v1 ruleset returned by `content-internal-link-policy`.
- Nested-block targeting in `content-update-block` — currently top-level blocks only.
- Backfill of pre-0.0.13 lifecycle events — event log records events forward-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)