### PR TITLE
Feature 059 — Recovery Mode / Safe Mode / fatal-error abilities

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.16
+Stable tag: 0.0.17
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -99,6 +99,12 @@ This plugin does not collect, store, or transmit any user data.
 No data is sent to any external server without explicit user action.
 
 == Changelog ==
+
+= 0.0.17 =
+* **New — 7 Recovery Mode abilities under a new `Recovery` category.** Adds `acrossai/get-recovery-mode-status`, `acrossai/list-paused-plugins`, `acrossai/list-paused-themes`, `acrossai/get-recovery-exit-url`, `acrossai/unpause-plugin`, `acrossai/unpause-theme`, and `acrossai/list-recent-fatal-errors`. Together they let an AI agent driving the site over REST/MCP detect if WordPress has entered Recovery Mode after a fatal error, enumerate paused (fatally-erroring) plugins and themes with their captured error details, clear a paused entry so WP retries loading the extension on the next request, retrieve the admin-clickable exit URL, and pull grouped fatal-error signatures from `debug.log`. Every write action gates on `manage_options` + `File_Mods_Guard::blocked_response()`; fuzzy plugin/theme identifiers flow through the existing `Plugin_Helpers::resolve_plugin()` / `Theme_Helpers::resolve_theme()` resolvers.
+* **Intentional non-goals: no programmatic recovery-mode trigger, no programmatic exit.** WP core has no public API to enter recovery mode from a REST call (the handler only fires on a real fatal at a protected endpoint), and exit is guarded by both a session cookie and a nonce that a normal admin REST session can't satisfy. The `get-recovery-exit-url` ability returns the URL for an admin (or a browser-driving agent) to follow instead.
+* **Docs — recovery-mode compatibility noted on 3 existing abilities.** `activate-plugin`, `deactivate-plugin`, and `activate-theme` now mention in their `description` that they work in recovery mode (they only update the `active_plugins` / active-theme option and don't load the extension file).
+* **Ships without JS, DB, or REST-controller changes.** Purely new PHP source under `includes/Abilities/Recovery/` plus 7-line bootstrap wiring. 21 new PHPUnit tests under the new `feature-059-unit` testsuite.
 
 = 0.0.16 =
 * **BREAKING — every ability slug has been renamed.** Two changes at once: (a) namespace shortens from `acrossai-abilities-manager/` (27 chars) to `acrossai/` (9 chars), and (b) suffixes flip to verb-first form. Every ability is now `acrossai/<verb>-<subject>` — e.g. `acrossai/get-site-title`, `acrossai/activate-theme`, `acrossai/list-plugins` — instead of the pre-0.0.16 `acrossai-abilities-manager/<subject>-<verb>` form. 163 suffixes changed; 56 already-verb-first suffixes only had their namespace shortened. Every ability's `label` was already verb-first ("Get Site Title", "Activate Theme"), so the slug now reads the same word order as the label. Motivation: alignment with the WordPress core MCP adapter convention (`mcp-adapter/discover-abilities`, `mcp-adapter/execute-ability`) and with the broader function-calling / MCP naming used by every major LLM tool-use spec.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.16
+ * Version:           0.0.17
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/docs/planning/059-recovery-mode.md
+++ b/docs/planning/059-recovery-mode.md
@@ -1,0 +1,118 @@
+# Feature 059 — Recovery Mode / Safe Mode / fatal-error abilities
+
+**Status**: input brief for `/speckit-specify`. Written 2026-07-25.
+
+## Problem
+
+WordPress **Recovery Mode** (WP 5.2+) is the safety net that engages on fatal errors. It pauses the offending plugin/theme and shows a recovery banner in `wp-admin`. Recovery mode's admin UI is discoverable only when someone happens to be logged in mid-fatal — an AI agent driving the site over REST/MCP has no way to see or act on it.
+
+The plugin today has:
+
+- No visibility into recovery-mode state.
+- No way to list which extensions WP has paused.
+- No way to clear a paused entry.
+- No filter to surface fatal errors specifically in `debug.log` (existing `read-debug-log` returns raw text).
+
+## Proposed abilities
+
+7 new abilities under a new `Recovery` category (`includes/Abilities/Recovery/`). Slug convention per `DEC-SLUG-CONVENTION-VERB-FIRST` (Feature 058): `acrossai/<verb>-<subject>`.
+
+### Reads (4)
+
+| Slug | Purpose | Core API |
+|---|---|---|
+| `acrossai/get-recovery-mode-status` | Detect if the site is currently in recovery mode + summary counters. | `wp_is_recovery_mode()`, `wp_paused_plugins()->get_all()`, `wp_paused_themes()->get_all()`, `wp_is_fatal_error_handler_enabled()` |
+| `acrossai/list-paused-plugins` | Enumerate every paused plugin with its captured error details. | `wp_paused_plugins()->get_all()` + enrichment via `Plugin_Helpers::resolve_plugin()` for the human plugin name |
+| `acrossai/list-paused-themes` | Symmetric for themes. | `wp_paused_themes()->get_all()` + `Theme_Helpers::resolve_theme()` |
+| `acrossai/get-recovery-exit-url` | Return the admin-clickable URL that exits recovery mode. Cannot programmatically exit (nonce + cookie guarded); this is the closest we can ship. | `wp_nonce_url( admin_url(), WP_Recovery_Mode::EXIT_ACTION )` — same pattern as `wp_recovery_mode_nag()` in `wp-admin/includes/update.php:1019` |
+
+### Writes (2)
+
+| Slug | Purpose | Core API | Guards |
+|---|---|---|---|
+| `acrossai/unpause-plugin` | Clear the paused-storage entry so WP retries loading the plugin next request. Distinct from `deactivate-plugin` (which only flips `active_plugins`). | `wp_paused_plugins()->delete($slug)` + `Plugin_Helpers::resolve_plugin()` for fuzzy match | `manage_options` + `File_Mods_Guard::blocked_response()` |
+| `acrossai/unpause-theme` | Symmetric for themes. | `wp_paused_themes()->delete($slug)` + `Theme_Helpers::resolve_theme()` | same |
+
+Annotations: `destructive: true, idempotent: true` (unpausing an already-unpaused extension is a no-op).
+
+### Read (fatal-error filter) (1)
+
+| Slug | Purpose | Notes |
+|---|---|---|
+| `acrossai/list-recent-fatal-errors` | Parse `debug.log` and return only PHP Fatal / Parse / Compile errors, grouped by signature (`type + file + line + message`), with `since_days` and `limit` inputs. | Streams the file line-by-line (don't `file_get_contents` — logs can be huge). Reuses log-path + `WP_DEBUG_LOG`-enabled guard from `Read_Debug_Log.php:90-101`. |
+
+Inputs:
+- `since_days` (int, default 7, max 90)
+- `limit` (int, default 20, max 200)
+
+Output shape:
+```json
+[
+  {
+    "first_seen": "2026-07-20T14:32:11+00:00",
+    "last_seen":  "2026-07-24T09:15:03+00:00",
+    "count":      7,
+    "type":       "Fatal Error",
+    "message":    "Uncaught Error: Call to undefined function foo()",
+    "file":       "/path/to/plugin/thing.php",
+    "line":       42,
+    "sample_stack": ["#0 /path/to/plugin/other.php(15): thing_do()", "..."]
+  }
+]
+```
+
+Sorted by `last_seen` desc.
+
+## Documentation-only tweaks (no code change)
+
+Append one sentence to the `description` of four existing abilities so agents know they work in recovery mode:
+
+- `acrossai/activate-plugin`, `acrossai/deactivate-plugin`
+- `acrossai/activate-theme`, `acrossai/deactivate-theme`
+
+Text: *"Works in recovery mode; only updates the active-plugins/themes option, does not load the extension file."*
+
+## Explicitly dropped from scope
+
+- **"Trigger recovery mode programmatically"** — WP core has NO public API. The recovery-mode handler only fires when a real fatal error hits a protected endpoint (admin / login / protected AJAX). Cannot be manually triggered from REST.
+- **"Exit recovery mode programmatically"** — the exit action is guarded by both a cookie (from the recovery-mode entry link) and a nonce. A normal admin REST call can't satisfy those. Replaced by `get-recovery-exit-url` above; an admin (or an agent driving a browser) clicks that URL to exit.
+
+## Existing utilities to reuse
+
+| Utility | Path | Reuse for |
+|---|---|---|
+| `Ability_Definition` base class | `includes/Modules/Library/Ability_Definition.php` | Every new ability extends this |
+| `Plugin_Helpers::resolve_plugin()` | `includes/Abilities/Utilities/Plugin_Helpers.php:100` | Fuzzy plugin-slug resolution for `Unpause_Plugin` + name enrichment in `List_Paused_Plugins` |
+| `Theme_Helpers::resolve_theme()` | `includes/Abilities/Utilities/Theme_Helpers.php:93` | Symmetric for themes |
+| `File_Mods_Guard::blocked_response()` | (used in `Clear_Debug_Log.php:82`) | Guards `Unpause_Plugin` + `Unpause_Theme` — same convention WP core uses on its paused-extension admin actions |
+| Log-path + `WP_DEBUG_LOG` guard | `Read_Debug_Log.php:90-101` | Copy the guard shape into `List_Recent_Fatal_Errors` (single re-user; no shared helper needed) |
+| `meta.acrossai` metadata pattern | Feature 041 convention | New abilities set `sub_group: 'recovery'` under a `tab_group: 'core'` (or new `tab_group: 'recovery'` — TBD in the spec) |
+
+## Bootstrap wiring
+
+Two additions to `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php`:
+
+- One `$loader->add_action( 'wp_abilities_api_categories_init', Recovery\Category_Registrar::instance(), 'register' );` line (matching the 17 existing per-category calls).
+- Seven `new Recovery\<Class>();` lines in `register_abilities()` matching the existing per-category block pattern (e.g. `Settings` block at lines 118-124).
+
+No changes to `Main.php`, `AcrossAI_Activator.php`, or the REST-controller stack — abilities auto-register through the existing bootstrap.
+
+## Testing
+
+- PHPUnit — one test class per ability under `tests/phpunit/abilities/Recovery/`. Cover: happy path, no-paused-extensions case, unknown-slug case for unpause, `DISALLOW_FILE_MODS` blocked case, empty-debug-log case for the fatal filter.
+- Manual verification (recovery mode requires an actual fatal on a protected endpoint — can't unit-test): force a fatal in a test plugin, trigger recovery via any admin page load, then exercise the 7 abilities in order (`get-recovery-mode-status` → `list-paused-plugins` → `unpause-plugin` → `list-recent-fatal-errors`).
+
+## Rollout
+
+- Ships as v0.0.17.
+- No breaking change; no data migration; no version bumps outside version constant + README stable-tag + plugin header.
+- Optional durable memory capture: append `DEC-RECOVERY-MODE-EXPOSURE` to `docs/memory/DECISIONS.md` recording (a) "trigger recovery mode" is intentionally not exposed because WP core has no public API, and (b) "exit" is exposed only as a URL, not as a direct action, because of nonce+cookie constraints.
+
+## References
+
+- WP core `wp-includes/error-protection.php` — public accessor functions (`wp_recovery_mode`, `wp_paused_plugins`, `wp_paused_themes`, `wp_is_recovery_mode`, `wp_is_fatal_error_handler_enabled`).
+- WP core `wp-includes/class-wp-recovery-mode.php` — main `WP_Recovery_Mode` class.
+- WP core `wp-includes/class-wp-paused-extensions-storage.php` — `WP_Paused_Extensions_Storage` (methods: `set`, `delete`, `get`, `get_all`, `delete_all`).
+- WP core `wp-admin/includes/update.php:1019` — `wp_recovery_mode_nag()` (reference for the exit-URL construction).
+- WP core `wp-admin/includes/plugin.php:2555` — `paused_plugins_notice()` (reference for the admin-side capability check pattern).
+- Approved plan for this feature: `~/.claude/plans/can-you-check-the-synchronous-pixel.md`.

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -83,6 +83,8 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		// Feature 055 — two new categories.
 		$loader->add_action( 'wp_abilities_api_categories_init', AdminMenu\Category_Registrar::instance(), 'register' );
 		$loader->add_action( 'wp_abilities_api_categories_init', ContentSearch\Category_Registrar::instance(), 'register' );
+		// Feature 059 — Recovery Mode / fatal-error abilities.
+		$loader->add_action( 'wp_abilities_api_categories_init', Recovery\Category_Registrar::instance(), 'register' );
 	}
 
 	/**
@@ -327,6 +329,15 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new ContentSearch\Review_Internal_Link_Suggestion();
 		new ContentSearch\Apply_Internal_Link_Suggestion();
 		new ContentSearch\Audit_Internal_Links();
+
+		// Feature 059 — Recovery Mode / fatal-error abilities.
+		new Recovery\Get_Recovery_Mode_Status();
+		new Recovery\List_Paused_Plugins();
+		new Recovery\List_Paused_Themes();
+		new Recovery\Get_Recovery_Exit_Url();
+		new Recovery\Unpause_Plugin();
+		new Recovery\Unpause_Theme();
+		new Recovery\List_Recent_Fatal_Errors();
 
 		// Feature 055 — register the option-backed lifecycle event log.
 		Utilities\Lifecycle_Event_Log::register_hooks();

--- a/includes/Abilities/Plugins/Activate_Plugin.php
+++ b/includes/Abilities/Plugins/Activate_Plugin.php
@@ -30,7 +30,7 @@ class Activate_Plugin extends Ability_Definition {
 			'name' => 'acrossai/activate-plugin',
 			'args' => array(
 				'label'               => __( 'Activate Plugin', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Activate an installed WordPress plugin by name, slug, or partial match.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Activate an installed WordPress plugin by name, slug, or partial match. Works in recovery mode; only updates the active-plugins option and does not load the plugin file.', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-plugins',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {

--- a/includes/Abilities/Plugins/Deactivate_Plugin.php
+++ b/includes/Abilities/Plugins/Deactivate_Plugin.php
@@ -30,7 +30,7 @@ class Deactivate_Plugin extends Ability_Definition {
 			'name' => 'acrossai/deactivate-plugin',
 			'args' => array(
 				'label'               => __( 'Deactivate Plugin', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Deactivate an active WordPress plugin by name, slug, or partial match.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Deactivate an active WordPress plugin by name, slug, or partial match. Works in recovery mode; only updates the active-plugins option and does not load the plugin file.', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-plugins',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {

--- a/includes/Abilities/Recovery/Category_Registrar.php
+++ b/includes/Abilities/Recovery/Category_Registrar.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Feature 059 — Recovery Mode abilities category.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Recovery
+ * @since      0.0.17
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Recovery;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the WP ability category used by all Recovery Mode abilities.
+ */
+final class Category_Registrar {
+
+	/** @var self|null */
+	protected static $instance = null;
+
+	/**
+	 * Private constructor — access via instance().
+	 */
+	private function __construct() {}
+
+	/**
+	 * Return the singleton instance.
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Register the ability category with the WP Abilities API.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		wp_register_ability_category(
+			'acrossai-abilities-manager-recovery',
+			array(
+				'label'       => __( 'Acrossai Abilities Manager — Recovery Mode', 'acrossai-abilities-manager' ),
+				'description' => __( 'Abilities for operating the site around WordPress Recovery Mode: detect if recovery is active, list paused (fatally-erroring) plugins and themes, clear paused entries so WP retries loading them, get the admin-clickable exit URL, and filter recent fatal errors from debug.log.', 'acrossai-abilities-manager' ),
+			)
+		);
+	}
+}

--- a/includes/Abilities/Recovery/Get_Recovery_Exit_Url.php
+++ b/includes/Abilities/Recovery/Get_Recovery_Exit_Url.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Feature 059 — Get recovery-mode exit URL ability.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Recovery
+ * @since      0.0.17
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Recovery;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use WP_Recovery_Mode;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Returns the admin-clickable URL that exits WordPress Recovery Mode when
+ * followed inside an active recovery session. Cannot programmatically exit —
+ * WP core guards the exit action with both a cookie (from the recovery-mode
+ * entry link) and a nonce; a normal admin REST call can't satisfy those.
+ * This ability returns the URL so an admin (or an agent driving a browser)
+ * can follow it.
+ */
+class Get_Recovery_Exit_Url extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/get-recovery-exit-url',
+			'args' => array(
+				'label'               => __( 'Get Recovery Mode Exit URL', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Returns the admin-clickable URL that exits WordPress Recovery Mode when followed inside an active recovery session. WP core does not expose a programmatic exit API (the action is cookie- and nonce-guarded); this ability returns the URL so an admin — or an agent driving a browser — can follow it. Returns null when the site is not in recovery mode.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-recovery',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'          => array( 'type' => 'boolean' ),
+						'in_recovery_mode' => array( 'type' => 'boolean' ),
+						'exit_url'         => array( 'type' => array( 'string', 'null' ) ),
+						'note'             => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success', 'in_recovery_mode', 'exit_url', 'note' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'recovery',
+						'sub_group_label' => __( 'Recovery Mode', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$in_recovery = function_exists( 'wp_is_recovery_mode' ) && wp_is_recovery_mode();
+
+		if ( ! $in_recovery ) {
+			return array(
+				'success'          => true,
+				'in_recovery_mode' => false,
+				'exit_url'         => null,
+				'note'             => __( 'The site is not currently in recovery mode. Exit URL is only meaningful during an active recovery session.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$action  = class_exists( 'WP_Recovery_Mode' ) ? WP_Recovery_Mode::EXIT_ACTION : 'exit_recovery_mode';
+		$url     = wp_nonce_url(
+			add_query_arg( 'action', $action, admin_url() ),
+			$action
+		);
+
+		return array(
+			'success'          => true,
+			'in_recovery_mode' => true,
+			'exit_url'         => (string) $url,
+			'note'             => __( 'Follow this URL in a browser that carries the recovery-mode cookie (typically the browser that entered recovery mode) to exit. Cannot be POSTed programmatically.', 'acrossai-abilities-manager' ),
+		);
+	}
+}

--- a/includes/Abilities/Recovery/Get_Recovery_Mode_Status.php
+++ b/includes/Abilities/Recovery/Get_Recovery_Mode_Status.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Feature 059 — Recovery Mode status ability.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Recovery
+ * @since      0.0.17
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Recovery;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Reports whether the site is currently in WordPress Recovery Mode and
+ * summarises paused-extension counts and the fatal-error-handler state.
+ */
+class Get_Recovery_Mode_Status extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/get-recovery-mode-status',
+			'args' => array(
+				'label'               => __( 'Get Recovery Mode Status', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Detects whether the site is currently in WordPress Recovery Mode (active only when a fatal error has been captured on a protected endpoint) and returns summary counters: paused-plugin count, paused-theme count, and whether the WP fatal-error handler is enabled.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-recovery',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'               => array( 'type' => 'boolean' ),
+						'in_recovery_mode'      => array( 'type' => 'boolean' ),
+						'paused_plugin_count'   => array( 'type' => 'integer' ),
+						'paused_theme_count'    => array( 'type' => 'integer' ),
+						'fatal_handler_enabled' => array( 'type' => 'boolean' ),
+					),
+					'required'             => array( 'success', 'in_recovery_mode', 'paused_plugin_count', 'paused_theme_count', 'fatal_handler_enabled' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'recovery',
+						'sub_group_label' => __( 'Recovery Mode', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$paused_plugins = function_exists( 'wp_paused_plugins' ) ? wp_paused_plugins()->get_all() : array();
+		$paused_themes  = function_exists( 'wp_paused_themes' ) ? wp_paused_themes()->get_all() : array();
+
+		return array(
+			'success'               => true,
+			'in_recovery_mode'      => function_exists( 'wp_is_recovery_mode' ) ? (bool) wp_is_recovery_mode() : false,
+			'paused_plugin_count'   => count( $paused_plugins ),
+			'paused_theme_count'    => count( $paused_themes ),
+			'fatal_handler_enabled' => function_exists( 'wp_is_fatal_error_handler_enabled' ) ? (bool) wp_is_fatal_error_handler_enabled() : false,
+		);
+	}
+}

--- a/includes/Abilities/Recovery/List_Paused_Plugins.php
+++ b/includes/Abilities/Recovery/List_Paused_Plugins.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Feature 059 — List paused plugins ability.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Recovery
+ * @since      0.0.17
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Recovery;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enumerates every plugin WordPress has paused after a fatal error, together
+ * with the captured error details (type / file / line / message).
+ */
+class List_Paused_Plugins extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/list-paused-plugins',
+			'args' => array(
+				'label'               => __( 'List Paused Plugins', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Returns every plugin WordPress has paused after a fatal error, with the captured error details (type, file, line, message). Returns an empty array when no plugins are paused.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-recovery',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'count'   => array( 'type' => 'integer' ),
+						'paused'  => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'plugin_file' => array( 'type' => 'string' ),
+									'plugin_name' => array( 'type' => 'string' ),
+									'error'       => array(
+										'type'       => 'object',
+										'properties' => array(
+											'type'    => array( 'type' => 'integer' ),
+											'file'    => array( 'type' => 'string' ),
+											'line'    => array( 'type' => 'integer' ),
+											'message' => array( 'type' => 'string' ),
+										),
+									),
+								),
+							),
+						),
+					),
+					'required'             => array( 'success', 'count', 'paused' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'recovery',
+						'sub_group_label' => __( 'Recovery Mode', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		if ( ! function_exists( 'wp_paused_plugins' ) ) {
+			return array( 'success' => true, 'count' => 0, 'paused' => array() );
+		}
+
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$all_plugins = get_plugins();
+		$paused      = wp_paused_plugins()->get_all();
+		$out         = array();
+
+		foreach ( $paused as $plugin_file => $error ) {
+			$name = isset( $all_plugins[ $plugin_file ]['Name'] ) ? (string) $all_plugins[ $plugin_file ]['Name'] : (string) $plugin_file;
+			$out[] = array(
+				'plugin_file' => (string) $plugin_file,
+				'plugin_name' => $name,
+				'error'       => array(
+					'type'    => isset( $error['type'] ) ? (int) $error['type'] : 0,
+					'file'    => isset( $error['file'] ) ? (string) $error['file'] : '',
+					'line'    => isset( $error['line'] ) ? (int) $error['line'] : 0,
+					'message' => isset( $error['message'] ) ? (string) $error['message'] : '',
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'count'   => count( $out ),
+			'paused'  => $out,
+		);
+	}
+}

--- a/includes/Abilities/Recovery/List_Paused_Themes.php
+++ b/includes/Abilities/Recovery/List_Paused_Themes.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Feature 059 — List paused themes ability.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Recovery
+ * @since      0.0.17
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Recovery;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enumerates every theme WordPress has paused after a fatal error, together
+ * with the captured error details (type / file / line / message).
+ */
+class List_Paused_Themes extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/list-paused-themes',
+			'args' => array(
+				'label'               => __( 'List Paused Themes', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Returns every theme WordPress has paused after a fatal error, with the captured error details (type, file, line, message). Returns an empty array when no themes are paused.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-recovery',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'count'   => array( 'type' => 'integer' ),
+						'paused'  => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'stylesheet' => array( 'type' => 'string' ),
+									'theme_name' => array( 'type' => 'string' ),
+									'error'      => array(
+										'type'       => 'object',
+										'properties' => array(
+											'type'    => array( 'type' => 'integer' ),
+											'file'    => array( 'type' => 'string' ),
+											'line'    => array( 'type' => 'integer' ),
+											'message' => array( 'type' => 'string' ),
+										),
+									),
+								),
+							),
+						),
+					),
+					'required'             => array( 'success', 'count', 'paused' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'recovery',
+						'sub_group_label' => __( 'Recovery Mode', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		if ( ! function_exists( 'wp_paused_themes' ) ) {
+			return array( 'success' => true, 'count' => 0, 'paused' => array() );
+		}
+
+		$paused = wp_paused_themes()->get_all();
+		$out    = array();
+
+		foreach ( $paused as $stylesheet => $error ) {
+			$theme = function_exists( 'wp_get_theme' ) ? wp_get_theme( $stylesheet ) : null;
+			$name  = ( $theme && $theme->exists() ) ? (string) $theme->get( 'Name' ) : (string) $stylesheet;
+
+			$out[] = array(
+				'stylesheet' => (string) $stylesheet,
+				'theme_name' => $name,
+				'error'      => array(
+					'type'    => isset( $error['type'] ) ? (int) $error['type'] : 0,
+					'file'    => isset( $error['file'] ) ? (string) $error['file'] : '',
+					'line'    => isset( $error['line'] ) ? (int) $error['line'] : 0,
+					'message' => isset( $error['message'] ) ? (string) $error['message'] : '',
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'count'   => count( $out ),
+			'paused'  => $out,
+		);
+	}
+}

--- a/includes/Abilities/Recovery/List_Recent_Fatal_Errors.php
+++ b/includes/Abilities/Recovery/List_Recent_Fatal_Errors.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Feature 059 — List recent fatal errors ability.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Recovery
+ * @since      0.0.17
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Recovery;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Streams `debug.log` line-by-line, extracts PHP Fatal / Parse / Compile error
+ * entries emitted within the last N days, groups by unique signature
+ * (type + file + line + message), and returns the top-M groups sorted by
+ * most-recent occurrence. Unlike `read-debug-log`, which returns the raw log,
+ * this ability targets the fatal-error signal specifically for triage.
+ */
+class List_Recent_Fatal_Errors extends Ability_Definition {
+
+	/**
+	 * PHP error-line regex.
+	 *
+	 * Matches lines like:
+	 *   [24-Jul-2026 09:15:03 UTC] PHP Fatal error:  Uncaught Error: ... in /path/to/file.php:42
+	 *   [24-Jul-2026 09:15:03 UTC] PHP Parse error:  syntax error, ... in /path/to/file.php on line 42
+	 */
+	private const ERROR_LINE_REGEX = '/^\[(?<ts>[^\]]+)\]\s+PHP\s+(?<type>Fatal|Parse|Compile)\s+error:\s+(?<message>.*?)(?:\s+in\s+(?<file>[^\s]+?)(?::(?<line_after_colon>\d+)|(?:\s+on\s+line\s+(?<line_after_on>\d+)))?)?$/i';
+
+	/**
+	 * Maximum bytes to scan from the tail of debug.log. Guards against
+	 * runaway logs (multi-GB) from consuming the request.
+	 */
+	private const MAX_SCAN_BYTES = 20 * 1024 * 1024;
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/list-recent-fatal-errors',
+			'args' => array(
+				'label'               => __( 'List Recent Fatal Errors', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Extracts PHP Fatal / Parse / Compile error entries from debug.log within the last N days, groups them by unique signature (type + file + line + message), and returns the top-M groups sorted by most-recent occurrence. Streams the log from disk with a 20 MB tail cap to guard against runaway logs.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-recovery',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'since_days' => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'maximum'     => 90,
+							'default'     => 7,
+							'description' => __( 'Only include errors logged within the last N days.', 'acrossai-abilities-manager' ),
+						),
+						'limit'      => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'maximum'     => 200,
+							'default'     => 20,
+							'description' => __( 'Maximum number of grouped errors to return.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'errors'  => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'first_seen' => array( 'type' => 'string' ),
+									'last_seen'  => array( 'type' => 'string' ),
+									'count'      => array( 'type' => 'integer' ),
+									'type'       => array( 'type' => 'string' ),
+									'message'    => array( 'type' => 'string' ),
+									'file'       => array( 'type' => 'string' ),
+									'line'       => array( 'type' => 'integer' ),
+								),
+							),
+						),
+						'scanned_bytes' => array( 'type' => 'integer' ),
+						'truncated'     => array( 'type' => 'boolean' ),
+						'message'       => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'recovery',
+						'sub_group_label' => __( 'Recovery Mode', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$log_path = WP_CONTENT_DIR . '/debug.log';
+
+		if ( ! is_file( $log_path ) ) {
+			$logging_on = ( defined( 'WP_DEBUG_LOG' ) && \WP_DEBUG_LOG ) && ( defined( 'WP_DEBUG' ) && \WP_DEBUG );
+			$reason     = $logging_on
+				? __( 'No entries have been written yet.', 'acrossai-abilities-manager' )
+				: __( 'WP_DEBUG and/or WP_DEBUG_LOG are not enabled in wp-config.php, so nothing is being written.', 'acrossai-abilities-manager' );
+			return array(
+				'success' => true,
+				'errors'  => array(),
+				/* translators: %s: reason the log file is missing */
+				'message' => sprintf( __( 'debug.log does not exist. %s', 'acrossai-abilities-manager' ), $reason ),
+			);
+		}
+
+		$since_days = isset( $input['since_days'] ) ? max( 1, min( 90, (int) $input['since_days'] ) ) : 7;
+		$limit      = isset( $input['limit'] ) ? max( 1, min( 200, (int) $input['limit'] ) ) : 20;
+		$cutoff_ts  = time() - ( $since_days * DAY_IN_SECONDS );
+
+		$file_size = filesize( $log_path );
+		if ( false === $file_size ) {
+			return array(
+				'success' => false,
+				'errors'  => array(),
+				'message' => __( 'Could not stat debug.log.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$truncated  = $file_size > self::MAX_SCAN_BYTES;
+		$seek_start = $truncated ? ( $file_size - self::MAX_SCAN_BYTES ) : 0;
+
+		$fh = fopen( $log_path, 'r' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		if ( false === $fh ) {
+			return array(
+				'success' => false,
+				'errors'  => array(),
+				'message' => __( 'Could not open debug.log.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( $seek_start > 0 ) {
+			fseek( $fh, $seek_start );
+			fgets( $fh ); // discard likely-truncated first line
+		}
+
+		$groups = array();
+
+		while ( ! feof( $fh ) ) {
+			$line = fgets( $fh );
+			if ( false === $line ) {
+				break;
+			}
+
+			if ( ! preg_match( self::ERROR_LINE_REGEX, rtrim( $line ), $m ) ) {
+				continue;
+			}
+
+			$ts = strtotime( $m['ts'] );
+			if ( false === $ts || $ts < $cutoff_ts ) {
+				continue;
+			}
+
+			$type    = ucfirst( strtolower( $m['type'] ) ) . ' Error';
+			$file    = isset( $m['file'] ) ? $m['file'] : '';
+			$line_no = 0;
+			if ( ! empty( $m['line_after_colon'] ) ) {
+				$line_no = (int) $m['line_after_colon'];
+			} elseif ( ! empty( $m['line_after_on'] ) ) {
+				$line_no = (int) $m['line_after_on'];
+			}
+			$message = trim( $m['message'] );
+
+			$sig = md5( $type . '|' . $file . '|' . $line_no . '|' . $message );
+			$iso = gmdate( 'c', $ts );
+
+			if ( ! isset( $groups[ $sig ] ) ) {
+				$groups[ $sig ] = array(
+					'first_seen' => $iso,
+					'last_seen'  => $iso,
+					'count'      => 0,
+					'type'       => $type,
+					'message'    => $message,
+					'file'       => $file,
+					'line'       => $line_no,
+				);
+			}
+			$groups[ $sig ]['last_seen'] = $iso;
+			++$groups[ $sig ]['count'];
+		}
+
+		fclose( $fh );
+
+		usort( $groups, static function ( array $a, array $b ): int {
+			return strcmp( $b['last_seen'], $a['last_seen'] );
+		} );
+
+		$groups = array_slice( $groups, 0, $limit );
+
+		return array(
+			'success'       => true,
+			'errors'        => array_values( $groups ),
+			'scanned_bytes' => (int) ( $file_size - $seek_start ),
+			'truncated'     => $truncated,
+			'message'       => $truncated
+				? sprintf(
+					/* translators: %d: number of bytes scanned */
+					__( 'debug.log exceeds %d bytes; scanned only the tail.', 'acrossai-abilities-manager' ),
+					self::MAX_SCAN_BYTES
+				)
+				: '',
+		);
+	}
+}

--- a/includes/Abilities/Recovery/Unpause_Plugin.php
+++ b/includes/Abilities/Recovery/Unpause_Plugin.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Feature 059 — Unpause plugin ability.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Recovery
+ * @since      0.0.17
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Recovery;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Plugin_Helpers;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Clears a plugin's paused-storage entry so WordPress retries loading it on
+ * the next request. Distinct from `deactivate-plugin`: this does NOT change
+ * the `active_plugins` option. If the plugin still fatally errors on retry,
+ * WP re-pauses it.
+ */
+class Unpause_Plugin extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/unpause-plugin',
+			'args' => array(
+				'label'               => __( 'Unpause Plugin', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Clears the paused-storage entry for a plugin so WordPress retries loading it on the next request. Distinct from deactivate-plugin (which flips the active_plugins option); this ability leaves the active/inactive state alone. If the plugin still fatally errors when WP retries, it will be re-paused. Accepts a fuzzy plugin identifier (name, slug, or partial); when uncertain, returns a candidates list rather than acting.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-recovery',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'slug' => array(
+							'type'        => 'string',
+							'description' => __( 'Plugin identifier: full plugin file (e.g. "hello-dolly/hello.php"), directory slug, or plugin name. Fuzzy-matched via Plugin_Helpers::resolve_plugin().', 'acrossai-abilities-manager' ),
+						),
+					),
+					'required'             => array( 'slug' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'                 => array( 'type' => 'boolean' ),
+						'unpaused'                => array( 'type' => 'boolean' ),
+						'plugin_file'             => array( 'type' => array( 'string', 'null' ) ),
+						'plugin_name'             => array( 'type' => array( 'string', 'null' ) ),
+						'was_paused'              => array( 'type' => 'boolean' ),
+						'remaining_paused_count'  => array( 'type' => 'integer' ),
+						'candidates'              => array( 'type' => 'array' ),
+						'message'                 => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'recovery',
+						'sub_group_label' => __( 'Recovery Mode', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response();
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		if ( ! function_exists( 'wp_paused_plugins' ) ) {
+			return array(
+				'success'  => false,
+				'unpaused' => false,
+				'message'  => __( 'WordPress paused-extensions storage is not available in this environment.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$identifier = isset( $input['slug'] ) ? (string) $input['slug'] : '';
+		if ( '' === trim( $identifier ) ) {
+			return array(
+				'success'  => false,
+				'unpaused' => false,
+				'message'  => __( 'Plugin identifier is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$resolved = Plugin_Helpers::resolve_plugin( $identifier );
+		if ( null === $resolved['plugin_file'] || $resolved['certainty'] < 8.0 ) {
+			return array(
+				'success'    => false,
+				'unpaused'   => false,
+				'candidates' => $resolved['candidates'],
+				'message'    => __( 'Ambiguous plugin identifier — pass a more specific slug or the full plugin_file value.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$paused_storage = wp_paused_plugins();
+		$all_paused     = $paused_storage->get_all();
+		$was_paused     = array_key_exists( $resolved['plugin_file'], $all_paused );
+
+		if ( $was_paused ) {
+			$paused_storage->delete( $resolved['plugin_file'] );
+		}
+
+		$remaining = $paused_storage->get_all();
+
+		return array(
+			'success'                => true,
+			'unpaused'               => $was_paused,
+			'plugin_file'            => $resolved['plugin_file'],
+			'plugin_name'            => $resolved['plugin_name'],
+			'was_paused'             => $was_paused,
+			'remaining_paused_count' => count( $remaining ),
+			'message'                => $was_paused
+				? __( 'Paused entry cleared. WordPress will retry loading the plugin on the next request.', 'acrossai-abilities-manager' )
+				: __( 'Plugin was not paused; nothing to do.', 'acrossai-abilities-manager' ),
+		);
+	}
+}

--- a/includes/Abilities/Recovery/Unpause_Theme.php
+++ b/includes/Abilities/Recovery/Unpause_Theme.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Feature 059 — Unpause theme ability.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Recovery
+ * @since      0.0.17
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Recovery;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Theme_Helpers;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Clears a theme's paused-storage entry so WordPress retries loading it on
+ * the next request. If the theme still fatally errors on retry, WP re-pauses
+ * it and falls back to the default theme.
+ */
+class Unpause_Theme extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/unpause-theme',
+			'args' => array(
+				'label'               => __( 'Unpause Theme', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Clears the paused-storage entry for a theme so WordPress retries loading it on the next request. If the theme still fatally errors when WP retries, it will be re-paused and WP falls back to the default theme. Accepts a fuzzy theme identifier (name, stylesheet, or partial); when uncertain, returns a candidates list rather than acting.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-recovery',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'slug' => array(
+							'type'        => 'string',
+							'description' => __( 'Theme identifier: stylesheet (directory slug) or theme name. Fuzzy-matched via Theme_Helpers::resolve_theme().', 'acrossai-abilities-manager' ),
+						),
+					),
+					'required'             => array( 'slug' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'                 => array( 'type' => 'boolean' ),
+						'unpaused'                => array( 'type' => 'boolean' ),
+						'stylesheet'              => array( 'type' => array( 'string', 'null' ) ),
+						'theme_name'              => array( 'type' => array( 'string', 'null' ) ),
+						'was_paused'              => array( 'type' => 'boolean' ),
+						'remaining_paused_count'  => array( 'type' => 'integer' ),
+						'candidates'              => array( 'type' => 'array' ),
+						'message'                 => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'recovery',
+						'sub_group_label' => __( 'Recovery Mode', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response();
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		if ( ! function_exists( 'wp_paused_themes' ) ) {
+			return array(
+				'success'  => false,
+				'unpaused' => false,
+				'message'  => __( 'WordPress paused-extensions storage is not available in this environment.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$identifier = isset( $input['slug'] ) ? (string) $input['slug'] : '';
+		if ( '' === trim( $identifier ) ) {
+			return array(
+				'success'  => false,
+				'unpaused' => false,
+				'message'  => __( 'Theme identifier is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$resolved = Theme_Helpers::resolve_theme( $identifier );
+		if ( null === $resolved['stylesheet'] || $resolved['certainty'] < 8.0 ) {
+			return array(
+				'success'    => false,
+				'unpaused'   => false,
+				'candidates' => $resolved['candidates'],
+				'message'    => __( 'Ambiguous theme identifier — pass a more specific stylesheet or theme name.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$paused_storage = wp_paused_themes();
+		$all_paused     = $paused_storage->get_all();
+		$was_paused     = array_key_exists( $resolved['stylesheet'], $all_paused );
+
+		if ( $was_paused ) {
+			$paused_storage->delete( $resolved['stylesheet'] );
+		}
+
+		$remaining = $paused_storage->get_all();
+
+		return array(
+			'success'                => true,
+			'unpaused'               => $was_paused,
+			'stylesheet'             => $resolved['stylesheet'],
+			'theme_name'             => $resolved['theme_name'],
+			'was_paused'             => $was_paused,
+			'remaining_paused_count' => count( $remaining ),
+			'message'                => $was_paused
+				? __( 'Paused entry cleared. WordPress will retry loading the theme on the next request.', 'acrossai-abilities-manager' )
+				: __( 'Theme was not paused; nothing to do.', 'acrossai-abilities-manager' ),
+		);
+	}
+}

--- a/includes/Abilities/Themes/Activate_Theme.php
+++ b/includes/Abilities/Themes/Activate_Theme.php
@@ -30,7 +30,7 @@ class Activate_Theme extends Ability_Definition {
 			'name' => 'acrossai/activate-theme',
 			'args' => array(
 				'label'               => __( 'Activate Theme', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Activate an installed WordPress theme by name, stylesheet, or partial match.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Activate an installed WordPress theme by name, stylesheet, or partial match. Works in recovery mode; only updates the active-theme option and does not load the theme file. Note: WordPress does not have a separate "deactivate-theme" ability — switching to a different theme via this ability is the way to remove an active theme.', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-themes',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.16' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.17' );
 	}
 
 	/**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -50,6 +50,9 @@
 		<testsuite name="feature-057-unit">
 			<file>tests/phpunit/abilities/Test_Feature_057_Core_Reinstall.php</file>
 		</testsuite>
+		<testsuite name="feature-059-unit">
+			<file>tests/phpunit/abilities/Test_Feature_059_Recovery_Mode.php</file>
+		</testsuite>
 	</testsuites>
 	<source>
 		<include>

--- a/tests/phpunit/abilities/Test_Feature_059_Recovery_Mode.php
+++ b/tests/phpunit/abilities/Test_Feature_059_Recovery_Mode.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Structural tests for the Feature 059 Recovery Mode abilities.
+ *
+ * Covers all 7 new abilities under includes/Abilities/Recovery/:
+ *   - Get_Recovery_Mode_Status
+ *   - List_Paused_Plugins
+ *   - List_Paused_Themes
+ *   - Get_Recovery_Exit_Url
+ *   - Unpause_Plugin
+ *   - Unpause_Theme
+ *   - List_Recent_Fatal_Errors
+ * Plus: Category_Registrar and Bootstrap wiring.
+ *
+ * Source-inspection only, mirroring Test_Feature_057_Core_Reinstall — the
+ * suite's established pattern for absorbed-tier abilities (fixture-free).
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.17
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Feature_059_Recovery_Mode.
+ */
+class Test_Feature_059_Recovery_Mode extends WP_UnitTestCase {
+
+	/**
+	 * Absolute paths to every source file exercised by these tests.
+	 *
+	 * @var array<string,string>
+	 */
+	private array $sources = array();
+
+	/**
+	 * Load every source file once per test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root   = dirname( __DIR__, 3 );
+		$this->sources = array(
+			'category_registrar'      => (string) file_get_contents( $plugin_root . '/includes/Abilities/Recovery/Category_Registrar.php' ),
+			'get_status'              => (string) file_get_contents( $plugin_root . '/includes/Abilities/Recovery/Get_Recovery_Mode_Status.php' ),
+			'list_paused_plugins'     => (string) file_get_contents( $plugin_root . '/includes/Abilities/Recovery/List_Paused_Plugins.php' ),
+			'list_paused_themes'      => (string) file_get_contents( $plugin_root . '/includes/Abilities/Recovery/List_Paused_Themes.php' ),
+			'get_exit_url'            => (string) file_get_contents( $plugin_root . '/includes/Abilities/Recovery/Get_Recovery_Exit_Url.php' ),
+			'unpause_plugin'          => (string) file_get_contents( $plugin_root . '/includes/Abilities/Recovery/Unpause_Plugin.php' ),
+			'unpause_theme'           => (string) file_get_contents( $plugin_root . '/includes/Abilities/Recovery/Unpause_Theme.php' ),
+			'list_recent_fatal'       => (string) file_get_contents( $plugin_root . '/includes/Abilities/Recovery/List_Recent_Fatal_Errors.php' ),
+			'bootstrap'               => (string) file_get_contents( $plugin_root . '/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php' ),
+			'activate_plugin'         => (string) file_get_contents( $plugin_root . '/includes/Abilities/Plugins/Activate_Plugin.php' ),
+			'deactivate_plugin'       => (string) file_get_contents( $plugin_root . '/includes/Abilities/Plugins/Deactivate_Plugin.php' ),
+			'activate_theme'          => (string) file_get_contents( $plugin_root . '/includes/Abilities/Themes/Activate_Theme.php' ),
+		);
+	}
+
+	// =========================================================================
+	// Category_Registrar
+	// =========================================================================
+
+	public function test_category_registrar_uses_recovery_category_slug(): void {
+		$src = $this->sources['category_registrar'];
+		$this->assertStringContainsString(
+			"'acrossai-abilities-manager-recovery'",
+			$src,
+			'Recovery category slug must be acrossai-abilities-manager-recovery.'
+		);
+		$this->assertStringContainsString( 'wp_register_ability_category', $src );
+		$this->assertStringContainsString( 'final class Category_Registrar', $src );
+		$this->assertStringContainsString( 'public static function instance(): self', $src );
+	}
+
+	// =========================================================================
+	// Common scaffolding across every ability
+	// =========================================================================
+
+	/**
+	 * Data provider for per-ability slug + expected annotations.
+	 *
+	 * @return array<string,array{string,string,bool,bool,bool}>
+	 */
+	public static function ability_provider(): array {
+		return array(
+			//                        source-key,             slug,                                    readonly, destructive, idempotent
+			'get_status'          => array( 'get_status',          'acrossai/get-recovery-mode-status',   true,  false, true ),
+			'list_paused_plugins' => array( 'list_paused_plugins', 'acrossai/list-paused-plugins',        true,  false, true ),
+			'list_paused_themes'  => array( 'list_paused_themes',  'acrossai/list-paused-themes',         true,  false, true ),
+			'get_exit_url'        => array( 'get_exit_url',        'acrossai/get-recovery-exit-url',      true,  false, true ),
+			'unpause_plugin'      => array( 'unpause_plugin',      'acrossai/unpause-plugin',             false, true,  true ),
+			'unpause_theme'       => array( 'unpause_theme',       'acrossai/unpause-theme',              false, true,  true ),
+			'list_recent_fatal'   => array( 'list_recent_fatal',   'acrossai/list-recent-fatal-errors',   true,  false, true ),
+		);
+	}
+
+	/**
+	 * @dataProvider ability_provider
+	 */
+	public function test_ability_has_correct_slug_category_and_scaffolding(
+		string $src_key,
+		string $expected_slug,
+		bool $readonly,
+		bool $destructive,
+		bool $idempotent
+	): void {
+		$src = $this->sources[ $src_key ];
+
+		$this->assertStringContainsString( 'extends Ability_Definition', $src, "$src_key must extend Ability_Definition" );
+		$this->assertStringContainsString( "'{$expected_slug}'", $src, "$src_key must register slug $expected_slug" );
+		$this->assertStringContainsString(
+			"'acrossai-abilities-manager-recovery'",
+			$src,
+			"$src_key must point at the Recovery category slug"
+		);
+		$this->assertStringContainsString(
+			"current_user_can( 'manage_options' )",
+			$src,
+			"$src_key permission_callback must gate on manage_options"
+		);
+
+		// Annotations: readonly / destructive / idempotent booleans.
+		$this->assertStringContainsString(
+			"'readonly'    => " . ( $readonly ? 'true' : 'false' ),
+			$src,
+			"$src_key annotation 'readonly' must be " . var_export( $readonly, true )
+		);
+		$this->assertStringContainsString(
+			"'destructive' => " . ( $destructive ? 'true' : 'false' ),
+			$src,
+			"$src_key annotation 'destructive' must be " . var_export( $destructive, true )
+		);
+		$this->assertStringContainsString(
+			"'idempotent'  => " . ( $idempotent ? 'true' : 'false' ),
+			$src,
+			"$src_key annotation 'idempotent' must be " . var_export( $idempotent, true )
+		);
+
+		// meta.acrossai sub_group.
+		$this->assertStringContainsString(
+			"'sub_group'       => 'recovery'",
+			$src,
+			"$src_key meta.acrossai.sub_group must be 'recovery'"
+		);
+	}
+
+	// =========================================================================
+	// Write-action guards
+	// =========================================================================
+
+	public function test_unpause_plugin_uses_file_mods_guard_and_plugin_helpers(): void {
+		$src = $this->sources['unpause_plugin'];
+		$this->assertStringContainsString( 'File_Mods_Guard::blocked_response', $src );
+		$this->assertStringContainsString( 'Plugin_Helpers::resolve_plugin', $src );
+		$this->assertStringContainsString( 'wp_paused_plugins()', $src );
+		$this->assertStringContainsString( '->delete(', $src, 'Unpause_Plugin must call delete() on the paused-extensions storage' );
+	}
+
+	public function test_unpause_theme_uses_file_mods_guard_and_theme_helpers(): void {
+		$src = $this->sources['unpause_theme'];
+		$this->assertStringContainsString( 'File_Mods_Guard::blocked_response', $src );
+		$this->assertStringContainsString( 'Theme_Helpers::resolve_theme', $src );
+		$this->assertStringContainsString( 'wp_paused_themes()', $src );
+		$this->assertStringContainsString( '->delete(', $src, 'Unpause_Theme must call delete() on the paused-extensions storage' );
+	}
+
+	// =========================================================================
+	// Read-side call sites
+	// =========================================================================
+
+	public function test_get_status_calls_wp_is_recovery_mode(): void {
+		$src = $this->sources['get_status'];
+		$this->assertStringContainsString( 'wp_is_recovery_mode', $src );
+		$this->assertStringContainsString( 'wp_paused_plugins', $src );
+		$this->assertStringContainsString( 'wp_paused_themes', $src );
+		$this->assertStringContainsString( 'wp_is_fatal_error_handler_enabled', $src );
+	}
+
+	public function test_list_paused_plugins_calls_get_all(): void {
+		$src = $this->sources['list_paused_plugins'];
+		$this->assertStringContainsString( 'wp_paused_plugins()->get_all()', $src );
+	}
+
+	public function test_list_paused_themes_calls_get_all(): void {
+		$src = $this->sources['list_paused_themes'];
+		$this->assertStringContainsString( 'wp_paused_themes()->get_all()', $src );
+	}
+
+	public function test_get_exit_url_uses_nonce_and_exit_action(): void {
+		$src = $this->sources['get_exit_url'];
+		$this->assertStringContainsString( 'wp_nonce_url', $src );
+		$this->assertStringContainsString( 'EXIT_ACTION', $src );
+		$this->assertStringContainsString( 'wp_is_recovery_mode', $src );
+	}
+
+	// =========================================================================
+	// Fatal-error log filter — safety + regex shape
+	// =========================================================================
+
+	public function test_list_recent_fatal_errors_streams_with_tail_cap(): void {
+		$src = $this->sources['list_recent_fatal'];
+		$this->assertStringContainsString( 'MAX_SCAN_BYTES', $src, 'must define a tail-scan cap' );
+		$this->assertStringContainsString( 'ERROR_LINE_REGEX', $src, 'must define an error-line regex constant' );
+		$this->assertStringContainsString( 'fopen(', $src, 'must stream the file (fopen), not slurp with file_get_contents' );
+		$this->assertStringContainsString( 'fgets(', $src, 'must read line-by-line with fgets' );
+		$this->assertStringContainsString( 'PHP Fatal error', $src, 'regex must match "PHP Fatal error" prose (present in the regex comment)' );
+	}
+
+	public function test_list_recent_fatal_errors_honors_debug_log_guard(): void {
+		$src = $this->sources['list_recent_fatal'];
+		$this->assertStringContainsString( "WP_CONTENT_DIR . '/debug.log'", $src );
+		$this->assertStringContainsString( 'WP_DEBUG_LOG', $src );
+		$this->assertStringContainsString( 'WP_DEBUG', $src );
+	}
+
+	// =========================================================================
+	// Bootstrap wiring
+	// =========================================================================
+
+	public function test_bootstrap_registers_recovery_category(): void {
+		$src = $this->sources['bootstrap'];
+		$this->assertStringContainsString(
+			'Recovery\\Category_Registrar::instance()',
+			$src,
+			'Bootstrap must register the Recovery Category_Registrar on wp_abilities_api_categories_init'
+		);
+	}
+
+	public function test_bootstrap_instantiates_all_seven_recovery_abilities(): void {
+		$src = $this->sources['bootstrap'];
+		foreach (
+			array(
+				'new Recovery\\Get_Recovery_Mode_Status()',
+				'new Recovery\\List_Paused_Plugins()',
+				'new Recovery\\List_Paused_Themes()',
+				'new Recovery\\Get_Recovery_Exit_Url()',
+				'new Recovery\\Unpause_Plugin()',
+				'new Recovery\\Unpause_Theme()',
+				'new Recovery\\List_Recent_Fatal_Errors()',
+			) as $expected
+		) {
+			$this->assertStringContainsString(
+				$expected,
+				$src,
+				"Bootstrap must instantiate $expected in register_abilities()"
+			);
+		}
+	}
+
+	// =========================================================================
+	// Description tweaks on existing plugin/theme abilities
+	// =========================================================================
+
+	public function test_activate_plugin_description_notes_recovery_compatibility(): void {
+		$src = $this->sources['activate_plugin'];
+		$this->assertStringContainsString( 'Works in recovery mode', $src );
+	}
+
+	public function test_deactivate_plugin_description_notes_recovery_compatibility(): void {
+		$src = $this->sources['deactivate_plugin'];
+		$this->assertStringContainsString( 'Works in recovery mode', $src );
+	}
+
+	public function test_activate_theme_description_notes_recovery_compatibility(): void {
+		$src = $this->sources['activate_theme'];
+		$this->assertStringContainsString( 'Works in recovery mode', $src );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds 7 new abilities under a new `Recovery` category (`includes/Abilities/Recovery/`) so an AI agent driving the site over REST/MCP can detect and act on WordPress Recovery Mode without needing an admin to notice the recovery banner in wp-admin.
- Every write action gates on `manage_options` + `File_Mods_Guard::blocked_response()`. Fuzzy identifiers flow through existing `Plugin_Helpers::resolve_plugin()` / `Theme_Helpers::resolve_theme()` resolvers.
- Ships as v0.0.17. No JS, no DB migration, no REST-controller changes — 100% new PHP under a new category, plus 7-line bootstrap wiring.

## New abilities (7)

| Slug | Purpose | Annotations |
|---|---|---|
| `acrossai/get-recovery-mode-status` | Detect recovery mode + summary counters (paused counts, fatal-handler enabled) | readonly, idempotent |
| `acrossai/list-paused-plugins` | List paused plugins + captured error details (type / file / line / message), enriched with human plugin_name | readonly, idempotent |
| `acrossai/list-paused-themes` | Symmetric for themes | readonly, idempotent |
| `acrossai/get-recovery-exit-url` | Return the admin-clickable URL that exits recovery mode (uses `wp_nonce_url() + WP_Recovery_Mode::EXIT_ACTION`) | readonly, idempotent |
| `acrossai/unpause-plugin` | Clear the paused-storage entry so WP retries loading the plugin next request (distinct from `deactivate-plugin`) | destructive, idempotent |
| `acrossai/unpause-theme` | Symmetric for themes | destructive, idempotent |
| `acrossai/list-recent-fatal-errors` | Grouped PHP Fatal/Parse/Compile errors from debug.log — streams the file with a 20 MB tail cap, groups by `md5(type\|file\|line\|message)`, sorts by last-seen desc | readonly, idempotent |

## What was intentionally NOT built

- **"Trigger recovery mode programmatically"** — WP core has NO public API. The handler only fires on real fatals at protected endpoints (admin/login/protected AJAX). Cannot be manually invoked from REST.
- **"Exit recovery mode programmatically"** — the exit action is guarded by both a session cookie (from the recovery-mode entry link) and a nonce. A normal admin REST call can't satisfy those. Replaced by the read-only `get-recovery-exit-url` ability which returns the URL an admin (or a browser-driving agent) can follow.

## Existing abilities that gained a description note (docs-only)

- `acrossai/activate-plugin`, `acrossai/deactivate-plugin`
- `acrossai/activate-theme`

Text added: *"Works in recovery mode; only updates the active-plugins / active-theme option and does not load the extension file."* No logic change — these already worked in recovery mode; the note just makes it discoverable to agents reading the `description` field.

## Files touched

| Area | Files | Notes |
|---|---|---|
| New abilities | `includes/Abilities/Recovery/` — 8 files (1 Category_Registrar + 7 abilities) | Modelled on `SiteHealth/` |
| Bootstrap wiring | `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php` | +8 lines (1 category, 7 abilities) |
| Docs-only tweaks | 3 existing ability files | one-sentence appends |
| Version bump | `acrossai-abilities-manager.php` header, `ACROSSAI_ABILITIES_MANAGER_VERSION`, `README.txt` stable-tag | 0.0.16 → 0.0.17 |
| Changelog | `README.txt` | new 0.0.17 entry |
| Tests | `tests/phpunit/abilities/Test_Feature_059_Recovery_Mode.php` + `phpunit.xml.dist` registration | 21 new tests |
| Spec-kit input | `docs/planning/059-recovery-mode.md` | Input brief ready for `/speckit-specify` (spec/plan/tasks/memory-synthesis not auto-generated per project preference) |

## Test plan

- [x] `composer test` — **191/191 PHPUnit tests pass** (170 pre-existing + 21 new)
- [x] `php -l` clean on all 12 touched/new PHP files
- [x] All 7 slug strings enumerable via `grep -rhoE "'name'\s*=>\s*'acrossai/[^']+'" includes/Abilities/Recovery/`
- [x] Bootstrap registers 1 new category + 7 new abilities (verified by grep + PHPUnit `test_bootstrap_instantiates_all_seven_recovery_abilities`)
- [ ] **Manual (no fatal state)**: `curl -u admin:PASS 'http://.../wp-json/wp-abilities/v1/abilities/acrossai/get-recovery-mode-status/run'` returns `{ in_recovery_mode: false, paused_plugin_count: 0, paused_theme_count: 0, fatal_handler_enabled: true }`
- [ ] **Manual (with real fatal)**: force a fatal in a test plugin; hit any admin page to trigger recovery; verify:
  1. `get-recovery-mode-status` reports `in_recovery_mode: true` and `paused_plugin_count: 1`
  2. `list-paused-plugins` returns the test plugin with error details
  3. `get-recovery-exit-url` returns a non-null URL
  4. `unpause-plugin { slug: 'broken-test' }` clears the entry
  5. `list-recent-fatal-errors` includes the fatal in the grouped output

## Notes for reviewers

- Category placement decision recorded in the plan: new `Recovery` category (not extending `SiteHealth` — which is read-only-reporting; and not splitting reads-in-SiteHealth-writes-in-Plugins — which would spread the feature across three dirs for reviewers). Single category, sibling to SiteHealth.
- Fuzzy resolution reuses existing utilities. When certainty < 8.0 the unpause abilities return a `candidates` list rather than acting — same pattern as `activate-plugin`.
- Fatal-log parsing uses `fopen` + `fgets` streaming with a 20 MB tail cap (`MAX_SCAN_BYTES`) to guard against runaway logs consuming the request.
- No new decisions or bug patterns captured in `docs/memory/` for this feature — nothing surprising surfaced during implementation. If you want a `DEC-RECOVERY-MODE-EXPOSURE` entry recording the "trigger not exposed, exit exposed only as URL" rationale, it's a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)