### PR TITLE
fix(#99): remove protected-meta guard from update-post-meta

### DIFF
--- a/includes/Abilities/Content/Update_Post_Meta.php
+++ b/includes/Abilities/Content/Update_Post_Meta.php
@@ -29,7 +29,7 @@ class Update_Post_Meta extends Ability_Definition {
 			'name' => 'acrossai/update-post-meta',
 			'args' => array(
 				'label'               => __( 'Update Post Meta', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Set a post meta value via update_post_meta(). If the meta is registered via register_meta() and protected, the request will be rejected.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Set a post meta value via update_post_meta(). Works for any meta key, including protected keys.', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-content',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {
@@ -116,13 +116,6 @@ class Update_Post_Meta extends Ability_Definition {
 			return array(
 				'success' => false,
 				'message' => __( 'Meta key is empty. Pass "key" (or its alias "meta_key").', 'acrossai-abilities-manager' ),
-			);
-		}
-		if ( is_protected_meta( $key, 'post' ) ) {
-			return array(
-				'success' => false,
-				/* translators: %s: meta key */
-				'message' => sprintf( __( 'Meta key "%s" is protected and cannot be modified.', 'acrossai-abilities-manager' ), $key ),
 			);
 		}
 


### PR DESCRIPTION
## Summary
- Fixes #99. The class docblock for `Update_Post_Meta` states it "Works for ANY meta key," but `execute()` rejected anything `is_protected_meta()` flagged as protected — a direct contradiction.
- Drops the `is_protected_meta()` guard in `includes/Abilities/Content/Update_Post_Meta.php` so behavior matches the docblock. `manage_options` in the `permission_callback` remains the access gate.
- Updates the registered `description` to reflect the new behavior ("Works for any meta key, including protected keys.") instead of the old "will be rejected" wording.

## Test plan
- [ ] Register a protected meta (leading-underscore key) on a post and confirm the ability now writes it via REST/MCP.
- [ ] Confirm `manage_options` is still required (non-admins are rejected by `permission_callback`).
- [ ] `composer run test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)