### PR TITLE
Feature 056 — break the Core tab into 8 per-domain Library tabs

### DIFF
--- a/includes/Abilities/AdminMenu/Admin_Menu_Get_Context.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_Get_Context.php
@@ -58,7 +58,7 @@ class Admin_Menu_Get_Context extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'admin-menu',
 						'sub_group'       => 'admin-menu',
 						'sub_group_label' => __( 'Admin Menu', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/AdminMenu/Admin_Menu_Get_Navigation_Target.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_Get_Navigation_Target.php
@@ -68,7 +68,7 @@ class Admin_Menu_Get_Navigation_Target extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'admin-menu',
 						'sub_group'       => 'admin-menu',
 						'sub_group_label' => __( 'Admin Menu', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/AdminMenu/Admin_Menu_List_Pages.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_List_Pages.php
@@ -58,7 +58,7 @@ class Admin_Menu_List_Pages extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'admin-menu',
 						'sub_group'       => 'admin-menu',
 						'sub_group_label' => __( 'Admin Menu', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/AdminMenu/Admin_Menu_List_Settings.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_List_Settings.php
@@ -56,7 +56,7 @@ class Admin_Menu_List_Settings extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'admin-menu',
 						'sub_group'       => 'admin-menu',
 						'sub_group_label' => __( 'Admin Menu', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/AdminMenu/Admin_Menu_Refresh_Context.php
+++ b/includes/Abilities/AdminMenu/Admin_Menu_Refresh_Context.php
@@ -54,7 +54,7 @@ class Admin_Menu_Refresh_Context extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'admin-menu',
 						'sub_group'       => 'admin-menu',
 						'sub_group_label' => __( 'Admin Menu', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Content_Autosaves_Inspect.php
+++ b/includes/Abilities/Content/Content_Autosaves_Inspect.php
@@ -63,7 +63,7 @@ class Content_Autosaves_Inspect extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'posts',
 						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Content_Update_Block.php
+++ b/includes/Abilities/Content/Content_Update_Block.php
@@ -76,7 +76,7 @@ class Content_Update_Block extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'posts',
 						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Create_Cpt_Item.php
+++ b/includes/Abilities/Content/Create_Cpt_Item.php
@@ -68,7 +68,7 @@ class Create_Cpt_Item extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'cpt',
 						'sub_group_label' => __( 'Custom Post Types', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Create_Page.php
+++ b/includes/Abilities/Content/Create_Page.php
@@ -72,7 +72,7 @@ class Create_Page extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'pages',
 						'sub_group_label' => __( 'Pages', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Create_Post.php
+++ b/includes/Abilities/Content/Create_Post.php
@@ -70,7 +70,7 @@ class Create_Post extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'posts',
 						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Delete_Cpt_Item.php
+++ b/includes/Abilities/Content/Delete_Cpt_Item.php
@@ -64,7 +64,7 @@ class Delete_Cpt_Item extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'cpt',
 						'sub_group_label' => __( 'Custom Post Types', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Delete_Post.php
+++ b/includes/Abilities/Content/Delete_Post.php
@@ -64,7 +64,7 @@ class Delete_Post extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'posts',
 						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Cpt_Item.php
+++ b/includes/Abilities/Content/Get_Cpt_Item.php
@@ -59,7 +59,7 @@ class Get_Cpt_Item extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'cpt',
 						'sub_group_label' => __( 'Custom Post Types', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Cpt_Item_Revisions.php
+++ b/includes/Abilities/Content/Get_Cpt_Item_Revisions.php
@@ -76,7 +76,7 @@ class Get_Cpt_Item_Revisions extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'cpt',
 						'sub_group_label' => __( 'Custom Post Types', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Cpt_Items.php
+++ b/includes/Abilities/Content/Get_Cpt_Items.php
@@ -82,7 +82,7 @@ class Get_Cpt_Items extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'cpt',
 						'sub_group_label' => __( 'Custom Post Types', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Page.php
+++ b/includes/Abilities/Content/Get_Page.php
@@ -58,7 +58,7 @@ class Get_Page extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'pages',
 						'sub_group_label' => __( 'Pages', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Page_Revisions.php
+++ b/includes/Abilities/Content/Get_Page_Revisions.php
@@ -75,7 +75,7 @@ class Get_Page_Revisions extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'pages',
 						'sub_group_label' => __( 'Pages', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Pages.php
+++ b/includes/Abilities/Content/Get_Pages.php
@@ -80,7 +80,7 @@ class Get_Pages extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'pages',
 						'sub_group_label' => __( 'Pages', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Post.php
+++ b/includes/Abilities/Content/Get_Post.php
@@ -62,7 +62,7 @@ class Get_Post extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'posts',
 						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Post_Meta.php
+++ b/includes/Abilities/Content/Get_Post_Meta.php
@@ -72,7 +72,7 @@ class Get_Post_Meta extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'posts',
 						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Post_Revisions.php
+++ b/includes/Abilities/Content/Get_Post_Revisions.php
@@ -79,7 +79,7 @@ class Get_Post_Revisions extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'posts',
 						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Post_Translations.php
+++ b/includes/Abilities/Content/Get_Post_Translations.php
@@ -60,7 +60,7 @@ class Get_Post_Translations extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'multilanguage',
 						'sub_group_label' => __( 'Multilanguage', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Get_Posts.php
+++ b/includes/Abilities/Content/Get_Posts.php
@@ -87,7 +87,7 @@ class Get_Posts extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'posts',
 						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Je_Get_Options_Page.php
+++ b/includes/Abilities/Content/Je_Get_Options_Page.php
@@ -56,7 +56,7 @@ class Je_Get_Options_Page extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'options-pages',
 						'sub_group_label' => __( 'Options Pages', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Je_List_Options_Pages.php
+++ b/includes/Abilities/Content/Je_List_Options_Pages.php
@@ -54,7 +54,7 @@ class Je_List_Options_Pages extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'options-pages',
 						'sub_group_label' => __( 'Options Pages', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Je_Update_Options_Page_Field.php
+++ b/includes/Abilities/Content/Je_Update_Options_Page_Field.php
@@ -59,7 +59,7 @@ class Je_Update_Options_Page_Field extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'options-pages',
 						'sub_group_label' => __( 'Options Pages', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Link_Post_Translation.php
+++ b/includes/Abilities/Content/Link_Post_Translation.php
@@ -60,7 +60,7 @@ class Link_Post_Translation extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'multilanguage',
 						'sub_group_label' => __( 'Multilanguage', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/List_Post_Types.php
+++ b/includes/Abilities/Content/List_Post_Types.php
@@ -66,7 +66,7 @@ class List_Post_Types extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'cpt',
 						'sub_group_label' => __( 'Custom Post Types', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Set_Post_Language.php
+++ b/includes/Abilities/Content/Set_Post_Language.php
@@ -61,7 +61,7 @@ class Set_Post_Language extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'multilanguage',
 						'sub_group_label' => __( 'Multilanguage', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Update_Cpt_Item.php
+++ b/includes/Abilities/Content/Update_Cpt_Item.php
@@ -66,7 +66,7 @@ class Update_Cpt_Item extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'cpt',
 						'sub_group_label' => __( 'Custom Post Types', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Update_Page.php
+++ b/includes/Abilities/Content/Update_Page.php
@@ -66,7 +66,7 @@ class Update_Page extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'pages',
 						'sub_group_label' => __( 'Pages', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Update_Post.php
+++ b/includes/Abilities/Content/Update_Post.php
@@ -68,7 +68,7 @@ class Update_Post extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'posts',
 						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Content/Update_Post_Meta.php
+++ b/includes/Abilities/Content/Update_Post_Meta.php
@@ -76,7 +76,7 @@ class Update_Post_Meta extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'content',
 						'sub_group'       => 'posts',
 						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Fonts/Font_Face_Create.php
+++ b/includes/Abilities/Fonts/Font_Face_Create.php
@@ -95,7 +95,7 @@ class Font_Face_Create extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'fonts',
 						'sub_group'       => 'font-faces',
 						'sub_group_label' => __( 'Font Faces', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Fonts/Font_Face_Delete.php
+++ b/includes/Abilities/Fonts/Font_Face_Delete.php
@@ -69,7 +69,7 @@ class Font_Face_Delete extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'fonts',
 						'sub_group'       => 'font-faces',
 						'sub_group_label' => __( 'Font Faces', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Fonts/Font_Face_Get.php
+++ b/includes/Abilities/Fonts/Font_Face_Get.php
@@ -67,7 +67,7 @@ class Font_Face_Get extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'fonts',
 						'sub_group'       => 'font-faces',
 						'sub_group_label' => __( 'Font Faces', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Fonts/Font_Face_List.php
+++ b/includes/Abilities/Fonts/Font_Face_List.php
@@ -75,7 +75,7 @@ class Font_Face_List extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'fonts',
 						'sub_group'       => 'font-faces',
 						'sub_group_label' => __( 'Font Faces', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Fonts/Font_Family_Create.php
+++ b/includes/Abilities/Fonts/Font_Family_Create.php
@@ -79,7 +79,7 @@ class Font_Family_Create extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'fonts',
 						'sub_group'       => 'font-families',
 						'sub_group_label' => __( 'Font Families', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Fonts/Font_Family_Delete.php
+++ b/includes/Abilities/Fonts/Font_Family_Delete.php
@@ -64,7 +64,7 @@ class Font_Family_Delete extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'fonts',
 						'sub_group'       => 'font-families',
 						'sub_group_label' => __( 'Font Families', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Fonts/Font_Family_Get.php
+++ b/includes/Abilities/Fonts/Font_Family_Get.php
@@ -63,7 +63,7 @@ class Font_Family_Get extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'fonts',
 						'sub_group'       => 'font-families',
 						'sub_group_label' => __( 'Font Families', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Fonts/Font_Family_List.php
+++ b/includes/Abilities/Fonts/Font_Family_List.php
@@ -70,7 +70,7 @@ class Font_Family_List extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'fonts',
 						'sub_group'       => 'font-families',
 						'sub_group_label' => __( 'Font Families', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/Create_Menu.php
+++ b/includes/Abilities/Menus/Create_Menu.php
@@ -61,7 +61,7 @@ class Create_Menu extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menus',
 						'sub_group_label' => __( 'Menus', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/Create_Menu_Item.php
+++ b/includes/Abilities/Menus/Create_Menu_Item.php
@@ -85,7 +85,7 @@ class Create_Menu_Item extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menu-items',
 						'sub_group_label' => __( 'Menu Items', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/Delete_Menu.php
+++ b/includes/Abilities/Menus/Delete_Menu.php
@@ -59,7 +59,7 @@ class Delete_Menu extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menus',
 						'sub_group_label' => __( 'Menus', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/Delete_Menu_Item.php
+++ b/includes/Abilities/Menus/Delete_Menu_Item.php
@@ -59,7 +59,7 @@ class Delete_Menu_Item extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menu-items',
 						'sub_group_label' => __( 'Menu Items', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/Get_Menu.php
+++ b/includes/Abilities/Menus/Get_Menu.php
@@ -58,7 +58,7 @@ class Get_Menu extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menus',
 						'sub_group_label' => __( 'Menus', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/Get_Menu_Item.php
+++ b/includes/Abilities/Menus/Get_Menu_Item.php
@@ -58,7 +58,7 @@ class Get_Menu_Item extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menu-items',
 						'sub_group_label' => __( 'Menu Items', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/List_Menu_Items.php
+++ b/includes/Abilities/Menus/List_Menu_Items.php
@@ -66,7 +66,7 @@ class List_Menu_Items extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menu-items',
 						'sub_group_label' => __( 'Menu Items', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/List_Menus.php
+++ b/includes/Abilities/Menus/List_Menus.php
@@ -65,7 +65,7 @@ class List_Menus extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menus',
 						'sub_group_label' => __( 'Menus', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/Navigation_Get_Context.php
+++ b/includes/Abilities/Menus/Navigation_Get_Context.php
@@ -54,7 +54,7 @@ class Navigation_Get_Context extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menus',
 						'sub_group_label' => __( 'Menus', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/Navigation_List_Locations.php
+++ b/includes/Abilities/Menus/Navigation_List_Locations.php
@@ -53,7 +53,7 @@ class Navigation_List_Locations extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menus',
 						'sub_group_label' => __( 'Menus', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/Update_Menu.php
+++ b/includes/Abilities/Menus/Update_Menu.php
@@ -65,7 +65,7 @@ class Update_Menu extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menus',
 						'sub_group_label' => __( 'Menus', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Menus/Update_Menu_Item.php
+++ b/includes/Abilities/Menus/Update_Menu_Item.php
@@ -76,7 +76,7 @@ class Update_Menu_Item extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'menus',
 						'sub_group'       => 'menu-items',
 						'sub_group_label' => __( 'Menu Items', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Options/Delete_Option.php
+++ b/includes/Abilities/Options/Delete_Option.php
@@ -55,7 +55,7 @@ class Delete_Option extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'options',
 						'sub_group'       => 'manage',
 						'sub_group_label' => __( 'Manage', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Options/Get_Option.php
+++ b/includes/Abilities/Options/Get_Option.php
@@ -58,7 +58,7 @@ class Get_Option extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'options',
 						'sub_group'       => 'manage',
 						'sub_group_label' => __( 'Manage', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Options/List_Options.php
+++ b/includes/Abilities/Options/List_Options.php
@@ -74,7 +74,7 @@ class List_Options extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'options',
 						'sub_group'       => 'search',
 						'sub_group_label' => __( 'Search', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Options/Search_Options.php
+++ b/includes/Abilities/Options/Search_Options.php
@@ -72,7 +72,7 @@ class Search_Options extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'options',
 						'sub_group'       => 'search',
 						'sub_group_label' => __( 'Search', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Options/Update_Option.php
+++ b/includes/Abilities/Options/Update_Option.php
@@ -74,7 +74,7 @@ class Update_Option extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'options',
 						'sub_group'       => 'manage',
 						'sub_group_label' => __( 'Manage', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Settings/Permalink_Flush.php
+++ b/includes/Abilities/Settings/Permalink_Flush.php
@@ -63,7 +63,7 @@ class Permalink_Flush extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'settings',
 						'sub_group'       => 'permalinks',
 						'sub_group_label' => __( 'Permalinks', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Settings/Permalink_Get.php
+++ b/includes/Abilities/Settings/Permalink_Get.php
@@ -57,7 +57,7 @@ class Permalink_Get extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'settings',
 						'sub_group'       => 'permalinks',
 						'sub_group_label' => __( 'Permalinks', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Settings/Permalink_Set.php
+++ b/includes/Abilities/Settings/Permalink_Set.php
@@ -82,7 +82,7 @@ class Permalink_Set extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'settings',
 						'sub_group'       => 'permalinks',
 						'sub_group_label' => __( 'Permalinks', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Settings/Site_Icon_Get.php
+++ b/includes/Abilities/Settings/Site_Icon_Get.php
@@ -54,7 +54,7 @@ class Site_Icon_Get extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'settings',
 						'sub_group'       => 'site-identity',
 						'sub_group_label' => __( 'Site Identity', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Settings/Site_Icon_Update.php
+++ b/includes/Abilities/Settings/Site_Icon_Update.php
@@ -66,7 +66,7 @@ class Site_Icon_Update extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'settings',
 						'sub_group'       => 'site-identity',
 						'sub_group_label' => __( 'Site Identity', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Settings/Site_Logo_Update.php
+++ b/includes/Abilities/Settings/Site_Logo_Update.php
@@ -70,7 +70,7 @@ class Site_Logo_Update extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'settings',
 						'sub_group'       => 'site-identity',
 						'sub_group_label' => __( 'Site Identity', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Settings/Site_Title_Get.php
+++ b/includes/Abilities/Settings/Site_Title_Get.php
@@ -51,7 +51,7 @@ class Site_Title_Get extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'settings',
 						'sub_group'       => 'site-identity',
 						'sub_group_label' => __( 'Site Identity', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Settings/Site_Title_Update.php
+++ b/includes/Abilities/Settings/Site_Title_Update.php
@@ -60,7 +60,7 @@ class Site_Title_Update extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'settings',
 						'sub_group'       => 'site-identity',
 						'sub_group_label' => __( 'Site Identity', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Settings/Tagline_Get.php
+++ b/includes/Abilities/Settings/Tagline_Get.php
@@ -51,7 +51,7 @@ class Tagline_Get extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'settings',
 						'sub_group'       => 'site-identity',
 						'sub_group_label' => __( 'Site Identity', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Settings/Tagline_Update.php
+++ b/includes/Abilities/Settings/Tagline_Update.php
@@ -60,7 +60,7 @@ class Tagline_Update extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'settings',
 						'sub_group'       => 'site-identity',
 						'sub_group_label' => __( 'Site Identity', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/SiteHealth/Site_Health_Info.php
+++ b/includes/Abilities/SiteHealth/Site_Health_Info.php
@@ -64,7 +64,7 @@ class Site_Health_Info extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'site-health',
 						'sub_group'       => 'read',
 						'sub_group_label' => __( 'Read Site Health', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/SiteHealth/Site_Health_Status.php
+++ b/includes/Abilities/SiteHealth/Site_Health_Status.php
@@ -82,7 +82,7 @@ class Site_Health_Status extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'site-health',
 						'sub_group'       => 'read',
 						'sub_group_label' => __( 'Read Site Health', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/SiteHealth/Site_Maintenance_Report.php
+++ b/includes/Abilities/SiteHealth/Site_Maintenance_Report.php
@@ -66,7 +66,7 @@ class Site_Maintenance_Report extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'site-health',
 						'sub_group'       => 'site-health',
 						'sub_group_label' => __( 'Site Health', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Taxonomies/Assign_Cpt_Terms.php
+++ b/includes/Abilities/Taxonomies/Assign_Cpt_Terms.php
@@ -68,7 +68,7 @@ class Assign_Cpt_Terms extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'taxonomies',
 						'sub_group'       => 'terms',
 						'sub_group_label' => __( 'Terms', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Taxonomies/Create_Term.php
+++ b/includes/Abilities/Taxonomies/Create_Term.php
@@ -62,7 +62,7 @@ class Create_Term extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'taxonomies',
 						'sub_group'       => 'terms',
 						'sub_group_label' => __( 'Terms', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Taxonomies/Delete_Term.php
+++ b/includes/Abilities/Taxonomies/Delete_Term.php
@@ -60,7 +60,7 @@ class Delete_Term extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'taxonomies',
 						'sub_group'       => 'terms',
 						'sub_group_label' => __( 'Terms', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Taxonomies/Get_Cpt_Taxonomies.php
+++ b/includes/Abilities/Taxonomies/Get_Cpt_Taxonomies.php
@@ -56,7 +56,7 @@ class Get_Cpt_Taxonomies extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'taxonomies',
 						'sub_group'       => 'taxonomies',
 						'sub_group_label' => __( 'Taxonomies', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Taxonomies/Get_Taxonomy.php
+++ b/includes/Abilities/Taxonomies/Get_Taxonomy.php
@@ -55,7 +55,7 @@ class Get_Taxonomy extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'taxonomies',
 						'sub_group'       => 'taxonomies',
 						'sub_group_label' => __( 'Taxonomies', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Taxonomies/Get_Term.php
+++ b/includes/Abilities/Taxonomies/Get_Term.php
@@ -59,7 +59,7 @@ class Get_Term extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'taxonomies',
 						'sub_group'       => 'terms',
 						'sub_group_label' => __( 'Terms', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Taxonomies/List_Taxonomies.php
+++ b/includes/Abilities/Taxonomies/List_Taxonomies.php
@@ -58,7 +58,7 @@ class List_Taxonomies extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'taxonomies',
 						'sub_group'       => 'taxonomies',
 						'sub_group_label' => __( 'Taxonomies', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Taxonomies/List_Terms.php
+++ b/includes/Abilities/Taxonomies/List_Terms.php
@@ -79,7 +79,7 @@ class List_Terms extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'taxonomies',
 						'sub_group'       => 'terms',
 						'sub_group_label' => __( 'Terms', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Taxonomies/Set_Term_Image.php
+++ b/includes/Abilities/Taxonomies/Set_Term_Image.php
@@ -67,7 +67,7 @@ class Set_Term_Image extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'taxonomies',
 						'sub_group'       => 'terms',
 						'sub_group_label' => __( 'Terms', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Taxonomies/Update_Term.php
+++ b/includes/Abilities/Taxonomies/Update_Term.php
@@ -63,7 +63,7 @@ class Update_Term extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'taxonomies',
 						'sub_group'       => 'terms',
 						'sub_group_label' => __( 'Terms', 'acrossai-abilities-manager' ),
 					),


### PR DESCRIPTION
## Summary

Retag every ability whose `tab_group` was still `core` into its own per-domain tab. Only the three `wp-core-*` abilities stay under Core — they literally administer WordPress core itself.

**Stacks on [PR #80](https://github.com/acrossai-co/acrossai-abilities-manager/pull/80)** — base is `055-implement-all-31-abilities`, not `main`. This branch retags 11 Feature 055 abilities that were left on `core` by mistake and would otherwise land pre-tagged. **Merge PR #80 first, then this one.** The PR base will auto-update to `main` after that.

## 81 abilities retagged across 8 domains

| Domain | Count | Notes |
|---|---|---|
| `admin-menu` | 5 | `AdminMenu/*` — fixes my Feature 055 mistake |
| `content` | 28 | posts / pages / CPTs / revisions / translations / JetEngine options-pages + `content-update-block` + `content-autosaves-inspect` |
| `fonts` | 8 | font-family + font-face CRUD |
| `menus` | 12 | nav-menu CRUD + `navigation-get-context` + `navigation-list-locations` |
| `options` | 5 | get / update / delete / list / search |
| `settings` | 10 | permalinks + site title / tagline / icon / logo |
| `site-health` | 3 | info + status + `site-maintenance-report` |
| `taxonomies` | 10 | list / get / create / update / delete + `assign-cpt-terms` + `taxonomy-set-term-image` |

## Core tab after this PR

Only 3 abilities — the ones that actually administer WordPress core itself:
- `wp-core-update-check`
- `wp-core-update`
- `wp-core-rollback`

## Full tab distribution (20 tabs, 218 abilities)

| Tab | # | Tab | # | Tab | # | Tab | # |
|---|---|---|---|---|---|---|---|
| Blocks | 33 | Comments | 11 | Media | 10 | Admin Menu | 5 |
| Content | 28 | Content Search | 11 | Users | 9 | Site Health | 3 |
| Cron | 15 | Taxonomies | 10 | Themes | 9 | Core | 3 |
| File Manager | 14 | Settings | 10 | Database | 9 | Cache | 3 |
| Menus | 12 | Plugins | 10 | Fonts | 8 | Options | 5 |

## What did NOT change

- Category slugs — every `acrossai-abilities-manager-*` category slug stays as-is
- Ability slugs — every `acrossai-abilities-manager/*` slug stays as-is
- Input / output schemas — unchanged
- Permission callbacks — unchanged
- Sub-groups — unchanged (still render as sub-headings inside the card)

**Zero breaking changes.**

## Method

8 `perl -pi -e "s/'tab_group' => 'core',/'tab_group' => '<domain>',/"` invocations, one per folder. Chosen over 81 individual Read+Edit pairs for cost efficiency on a pure mechanical text replacement. The exact string `'tab_group'       => 'core',` only occurs in ability-definition arrays; `Category_Registrar.php` and formatter helpers don't contain it, so they were untouched.

## Verification

- ✅ Tab distribution grep matches expected counts (218 total, only 3 remaining on `core`)
- ✅ `composer run phpstan` exit 0 (L8 clean)
- ✅ `git diff --stat` shows 81 files changed, +81 / -81 (single-string retag per file)
- ✅ No Bootstrap change, no schema change, no build artifact change

## Test plan

- [ ] After PR #80 merges + this PR merges: refresh `?page=acrossai-abilities-library`
- [ ] Confirm the tab bar shows 20 tabs (was 12)
- [ ] Confirm each affected category card's header chip reads its new domain name (e.g. Content, Menus, Settings) instead of "Core"
- [ ] Confirm the 3 remaining Core-tab abilities are only `wp-core-update-check`, `wp-core-update`, `wp-core-rollback`
- [ ] Sanity-check on a live site: existing saved Library config (option `acrossai_abilities_manager_library_config`) still works — the config is keyed by category, not by tab, so retagging tabs is inert to persisted state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)