### PR TITLE
feat: add acrossai/delete-post-meta ability

### DIFF
--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -214,6 +214,7 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Content\Delete_Post();
 		new Content\Get_Post_Meta();
 		new Content\Update_Post_Meta();
+		new Content\Delete_Post_Meta();
 		new Content\Create_Page();
 		new Content\Get_Page();
 		new Content\List_Page_Revisions();

--- a/includes/Abilities/Content/Delete_Post_Meta.php
+++ b/includes/Abilities/Content/Delete_Post_Meta.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Absorbed ability class scaffolded from acrossai-core-abilities (Feature 046).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Content
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Delete post meta via delete_post_meta(). Works for any meta key. If a value
+ * is supplied, only rows matching that value are removed; otherwise every row
+ * for the given key is removed.
+ */
+class Delete_Post_Meta extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/delete-post-meta',
+			'args' => array(
+				'label'               => __( 'Delete Post Meta', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Delete a post meta row via delete_post_meta(). If a value is supplied, only rows matching that value are removed; otherwise every row for the given key is removed.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'    => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'key'        => array( 'type' => 'string' ),
+						'meta_key'   => array(
+							'type'        => 'string',
+							'description' => __( 'Alias for "key" (matches WordPress core naming). If both are provided, "key" wins.', 'acrossai-abilities-manager' ),
+						),
+						'value'      => array(
+							'type'        => array( 'string', 'integer', 'number', 'boolean', 'array', 'object', 'null' ),
+							'description' => __( 'Optional. If supplied, only meta rows whose stored value matches will be deleted.', 'acrossai-abilities-manager' ),
+						),
+						'meta_value' => array(
+							'type'        => array( 'string', 'integer', 'number', 'boolean', 'array', 'object', 'null' ),
+							'description' => __( 'Alias for "value" (matches WordPress core naming). If both are provided, "value" wins.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'allOf'                => array(
+						array( 'required' => array( 'post_id' ) ),
+						array(
+							'anyOf' => array(
+								array( 'required' => array( 'key' ) ),
+								array( 'required' => array( 'meta_key' ) ),
+							),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'deleted' => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'posts',
+						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id = (int) ( $input['post_id'] ?? 0 );
+		$raw_key = ! empty( $input['key'] ) ? $input['key'] : ( $input['meta_key'] ?? '' );
+		$key     = sanitize_text_field( (string) $raw_key );
+
+		if ( $post_id <= 0 || ! get_post( $post_id ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+		if ( '' === $key ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Meta key is empty. Pass "key" (or its alias "meta_key").', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$has_value = array_key_exists( 'value', $input ) || array_key_exists( 'meta_value', $input );
+		$value     = array_key_exists( 'value', $input ) ? $input['value'] : ( $input['meta_value'] ?? '' );
+
+		$deleted = $has_value
+			? delete_post_meta( $post_id, $key, $value )
+			: delete_post_meta( $post_id, $key );
+
+		return array(
+			'success' => true,
+			'deleted' => (bool) $deleted,
+			/* translators: 1: meta key, 2: post ID */
+			'message' => sprintf( __( 'Deleted meta "%1$s" on post #%2$d.', 'acrossai-abilities-manager' ), $key, $post_id ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `acrossai/delete-post-meta` under `includes/Abilities/Content/Delete_Post_Meta.php`, mirroring the shape of `Update_Post_Meta`.
- Gated by `current_user_can( 'manage_options' )`; annotated `destructive: true`, `idempotent: true`.
- Input accepts `post_id` + `key` (with `meta_key` alias) and an optional `value` (with `meta_value` alias). When a value is supplied it forwards to `delete_post_meta( \$post_id, \$key, \$value )` so only rows matching that value are removed; otherwise every row for the key is removed.
- Registered in `AcrossAI_Core_Abilities_Bootstrap` next to `Update_Post_Meta`.
- No `is_protected_meta()` guard — consistent with the fix proposed in #105 for the update counterpart. The `manage_options` capability is the access gate.

## Test plan
- [ ] Register a meta key (protected and unprotected) on a post, delete via the ability, and confirm the row is gone.
- [ ] Pass `value` and confirm only matching rows are deleted; omit `value` and confirm every row for the key is deleted.
- [ ] Confirm non-admins are rejected by `permission_callback`.
- [ ] `composer run test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)