### PR TITLE
Release 0.0.20 — route access-control library-missing notice through main-menu 0.0.30 acrossai_notices hub

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.19
+Stable tag: 0.0.20
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -137,6 +137,17 @@ No data is sent to any external server without an explicit administrator action.
 
 == Changelog ==
 
+= 0.0.20 =
+* **Changed — access-control library-missing notice now routes through the shared AcrossAI notice hub.** The pre-0.0.20 `AcrossAI_Abilities_Access_Control::maybe_show_library_notice()` method was hooked on WordPress core `admin_notices` and printed a raw `.notice.notice-warning` banner on every admin screen when the `wpb-access-control` library wasn't loaded. It is renamed to `register_library_notice( array $notices ): array` and now registers into the new `acrossai_notices` filter shipped by `acrossai-co/main-menu` 0.0.30. The notice appears in two places instead: (1) as a card on the new **AcrossAI → Notices** submenu (only registered when at least one notice is present, with a WP-style count bubble on the menu label), and (2) as a single top-of-page WordPress-native `.notice.notice-warning.is-dismissible` summary banner ("AcrossAI has N notifications for your attention — View notices →") printed on every other admin page. Dismissal is fingerprint-persisted per user until the notice set changes. Notice record shape: `id=wpb_access_control_missing`, `type=warning`, `source=AcrossAI Abilities Manager`. Semantics are unchanged — the fail-open behaviour, the `manage_options` gate (enforced by the menu itself and the summary emitter), and the message copy are all preserved.
+* **Composer dependency bump — `acrossai-co/main-menu` 0.0.29 → 0.0.30.** Ships the cross-plugin notice system this release routes through:
+  * New `acrossai_notices` filter — any AcrossAI consumer plugin can push admin-notice records into a shared collection using a single documented record shape (`id`, `title`, `message`, `type`, optional `source`, optional `action { label, url }`). Later registrations of the same `id` are ignored (first-wins). Missing `id` or both `title` and `message` empty → the entry is dropped.
+  * New **AcrossAI → Notices** submenu (slug `acrossai-notices`, class `NoticesPageRenderer`) — only registered when at least one notice exists. Menu label carries a WP-style count bubble (`.awaiting-mod`).
+  * New top-of-page summary notice emitter (`SummaryNoticeEmitter`) — prints one WordPress-native dismissible banner on every other admin page linking to the Notices submenu. Dismissal is fingerprint-based (SHA-1 of sorted notice IDs stored in per-user meta `_acrossai_notices_summary_fp`) so the summary re-appears whenever the notice set changes.
+  * New AJAX endpoint `wp_ajax_acrossai_notices_dismiss_summary` — nonce + `manage_options` guarded; server re-validates the client-supplied fingerprint against the current notice set as defense-in-depth against poisoning the user meta with an unrelated hash.
+  * New public classes under `AcrossAI_Main_Menu\`: `Notices`, `NoticesPageRenderer`, `NoticesAjaxHandlers`, `SummaryNoticeEmitter`. New page-slug constant `SettingsPage::NOTICES_SLUG` and static accessor `SettingsPage::get_notices(): ?Notices` for consumers that want to inspect the current notice list programmatically.
+* **Note — the vendor-missing boot-resilience notice in `Includes\Main::__construct()` remains on core `admin_notices`.** That code path fires precisely when the composer autoloader is absent — the moment when the shared main-menu package isn't loadable either — so the `acrossai_notices` filter cannot be reached from it. This is intentional and matches Constitution §V Integration Resilience.
+* **No breaking changes.** No ability slug rename. No REST endpoint change. No option-shape change. No new required capability. Existing 218 abilities behave identically. Safe upgrade from 0.0.19.
+
 = 0.0.19 =
 * **New — MCP Manager promo callout on the ability edit form.** The MCP Exposure section (Section 3) of the Custom Abilities edit page now surfaces a blue-tinted informational callout advertising the sibling `acrossai-mcp-manager` plugin when it is not installed / active on the current site. The callout renders directly below the existing "Heads up" warning and offers two actions: an "Install from Add-ons" button that deep-links to the AcrossAI Add-ons page (`admin.php?page=acrossai-addons`), and a "Learn more" external link to `https://acrossai.co/mcp-manager/`. When the AcrossAI MCP Manager plugin IS active on the site, the callout is fully suppressed — zero UI on the edit form. Detection uses WordPress core `is_plugin_active( 'acrossai-mcp-manager/acrossai-mcp-manager.php' )` inside the admin script enqueue path; the resolved boolean plus the two URLs are injected into the existing `window.acrossaiAbilitiesManager` localize payload as `mcp_manager_active`, `mcp_manager_addons_url`, and `mcp_manager_info_url`. The callout also degrades gracefully on older bundles or a customised localize payload — the two action buttons render only when their corresponding URL keys are non-empty.
 * **Composer dependency bump — `acrossai-co/main-menu` 0.0.27 → 0.0.29.** Two-hop bump rolled into one release:
