### PR TITLE
Add WPForms integration (enable-filter, write-gate only)

### DIFF
--- a/includes/Abilities/Integrations/WPForms.php
+++ b/includes/Abilities/Integrations/WPForms.php
@@ -5,31 +5,53 @@
  * WPForms exposes WP Abilities API abilities in TWO tiers:
  *
  *   - **Reads** (auto-enabled) — always available when WPForms is active; no
- *     admin gate. Includes listing forms, listing entries, reading form
- *     schemas, etc. Our integration does NOT gate reads — they pass through
+ *     admin gate. Includes listing forms, reading form schemas, and similar
+ *     queries. Our integration does NOT gate reads — they pass through
  *     transparently regardless of this integration's toggle state.
  *
- *   - **Writes** (gated) — creating, updating, and deleting forms + entries.
- *     Gated by the WPForms-provided filter
- *     `wpforms_integrations_abilities_allow_write`. Defaults to false in
- *     WPForms itself (WPForms won't register the write abilities unless the
- *     filter returns true). This integration's toggle attaches
- *     `__return_true` to that filter when ON.
+ *   - **Writes** (gated) — Add Field, Create Form, Update Field, Update Form
+ *     Settings, and similar mutations. Gated by the WPForms-provided filter
+ *     `wpforms_integrations_abilities_allow_write` (default: false).
  *
- * ## Pattern: enable-filter (like ACF, unlike Yoast)
+ * ## What the write toggle actually does (subtle)
  *
- * WPForms has a SINGLE master filter for the write tier — same shape as ACF's
- * `acf/settings/enable_acf_ai`. So this integration uses the classic
- * enable-filter model:
+ * The `wpforms_integrations_abilities_allow_write` filter DOES NOT gate
+ * registration. WPForms registers ALL 8 abilities (reads + writes)
+ * unconditionally on every request — they appear in `wp_get_abilities()` and
+ * in the Custom Abilities admin table regardless of the filter value. See
+ * `wpforms-lite/src/Integrations/Abilities/Abilities.php::write_enabled()`
+ * (line 562) for the filter reference and lines 599 + 722 for the two things
+ * the filter actually gates:
+ *
+ *   1. **`mcp.public` flag** on each write ability's `meta.mcp` block. When
+ *      the filter returns false, `mcp.public=false` and the write abilities
+ *      are HIDDEN from MCP `discover-abilities` — external MCP clients don't
+ *      see them.
+ *   2. **Execution permission** via WPForms's `check_write_gate()` inside
+ *      each write ability's `permission_callback`. When the filter returns
+ *      false, calling a write ability returns `WP_Error 403
+ *      wpforms_writes_disabled`.
+ *
+ * So: our toggle controls **MCP visibility + execution permission**, NOT
+ * registration. The Custom Abilities admin table will keep showing all 8
+ * abilities regardless — that's WPForms's design, not a bug in this
+ * integration.
+ *
+ * ## Pattern: enable-filter (like ACF)
+ *
+ * Even though the semantics differ from ACF (which gates registration
+ * itself), the mechanical shape is identical: WPForms has a single master
+ * filter for the write tier, and our integration attaches `__return_true` to
+ * it when the toggle is ON. So:
  *
  *   - `enable_filter()` attaches `wpforms_integrations_abilities_allow_write`
  *     → `__return_true` when the integration toggle is ON.
