### PR TITLE
Feature 057 — wp-core-reinstall ability

### DIFF
--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -293,6 +293,7 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Core\Wp_Core_Update_Check();
 		new Core\Wp_Core_Update();
 		new Core\Wp_Core_Rollback();
+		new Core\Wp_Core_Reinstall();
 
 		// Feature 055 — 31 new abilities across 10 domains.
 		new Users\Current_Access();

--- a/includes/Abilities/Core/Wp_Core_Reinstall.php
+++ b/includes/Abilities/Core/Wp_Core_Reinstall.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Wp_Core_Reinstall ability (Feature 057).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Core
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Core;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Reinstall the currently installed WordPress core version via WP core's
+ * Core_Upgrader by forcing `$update->response = 'reinstall'`.
+ *
+ * Equivalent to the WP admin action at
+ * `/wp-admin/update-core.php?action=do-core-reinstall`: re-downloads and
+ * re-applies the current WP version even when no upgrade offer is pending.
+ * Honours DISALLOW_FILE_MODS. Idempotent — safe to re-run.
+ */
+class Wp_Core_Reinstall extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai-abilities-manager/wp-core-reinstall',
+			'args' => array(
+				'label'               => __( 'Reinstall WordPress Core', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Reinstall the currently installed WordPress version by re-downloading and re-applying the same release via WP core\'s Core_Upgrader with response="reinstall". Equivalent to the wp-admin "Re-install version X" action at /wp-admin/update-core.php?action=do-core-reinstall. Honours DISALLOW_FILE_MODS. Idempotent — safe to re-run.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-core',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'update_core' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(
+						'locale' => array(
+							'type'        => 'string',
+							'description' => __( 'Optional locale of the reinstall offer to pin to (e.g. "en_US"). When omitted, defaults to the site\'s active locale from get_locale().', 'acrossai-abilities-manager' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'reinstalled' => array( 'type' => 'boolean' ),
+						'version'     => array( 'type' => 'string' ),
+						'message'     => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'lifecycle',
+						'sub_group_label' => __( 'Lifecycle', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response( 'install' );
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		if ( is_multisite() && ! current_user_can( 'update_core' ) ) {
+			return array(
+				'success'     => false,
+				'reinstalled' => false,
+				'message'     => __( 'Core reinstall on multisite requires the update_core capability at the network level.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( ! function_exists( 'get_core_updates' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/update.php';
+		}
+		if ( ! class_exists( '\Core_Upgrader' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		}
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
+
+		$current_version = (string) get_bloginfo( 'version' );
+
+		$locale = isset( $input['locale'] ) ? sanitize_text_field( (string) $input['locale'] ) : '';
+		if ( '' === $locale ) {
+			$locale = get_locale();
+		}
+
+		$update = find_core_update( $current_version, $locale );
+
+		if ( null === $update || false === $update ) {
+			return array(
+				'success'     => true,
+				'reinstalled' => false,
+				'version'     => $current_version,
+				'message'     => __( 'No core update offer available for reinstall. Run wp-core-update-check first to refresh the update_core transient.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Force the reinstall response so Core_Upgrader downloads the full
+		// (or no-content) package instead of a partial diff. Mirrors WP core's
+		// do_core_upgrade( $reinstall = true ) at wp-admin/update-core.php.
+		$update->response = 'reinstall';
+
+		$skin     = new \WP_Ajax_Upgrader_Skin();
+		$upgrader = new \Core_Upgrader( $skin );
+		$result   = $upgrader->upgrade(
+			$update,
+			array(
+				'allow_relaxed_file_ownership' => false,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'     => true,
+				'reinstalled' => false,
+				'version'     => $current_version,
+				'message'     => $result->get_error_message(),
+			);
+		}
+
+		if ( null === $result || false === $result ) {
+			$skin_errors = $skin->get_errors();
+			$msg         = is_wp_error( $skin_errors ) && $skin_errors->has_errors()
+				? $skin_errors->get_error_message()
+				: __( 'Core reinstall did not report success.', 'acrossai-abilities-manager' );
+			return array(
+				'success'     => true,
+				'reinstalled' => false,
+				'version'     => $current_version,
+				'message'     => $msg,
+			);
+		}
+
+		return array(
+			'success'     => true,
+			'reinstalled' => true,
+			'version'     => $current_version,
+			'message'     => sprintf(
+				/* translators: %s: WordPress version that was reinstalled */
+				__( 'WordPress %s reinstalled.', 'acrossai-abilities-manager' ),
+				$current_version
+			),
+		);
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -47,6 +47,9 @@
 		<testsuite name="feature-043-unit">
 			<file>tests/phpunit/abilities/Test_Feature_043_Core_Rollback.php</file>
 		</testsuite>
+		<testsuite name="feature-057-unit">
+			<file>tests/phpunit/abilities/Test_Feature_057_Core_Reinstall.php</file>
+		</testsuite>
 	</testsuites>
 	<source>
 		<include>

--- a/tests/phpunit/abilities/Test_Feature_057_Core_Reinstall.php
+++ b/tests/phpunit/abilities/Test_Feature_057_Core_Reinstall.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Structural tests for the Feature 057 Wp_Core_Reinstall ability.
+ *
+ * Covers:
+ *   - Class scaffolding, name, category, guards, and permission gate.
+ *   - The reinstall-specific difference: forces $update->response = 'reinstall'
+ *     and passes allow_relaxed_file_ownership=false to Core_Upgrader.
+ *   - Bootstrap wiring.
+ *
+ * Source-inspection only, mirroring Test_Feature_042_Core_Update.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Feature_057_Core_Reinstall.
+ */
+class Test_Feature_057_Core_Reinstall extends WP_UnitTestCase {
+
+	/**
+	 * Absolute paths to every source file exercised by these tests.
+	 *
+	 * @var array<string,string>
+	 */
+	private array $sources = array();
+
+	/**
+	 * Load every source file once per test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$plugin_root = dirname( __DIR__, 3 );
+
+		$this->sources = array(
+			'wp_core_reinstall' => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Core/Wp_Core_Reinstall.php'
+			),
+			'bootstrap'         => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php'
+			),
+		);
+	}
+
+	// =========================================================================
+	// Wp_Core_Reinstall — scaffolding + guards
+	// =========================================================================
+
+	/**
+	 * The reinstall ability wraps WP core's Core_Upgrader and honours
+	 * DISALLOW_FILE_MODS via File_Mods_Guard.
+	 *
+	 * @return void
+	 */
+	public function test_wp_core_reinstall_uses_core_upgrader_and_guards(): void {
+		$src = $this->sources['wp_core_reinstall'];
+		$this->assertStringContainsString( 'extends Ability_Definition', $src );
+		$this->assertStringContainsString(
+			"'acrossai-abilities-manager/wp-core-reinstall'",
+			$src,
+			'Ability name must be acrossai-abilities-manager/wp-core-reinstall.'
+		);
+		$this->assertStringContainsString(
+			"'acrossai-abilities-manager-core'",
+			$src,
+			'Ability category must point at the Core category slug.'
+		);
+		$this->assertStringContainsString(
+			'File_Mods_Guard::blocked_response',
+			$src,
+			'Wp_Core_Reinstall must invoke File_Mods_Guard::blocked_response(install).'
+		);
+		$this->assertMatchesRegularExpression(
+			"/File_Mods_Guard::blocked_response\(\s*'install'\s*\)/",
+			$src
+		);
+		$this->assertStringContainsString(
+			'Core_Upgrader',
+			$src,
+			'Wp_Core_Reinstall must wrap WP core Core_Upgrader.'
+		);
+		$this->assertStringContainsString(
+			'->upgrade(',
+			$src,
+			'Wp_Core_Reinstall must call ->upgrade( $update, ... ).'
+		);
+		$this->assertStringContainsString(
+			'WP_Ajax_Upgrader_Skin',
+			$src,
+			'Wp_Core_Reinstall must use WP_Ajax_Upgrader_Skin (same as Wp_Core_Update).'
+		);
+		$this->assertStringContainsString(
+			'is_multisite()',
+			$src,
+			'Wp_Core_Reinstall must contain a multisite guard.'
+		);
+	}
+
+	/**
+	 * The reinstall ability's permission_callback gates on BOTH manage_options
+	 * AND update_core — matching WP core's own admin gate.
+	 *
+	 * @return void
+	 */
+	public function test_wp_core_reinstall_requires_both_caps(): void {
+		$src = $this->sources['wp_core_reinstall'];
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\).*current_user_can\(\s*'update_core'\s*\)/s",
+			$src,
+			'Wp_Core_Reinstall permission_callback must AND manage_options with update_core.'
+		);
+	}
+
+	/**
+	 * The reinstall ability forces `$update->response = 'reinstall'` before
+	 * calling Core_Upgrader::upgrade() — the semantic difference from
+	 * Wp_Core_Update.
+	 *
+	 * @return void
+	 */
+	public function test_wp_core_reinstall_forces_reinstall_response(): void {
+		$src = $this->sources['wp_core_reinstall'];
+		$this->assertMatchesRegularExpression(
+			"/\\\$update->response\s*=\s*'reinstall'\s*;/",
+			$src,
+			'Wp_Core_Reinstall must set $update->response = \'reinstall\' before calling the upgrader.'
+		);
+	}
+
+	/**
+	 * The reinstall ability passes `allow_relaxed_file_ownership=false` to
+	 * the upgrader — matching WP admin's do_core_upgrade($reinstall=true).
+	 *
+	 * @return void
+	 */
+	public function test_wp_core_reinstall_disables_relaxed_file_ownership(): void {
+		$src = $this->sources['wp_core_reinstall'];
+		$this->assertStringContainsString(
+			"'allow_relaxed_file_ownership' => false",
+			$src,
+			'Wp_Core_Reinstall must pass allow_relaxed_file_ownership=false to the upgrader.'
+		);
+	}
+
+	/**
+	 * The reinstall ability accepts an optional `locale` override and does
+	 * NOT accept a `version` input (reinstall always targets the currently
+	 * installed version, matching WP admin's do-core-reinstall).
+	 *
+	 * @return void
+	 */
+	public function test_wp_core_reinstall_accepts_locale_only(): void {
+		$src = $this->sources['wp_core_reinstall'];
+		$this->assertStringContainsString( "'locale'", $src );
+		$this->assertStringContainsString( 'find_core_update', $src );
+		$this->assertStringNotContainsString(
+			"'version' => array(",
+			$src,
+			'Reinstall input schema must not accept a version pin.'
+		);
+	}
+
+	/**
+	 * The reinstall ability declares destructive=true — the annotation
+	 * difference from Wp_Core_Update (which is destructive=false).
+	 *
+	 * @return void
+	 */
+	public function test_wp_core_reinstall_annotations_declare_destructive(): void {
+		$src = $this->sources['wp_core_reinstall'];
+		$this->assertMatchesRegularExpression(
+			"/'destructive'\s*=>\s*true/",
+			$src,
+			'Reinstall annotations must declare destructive=true.'
+		);
+		$this->assertMatchesRegularExpression(
+			"/'idempotent'\s*=>\s*true/",
+			$src,
+			'Reinstall annotations must declare idempotent=true.'
+		);
+	}
+
+	// =========================================================================
+	// Bootstrap wiring
+	// =========================================================================
+
+	/**
+	 * The core bootstrap instantiates the new Wp_Core_Reinstall ability.
+	 *
+	 * @return void
+	 */
+	public function test_bootstrap_wires_wp_core_reinstall(): void {
+		$src = $this->sources['bootstrap'];
+		$this->assertStringContainsString(
+			'new Core\\Wp_Core_Reinstall()',
+			$src,
+			'Bootstrap must instantiate Wp_Core_Reinstall.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `acrossai-abilities-manager/wp-core-reinstall` under the existing Core category. Wraps WP core's `Core_Upgrader` with `\$update->response = 'reinstall'` to re-download and re-apply the currently installed WordPress version — the programmatic equivalent of wp-admin's `/wp-admin/update-core.php?action=do-core-reinstall`.
- Mirrors Feature 042's `wp-core-update` shape: same `File_Mods_Guard('install')` gate, multisite guard, `manage_options` + `update_core` permission callback, and `WP_Ajax_Upgrader_Skin` wiring. Differences: forces the reinstall response, passes `allow_relaxed_file_ownership => false` to match WP admin's `do_core_upgrade( \$reinstall = true )`, accepts only an optional `locale` input (no version pin — reinstall targets the running version), and annotates `destructive => true`.
- Adds `feature-057-unit` PHPUnit suite (7 source-inspection tests, 18 assertions) covering guards, permission gate, reinstall-response assignment, `allow_relaxed_file_ownership` flag, annotations, and bootstrap wiring.

## Test plan
- [x] `composer phpcs` — clean
- [x] `composer phpstan` — clean (level 8)
- [x] `composer test -- --testsuite feature-057-unit` — 7 passed / 18 assertions
- [x] `composer test` — 170 passed (no regressions)
- [ ] Manual: `GET /wp-json/wp-abilities/v1/abilities` — confirm `acrossai-abilities-manager/wp-core-reinstall` appears under the Core category
- [ ] Manual: as non-admin, REST `execute` returns 403
- [ ] Manual: with `DISALLOW_FILE_MODS` defined, `execute` returns the blocked response
- [ ] Manual: run `wp-core-update-check` to warm the transient, then `wp-core-reinstall` — expect `success=true, reinstalled=true, version=<current>` and re-flushed core files
- [ ] Manual: re-run immediately — expect the same success payload (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)