@@ -254,6 +265,9 @@ No data is sent to any external server without an explicit administrator action.
 * MCP server listing via MCP Adapter integration.
 
 == Upgrade Notice ==
+
+= 0.0.20 =
+Routes the access-control library-missing warning through the new shared AcrossAI notice hub (`acrossai_notices` filter shipped by `acrossai-co/main-menu` 0.0.30). Instead of a raw wp-admin banner on every screen, the notice now appears on the new AcrossAI → Notices submenu (with a count bubble on the menu label) and as a single top-of-page summary banner ("AcrossAI has N notifications for your attention — View notices →") whose dismissal persists per user until the notice set changes. The fail-open semantics and message copy are unchanged. No breaking changes; existing abilities unaffected. Safe upgrade from 0.0.19.
 
 = 0.0.19 =
 Adds a blue promotional callout on the ability edit form (MCP Exposure section) that advertises the sibling AcrossAI MCP Manager plugin when it is not installed / active. The callout links to the AcrossAI Add-ons page for install and to acrossai.co/mcp-manager/ for more info. Fully suppressed when the AcrossAI MCP Manager plugin is active. Also bumps the `acrossai-co/main-menu` composer dependency from 0.0.27 to 0.0.29 — 0.0.28 refreshes the Add-ons page baseline catalogue (AcrossAI Abilities Manager + AcrossAI MCP Manager + AI Connectors) with shared brand icon, `contain`-fitted icon boxes, fixed 3-column grid layout, and a new optional `learn_more_url` field; 0.0.29 reworks the card action states so active add-ons render a non-clickable "● Running" pill (deactivation stays in Plugins → Installed Plugins) and installed non-wp.org add-ons now show an in-page Activate button instead of always linking out. No breaking changes; existing abilities unaffected. Safe upgrade from 0.0.18.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.19
+ * Version:           0.0.20
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"automattic/jetpack-autoloader": "^5.0",
 		"wpboilerplate/wpb-access-control": "^2.0.0",
 		"berlindb/core": "^3.0.0",