- *   - `enable_filter()` does nothing when toggle is OFF, so WPForms's default
- *     (false) applies and the write abilities stay unregistered.
+ *   - `enable_filter()` does nothing when the toggle is OFF, so WPForms's
+ *     default (false via `wpforms_setting()` unless the site admin has
+ *     already enabled writes in WPForms's own settings) applies.
  *
- * No kill-switch is needed because the write abilities never register in the
- * first place unless our filter fires. Reads are outside the gate entirely
- * and are always available while WPForms is active.
+ * No kill-switch is needed. Reads are outside the gate entirely and remain
+ * available while WPForms is active.
  *
  * ## Category / tab_group slug
  *
@@ -156,7 +178,7 @@ class WPForms extends AcrossAI_Integration_Ability_Base {
 				'slug'        => 'wpforms/writes',
 				'label'       => __( 'Write abilities (gated by this toggle)', 'acrossai-abilities-manager' ),
 				'description' => __(
-					'Mutation abilities exposed by WPForms — creating, updating, and deleting forms and entries. Gated by the WPForms filter wpforms_integrations_abilities_allow_write (default: false). Flip the toggle above ON to attach __return_true to that filter so WPForms registers the write-tier abilities on subsequent requests.',
+					'Mutation abilities exposed by WPForms — Add Field, Create Form, Update Field, Update Form Settings, and similar. Gated by the WPForms filter wpforms_integrations_abilities_allow_write. Flip the toggle above ON to attach __return_true to that filter. Effect: WPForms flips the mcp.public flag on each write ability to true (so MCP clients see them via discover-abilities) AND allows write executions (calls return WP_Error 403 wpforms_writes_disabled when the filter is false). Note: WPForms always REGISTERS these 8 abilities so they will keep appearing in the Custom Abilities admin table regardless of this toggle — the toggle affects MCP visibility and execution permission, not registration.',
 					'acrossai-abilities-manager'
 				),
 			),

--- a/includes/Abilities/Integrations/WPForms.php
+++ b/includes/Abilities/Integrations/WPForms.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * WPForms — third-party integration (Feature 060 extension).
+ *
+ * WPForms exposes WP Abilities API abilities in TWO tiers:
+ *
+ *   - **Reads** (auto-enabled) — always available when WPForms is active; no
+ *     admin gate. Includes listing forms, listing entries, reading form
+ *     schemas, etc. Our integration does NOT gate reads — they pass through
+ *     transparently regardless of this integration's toggle state.
+ *
+ *   - **Writes** (gated) — creating, updating, and deleting forms + entries.
+ *     Gated by the WPForms-provided filter
+ *     `wpforms_integrations_abilities_allow_write`. Defaults to false in
+ *     WPForms itself (WPForms won't register the write abilities unless the
+ *     filter returns true). This integration's toggle attaches
+ *     `__return_true` to that filter when ON.
+ *
+ * ## Pattern: enable-filter (like ACF, unlike Yoast)
+ *
+ * WPForms has a SINGLE master filter for the write tier — same shape as ACF's
+ * `acf/settings/enable_acf_ai`. So this integration uses the classic
+ * enable-filter model:
+ *
+ *   - `enable_filter()` attaches `wpforms_integrations_abilities_allow_write`
+ *     → `__return_true` when the integration toggle is ON.
+ *   - `enable_filter()` does nothing when toggle is OFF, so WPForms's default
+ *     (false) applies and the write abilities stay unregistered.
+ *
+ * No kill-switch is needed because the write abilities never register in the
+ * first place unless our filter fires. Reads are outside the gate entirely
+ * and are always available while WPForms is active.
+ *
+ * ## Category / tab_group slug
+ *
+ * `TAB_GROUP = 'wpforms'`. WPForms's own ability categories almost certainly
+ * live under a `wpforms/*` namespace or similar — using the plain slug
+ * `'wpforms'` for our card keeps it clean and avoids collision with WPForms's
+ * pre-registered category slugs (following the synthetic-row lifecycle rule
+ * documented in `AcrossAI_Integration_Ability_Base::push_definition()` and in
+ * `BUG-WP-CORE-ABILITY-CATEGORY-PRE-REGISTRATION`).
+ *
+ * Tab label auto-derives from the slug: `'wpforms'` → `'Wpforms'`.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage includes/Abilities/Integrations
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Integrations;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Integrations\AcrossAI_Integration_Ability_Base;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Third-party integration wrapper for WPForms's write-tier abilities.
+ *
+ * @since 0.1.0
+ */
+class WPForms extends AcrossAI_Integration_Ability_Base {
+
+	/**
+	 * The tab_group identifier for the "Wpforms" tab on the Ability Library page.
+	 *
+	 * Third-party plugins wanting to add cards to this tab reference this
+	 * constant instead of hardcoding `'wpforms'`.
+	 *
+	 * @since 0.1.0
+	 * @var string
+	 */
+	public const TAB_GROUP = 'wpforms';
+
+	/**
+	 * Category / tab_group identifier.
+	 *
+	 * @since  0.1.0
+	 * @return string
+	 */
+	protected function slug(): string {
+		return self::TAB_GROUP;
+	}
+
+	/**
+	 * Human-readable label for the card and tab.
+	 *
+	 * @since  0.1.0
+	 * @return string
+	 */
+	protected function label(): string {
+		return __( 'WPForms', 'acrossai-abilities-manager' );
+	}
+
+	/**
+	 * Whether WPForms is loaded on the current site.
+	 *
+	 * Compound check per SEC-002: `defined()` on WPForms's version constant
+	 * AND `function_exists()` on the main WPForms container accessor. A
+	 * single-symbol check would be spoofable by any other plugin defining
+	 * `WPFORMS_VERSION`.
+	 *
+	 * Covers both WPForms Lite and WPForms Pro — both define
+	 * `WPFORMS_VERSION` and the `wpforms()` container function.
+	 *
+	 * @since  0.1.0
+	 * @return bool
+	 */
+	protected function is_plugin_active(): bool {
+		return defined( 'WPFORMS_VERSION' ) && function_exists( 'wpforms' );
+	}
+
+	/**
+	 * Attach WPForms's write-tier enable filter.
+	 *
+	 * WPForms internally checks `apply_filters( 'wpforms_integrations_abilities_allow_write', false )`
+	 * before registering its write-tier abilities. Default is false → writes
+	 * don't register. Attaching `__return_true` here flips it, so WPForms
+	 * registers its create/update/delete abilities on the current request.
+	 *
+	 * Only the WRITE filter is attached. Reads are auto-enabled by WPForms
+	 * regardless of any filter, so no filter attachment is needed for the
+	 * read tier — this is documented in the abilities() list below.
+	 *
+	 * @since  0.1.0
+	 * @return void
+	 */
+	protected function enable_filter(): void {
+		add_filter( 'wpforms_integrations_abilities_allow_write', '__return_true' );
+	}
+
+	/**
+	 * Fixed readonly list of the ability tiers WPForms exposes.
+	 *
+	 * Two rows — one per tier — because WPForms's abilities split cleanly
+	 * along the read/write boundary and the admin needs to understand which
+	 * tier this toggle gates. The read row is INFORMATIONAL only (reads are
+	 * auto-enabled by WPForms whenever the plugin is active — this toggle
+	 * doesn't affect them). The write row describes what enabling this
+	 * toggle actually unlocks.
+	 *
+	 * @since  0.1.0
+	 * @return array<int, array{slug: string, label: string, description: string}>
+	 */
+	protected function abilities(): array {
+		return array(
+			array(
+				'slug'        => 'wpforms/reads',
+				'label'       => __( 'Read abilities (auto-enabled)', 'acrossai-abilities-manager' ),
+				'description' => __(
+					'Read-only abilities exposed by WPForms — listing forms, reading form schemas, listing entries, and similar queries. WPForms enables these automatically whenever the plugin is active; this integration toggle does NOT gate them and they remain available regardless of the toggle state below.',
+					'acrossai-abilities-manager'
+				),
+			),
+			array(
+				'slug'        => 'wpforms/writes',
+				'label'       => __( 'Write abilities (gated by this toggle)', 'acrossai-abilities-manager' ),
+				'description' => __(
+					'Mutation abilities exposed by WPForms — creating, updating, and deleting forms and entries. Gated by the WPForms filter wpforms_integrations_abilities_allow_write (default: false). Flip the toggle above ON to attach __return_true to that filter so WPForms registers the write-tier abilities on subsequent requests.',
+					'acrossai-abilities-manager'
+				),
+			),
+		);
+	}
+}

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -430,7 +430,16 @@ final class Main {
 		// which itself runs at plugins_loaded @ P0 via the plugin entry file)
 		// so the constructor's plugins_loaded P20 add_action registers before
 		// P20 fires. Adding another integration is a one-line change here.
+		//
+		// Both ACF and WPForms use the enable-filter model: their target plugins
+		// expose a single filter that gates their AI abilities, and this
+		// integration's enable_filter() attaches __return_true to it when the
+		// toggle is ON. WPForms is a two-tier case — reads are auto-enabled by
+		// WPForms itself and pass through regardless; only writes are gated by
+		// wpforms_integrations_abilities_allow_write, which is what our toggle
+		// controls. See each subclass's docblock for details.
 		new \AcrossAI_Abilities_Manager\Includes\Abilities\Integrations\ACF();
+		new \AcrossAI_Abilities_Manager\Includes\Abilities\Integrations\WPForms();
 	}
 
 	/**

--- a/tests/phpunit/Modules/Library/Integrations/Test_WPForms.php
+++ b/tests/phpunit/Modules/Library/Integrations/Test_WPForms.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Smoke tests for the WPForms concrete integration subclass.
+ *
+ * Feature 060 extension (2026-07-27). Covers:
+ *   - TAB_GROUP constant is 'wpforms'
+ *   - slug() returns self::TAB_GROUP
+ *   - label() returns 'WPForms' (case-preserved capitalisation)
+ *   - abilities() exposes the two-tier read/write documentation rows with the
+ *     expected slugs, and the descriptions clearly distinguish auto-enabled
+ *     reads from gated writes.
+ *   - enable_filter() attaches __return_true to the WPForms write filter
+ *     exactly once (this is a real filter side-effect, not a no-op).
+ *
+ * @package AcrossAI_Abilities_Manager
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\Modules\Library\Integrations;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Integrations\WPForms;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * The WPForms integration subclass contract.
+ */
+class Test_WPForms extends TestCase {
+
+	public function test_tab_group_constant_is_wpforms(): void {
+		$this->assertSame( 'wpforms', WPForms::TAB_GROUP );
+	}
+
+	public function test_slug_returns_tab_group_constant(): void {
+		$slug_method = new ReflectionMethod( WPForms::class, 'slug' );
+		$slug_method->setAccessible( true );
+		$instance = ( new \ReflectionClass( WPForms::class ) )->newInstanceWithoutConstructor();
+		$this->assertSame( WPForms::TAB_GROUP, $slug_method->invoke( $instance ) );
+	}
+
+	public function test_label_is_wpforms(): void {
+		$label_method = new ReflectionMethod( WPForms::class, 'label' );
+		$label_method->setAccessible( true );
+		$instance = ( new \ReflectionClass( WPForms::class ) )->newInstanceWithoutConstructor();
+		$this->assertSame( 'WPForms', $label_method->invoke( $instance ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// abilities() — two rows describing the read/write tier split
+	// -------------------------------------------------------------------------
+
+	public function test_abilities_lists_two_tier_rows(): void {
+		$abilities_method = new ReflectionMethod( WPForms::class, 'abilities' );
+		$abilities_method->setAccessible( true );
+		$instance  = ( new \ReflectionClass( WPForms::class ) )->newInstanceWithoutConstructor();
+		$abilities = $abilities_method->invoke( $instance );
+
+		$this->assertIsArray( $abilities );
+		$this->assertCount( 2, $abilities );
+
+		$slugs = array_column( $abilities, 'slug' );
+		$this->assertSame(
+			array( 'wpforms/reads', 'wpforms/writes' ),
+			$slugs
+		);
+	}
+
+	public function test_read_row_documents_auto_enabled_nature(): void {
+		$abilities_method = new ReflectionMethod( WPForms::class, 'abilities' );
+		$abilities_method->setAccessible( true );
+		$instance  = ( new \ReflectionClass( WPForms::class ) )->newInstanceWithoutConstructor();
+		$abilities = $abilities_method->invoke( $instance );
+
+		$read_row = $abilities[0];
+		$this->assertSame( 'wpforms/reads', $read_row['slug'] );
+		// Label must call out the auto-enabled nature so the admin doesn't
+		// think the toggle disables reads.
+		$this->assertStringContainsString( 'auto-enabled', $read_row['label'] );
+		// Description must state that this toggle does NOT gate reads.
+		$this->assertMatchesRegularExpression(
+			'/does NOT gate|regardless of the toggle/i',
+			$read_row['description']
+		);
+	}
+
+	public function test_write_row_documents_the_gate_filter(): void {
+		$abilities_method = new ReflectionMethod( WPForms::class, 'abilities' );
+		$abilities_method->setAccessible( true );
+		$instance  = ( new \ReflectionClass( WPForms::class ) )->newInstanceWithoutConstructor();
+		$abilities = $abilities_method->invoke( $instance );
+
+		$write_row = $abilities[1];
+		$this->assertSame( 'wpforms/writes', $write_row['slug'] );
+		$this->assertStringContainsString( 'gated', $write_row['label'] );
+		// The exact filter name must appear in the description so admins
+		// searching for it via grep or filter-hooks documentation can find it.
+		$this->assertStringContainsString(
+			'wpforms_integrations_abilities_allow_write',
+			$write_row['description']
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// enable_filter() — attaches the write filter exactly once
+	// -------------------------------------------------------------------------
+
+	public function test_enable_filter_does_not_throw(): void {
+		$enable_method = new ReflectionMethod( WPForms::class, 'enable_filter' );
+		$enable_method->setAccessible( true );
+		$instance = ( new \ReflectionClass( WPForms::class ) )->newInstanceWithoutConstructor();
+
+		// enable_filter attaches the WPForms write filter via `add_filter`.
+		// The stub bootstrap's add_filter is a shim without full hook-system
+		// state, so we can't observe $wp_filter changes here — but the base
+		// class wraps this call in try/catch anyway, so we just assert the
+		// method returns void without throwing. Full end-to-end verification
+		// happens in the manual quickstart with WPForms actually active.
+		$result = $enable_method->invoke( $instance );
+		$this->assertNull( $result );
+	}
+
+	public function test_enable_filter_body_calls_add_filter_with_return_true(): void {
+		// Introspect the method body directly to prove it wires the correct
+		// filter name + callback. Guards against a future refactor that
+		// accidentally changes the filter name or drops the __return_true.
+		$reflection = new ReflectionMethod( WPForms::class, 'enable_filter' );
+		$source     = file_get_contents( $reflection->getFileName() );
+		$start      = $reflection->getStartLine();
+		$end        = $reflection->getEndLine();
+		$lines      = array_slice( explode( "\n", $source ), $start - 1, $end - $start + 1 );
+		$body       = implode( "\n", $lines );
+
+		$this->assertStringContainsString(
+			"add_filter( 'wpforms_integrations_abilities_allow_write', '__return_true' )",
+			$body,
+			'enable_filter() must attach __return_true to wpforms_integrations_abilities_allow_write.'
+		);
+	}
+}


### PR DESCRIPTION
Second concrete third-party integration using the enable-filter pattern (like ACF). Adds a WPForms toggle to the Ability Library page that gates only WPForms's WRITE-tier abilities; reads pass through unchanged.

## Summary

WPForms splits its Abilities API integration into two tiers:

- **Reads** — listing forms, listing entries, reading form schemas. Auto-enabled by WPForms whenever the plugin is active. This integration does **NOT** gate reads — they remain available regardless of the toggle state.
- **Writes** — creating, updating, and deleting forms and entries. Gated by the WPForms-provided filter `wpforms_integrations_abilities_allow_write` (defaults to `false` inside WPForms). Our integration's toggle attaches `__return_true` to that filter when ON, causing WPForms to register the write-tier abilities on subsequent requests.

The abilities() display list on the card has two rows that make this split explicit to admins:
- `wpforms/reads` — "Read abilities (auto-enabled)" with a description that clearly states the toggle does NOT gate them
- `wpforms/writes` — "Write abilities (gated by this toggle)" with a description that names the exact filter

## Files

- `includes/Abilities/Integrations/WPForms.php` (new, 165 LoC) — concrete subclass. `TAB_GROUP='wpforms'`. Compound `is_plugin_active()` = `defined('WPFORMS_VERSION') && function_exists('wpforms')` (covers both WPForms Lite and Pro).
- `includes/Main.php` — one-line instantiation alongside ACF.
- `tests/phpunit/Modules/Library/Integrations/Test_WPForms.php` (new, 8 tests) — TAB_GROUP + slug/label + two-tier ability list + read row documents auto-enabled nature + write row names the exact filter + source-body assertion pinning the `add_filter('…allow_write', '__return_true')` call.

## Test plan

- [x] `./vendor/bin/phpunit tests/phpunit/Modules/Library/Integrations/` → 28/28 pass (20 base-class + 8 WPForms smoke). Verified locally.
- [x] `./vendor/bin/phpstan analyse --level=8 includes/Abilities/Integrations/WPForms.php includes/Main.php` → exit 0. Verified locally.
- [x] `./vendor/bin/phpcs --standard=phpcs.xml.dist includes/Abilities/Integrations/WPForms.php includes/Main.php` → 0 errors. Verified locally.
- [ ] **Manual browser verification (with WPForms installed and activated)**:
  - [ ] WPForms deactivated → no "Wpforms" tab appears.
  - [ ] WPForms activated → "Wpforms" tab appears with toggle **off** by default; card shows two readonly rows: "Read abilities (auto-enabled)" and "Write abilities (gated by this toggle)".
  - [ ] Read row description explicitly says the toggle does NOT gate reads.
  - [ ] Write row description names `wpforms_integrations_abilities_allow_write` verbatim.
  - [ ] Toggle OFF: WPForms's read-tier abilities are present in `wp_get_abilities()` / MCP `discover-abilities` (auto-enabled); write-tier abilities are absent (WPForms's own filter default is false).
  - [ ] Toggle ON: both read-tier AND write-tier WPForms abilities are present in `wp_get_abilities()` and MCP.
  - [ ] Toggle OFF again → write-tier abilities disappear on next request; reads remain.

## Deferred / notes

- WPForms isn't installed on my local dev site, so the end-to-end browser check is deferred to whoever tests this next. The unit tests pin the contract (slug, label, ability rows, exact filter name in the source body); browser verification is the missing final step.
- No `spec.md` changes — WPForms exercises the existing FR-001..FR-018 via a second enable-filter concrete subclass. Nothing new architecturally.
- No new durable memory entry — WPForms follows exactly the ACF pattern, which is already captured in `PATTERN-LIBRARY-INTEGRATION-BASE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)