-		"acrossai-co/main-menu": "0.0.29"
+		"acrossai-co/main-menu": "0.0.30"
 	},
 	"keywords": [
 		"wordpress",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a38716af83cd76e97a24ab145918606",
+    "content-hash": "1af2fd7607437cedbacc67b61a76db43",
     "packages": [
         {
             "name": "acrossai-co/main-menu",
-            "version": "0.0.29",
+            "version": "0.0.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acrossai-co/main-menu.git",
-                "reference": "c051a97d449594f6887c6dabe25b8d134e979dc7"
+                "reference": "13337690bc52b21fa177b47138f0c045e15896c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acrossai-co/main-menu/zipball/c051a97d449594f6887c6dabe25b8d134e979dc7",
-                "reference": "c051a97d449594f6887c6dabe25b8d134e979dc7",
+                "url": "https://api.github.com/repos/acrossai-co/main-menu/zipball/13337690bc52b21fa177b47138f0c045e15896c5",
+                "reference": "13337690bc52b21fa177b47138f0c045e15896c5",
                 "shasum": ""
             },
             "require": {
@@ -41,9 +41,9 @@
             "description": "AcrossAI Admin Dashboard — parent menu, shared Settings page (Settings API, flat or tabbed), and reusable Tabs base for other admin screens.",
             "support": {
                 "issues": "https://github.com/acrossai-co/main-menu/issues",
-                "source": "https://github.com/acrossai-co/main-menu/tree/0.0.29"
+                "source": "https://github.com/acrossai-co/main-menu/tree/0.0.30"
             },
-            "time": "2026-07-31T07:21:06+00:00"
+            "time": "2026-08-02T14:00:49+00:00"
         },
         {
             "name": "automattic/jetpack-autoloader",

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.19' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.20' );
 	}
 
 	/**
@@ -343,10 +343,13 @@ final class Main {
 		// Named variable before Loader call — Boot Flow Rule variable-first pattern (AC-HOOKS-MAIN).
 		$abilities_table = \AcrossAI_Abilities_Manager\Includes\Modules\Abilities\Database\AcrossAI_Abilities_Table::instance();
 
-		// Register Access Control REST routes and admin notice for absent library (SAC-01).
+		// Register Access Control REST routes and library-missing notice (SAC-01).
+		// The library-missing notice is routed through the shared main-menu 0.0.30
+		// `acrossai_notices` filter — surfaces on AcrossAI → Notices submenu +
+		// the top-of-page summary banner instead of a raw admin_notices banner.
 		$abilities_ac = \AcrossAI_Abilities_Manager\Includes\Modules\Abilities\AcrossAI_Abilities_Access_Control::instance();
 		$this->loader->add_action( 'rest_api_init', $abilities_ac, 'register_rest_api' );
-		$this->loader->add_action( 'admin_notices', $abilities_ac, 'maybe_show_library_notice' );
+		$this->loader->add_filter( 'acrossai_notices', $abilities_ac, 'register_library_notice' );
 
 		// Abilities module REST routes (Spec 009).
 		// Named variable before Loader call — Boot Flow Rule variable-first pattern.

--- a/includes/Modules/Abilities/AcrossAI_Abilities_Access_Control.php
+++ b/includes/Modules/Abilities/AcrossAI_Abilities_Access_Control.php
@@ -123,36 +123,41 @@ class AcrossAI_Abilities_Access_Control {
 	}
 
 	/**
-	 * Display an admin notice when the wpb-access-control library is absent.
+	 * Register a notice in the shared AcrossAI notices collection when the
+	 * wpb-access-control library is absent.
 	 *
-	 * Hooked to admin_notices. Only shown to users with manage_options and only
-	 * when the library class is not loaded. This ensures that admins who rely on
-	 * per-ability access-control rules are made aware that enforcement is currently
-	 * inactive (fail-open, per DEC-PERM-CB). (SAC-01 / MEDIUM-03)
+	 * Hooked to the `acrossai_notices` filter provided by
+	 * `acrossai-co/main-menu` 0.0.30+. The notice surfaces on the AcrossAI →
+	 * Notices submenu (rendered by `NoticesPageRenderer`) and as a summary
+	 * banner on every other admin page (`SummaryNoticeEmitter`). Ensures
+	 * admins are aware that per-ability rules are inactive (fail-open, per
+	 * DEC-PERM-CB) without adding a raw wp-admin banner. (SAC-01 / MEDIUM-03)
 	 *
-	 * @since  0.1.0
-	 * @return void
+	 * @since 0.1.0
+	 * @param array $notices Current notice records keyed 0..N; see main-menu Notices class.
+	 * @return array Notice list with the library-missing entry appended when applicable.
 	 */
-	public function maybe_show_library_notice(): void {
+	public function register_library_notice( $notices ) {
+		if ( ! is_array( $notices ) ) {
+			$notices = array();
+		}
+
 		if ( $this->is_available() ) {
-			return;
+			return $notices;
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
-		wp_admin_notice(
-			sprintf(
+		$notices[] = array(
+			'id'      => 'wpb_access_control_missing',
+			'title'   => __( 'Access-control library is not loaded', 'acrossai-abilities-manager' ),
+			'message' => sprintf(
 				/* translators: %s: library class name */
-				esc_html__( 'AcrossAI Abilities Manager: The wpb-access-control library (%s) is not loaded. Per-ability access-control rules are inactive and all ability checks will pass (fail-open). Install or activate the library to enforce saved rules.', 'acrossai-abilities-manager' ),
-				'<code>WPBoilerplate\\AccessControl\\AccessControlManager</code>'
+				__( 'The wpb-access-control library (%s) is not loaded. Per-ability access-control rules are inactive and all ability checks will pass (fail-open). Install or activate the library to enforce saved rules.', 'acrossai-abilities-manager' ),
+				'WPBoilerplate\\AccessControl\\AccessControlManager'
 			),
-			array(
-				'type'           => 'warning',
-				'dismissible'    => true,
-				'paragraph_wrap' => false,
-			)
+			'type'    => 'warning',
+			'source'  => __( 'AcrossAI Abilities Manager', 'acrossai-abilities-manager' ),
 		);
+
+		return $notices;
 	}
 }


### PR DESCRIPTION
## Summary

- **Changed — access-control library-missing warning now routes through the shared AcrossAI notice hub.** `AcrossAI_Abilities_Access_Control::maybe_show_library_notice()` (raw `admin_notices` action, printed a `.notice.notice-warning` banner on every admin screen) is renamed to `register_library_notice( array $notices ): array` and now registers into the new `acrossai_notices` filter shipped by `acrossai-co/main-menu` 0.0.30. The notice surfaces on **AcrossAI → Notices** (new submenu with a WP-style count bubble on the menu label) and as a single top-of-page dismissible summary banner ("AcrossAI has N notifications for your attention — View notices →"). Notice record: `id=wpb_access_control_missing`, `type=warning`, `source=AcrossAI Abilities Manager`. Semantics preserved — fail-open behaviour, message copy, and `manage_options` gate are unchanged.
- **Composer dependency bump — `acrossai-co/main-menu` 0.0.29 → 0.0.30.** Ships the cross-plugin notice system this release routes through: `acrossai_notices` filter, `Notices` / `NoticesPageRenderer` / `NoticesAjaxHandlers` / `SummaryNoticeEmitter` public classes, `SettingsPage::NOTICES_SLUG` page slug, and the `wp_ajax_acrossai_notices_dismiss_summary` AJAX endpoint (nonce + `manage_options` guarded; server re-validates the client-supplied fingerprint against the current notice set).
- **Plugin version 0.0.19 → 0.0.20** across the bootstrap header, `ACROSSAI_ABILITIES_MANAGER_VERSION` constant, and README.txt (`Stable tag` + Changelog + Upgrade Notice).

## Implementation notes

- Hook wiring changed in `includes/Main.php`: `$this->loader->add_action( 'admin_notices', $abilities_ac, 'maybe_show_library_notice' )` → `$this->loader->add_filter( 'acrossai_notices', $abilities_ac, 'register_library_notice' )`. The Loader's `add_filter` default (`$accepted_args = 1`) matches the new callback signature.
- The notice record does not set a `type` value beyond `'warning'` and omits `action` — the AC library isn't something a link would fix in one click; the message tells the admin to install/activate the library themselves.
- The vendor-missing boot-resilience notice in `Includes\Main::__construct()` intentionally stays on core `admin_notices`. It fires precisely when the composer autoloader is absent — the moment when the shared main-menu package isn't loadable — so the `acrossai_notices` filter can't be reached from it. Matches Constitution §V Integration Resilience.
- No breaking changes. No ability slug rename. No REST endpoint change. No option-shape change. No new required capability. Existing 218 abilities behave identically.

## Test plan

- [ ] Fresh checkout: `composer install` resolves `acrossai-co/main-menu` to 0.0.30.
- [ ] Simulate the AC library being absent (`class_exists( 'WPBoilerplate\\AccessControl\\AccessControlManager' )` returns false) and confirm:
  - [ ] Admin sees **AcrossAI → Notices** submenu with a `(1)` count bubble on the label.
  - [ ] Notices page shows a card titled "Access-control library is not loaded" with the fail-open message and `AcrossAI Abilities Manager` as the source label.
  - [ ] Every other admin page shows one WordPress-native summary banner linking to the Notices page.
  - [ ] Dismissing the summary banner persists until the notice set changes (fingerprint stored under user meta `_acrossai_notices_summary_fp`).
- [ ] Install/activate the AC library and confirm the notice disappears from both the Notices submenu and the summary banner (the submenu is not registered when count is zero).
- [ ] Confirm no raw `.notice.notice-warning` banner is printed on `admin_notices` for the library-missing state.
- [ ] Confirm the vendor-missing (composer autoloader absent) boot-resilience notice still fires on `admin_notices` — that path is unchanged.
- [ ] `vendor/bin/phpcs --standard=phpcs.xml.dist` exits 0 (verified locally).
- [ ] `vendor/bin/phpunit --testsuite=abilities-unit` passes (verified locally: 69 tests, 107 assertions, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)