### PR TITLE
chore(deps): bump acrossai-co/main-menu from 0.0.30 to 0.0.33

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"automattic/jetpack-autoloader": "^5.0",
 		"wpboilerplate/wpb-access-control": "^3.1.0",
 		"berlindb/core": "^3.0.0",
-		"acrossai-co/main-menu": "0.0.30"
+		"acrossai-co/main-menu": "0.0.32"
 	},
 	"keywords": [
 		"wordpress",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"automattic/jetpack-autoloader": "^5.0",
 		"wpboilerplate/wpb-access-control": "^3.1.0",
 		"berlindb/core": "^3.0.0",
-		"acrossai-co/main-menu": "0.0.32"
+		"acrossai-co/main-menu": "0.0.33"
 	},
 	"keywords": [
 		"wordpress",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1eea1fb79b16993f97658fd49eb2a9c6",
+    "content-hash": "646ed1c1ae6ada33cdc4a5dd325745d9",
     "packages": [
         {
             "name": "acrossai-co/main-menu",
-            "version": "0.0.32",
+            "version": "0.0.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acrossai-co/main-menu.git",
-                "reference": "e1faed188c84c71f366397c33f595aca3ab13c88"
+                "reference": "e17e1e86bff8037b81df24b6bde5e2bd5e127a66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acrossai-co/main-menu/zipball/e1faed188c84c71f366397c33f595aca3ab13c88",
-                "reference": "e1faed188c84c71f366397c33f595aca3ab13c88",
+                "url": "https://api.github.com/repos/acrossai-co/main-menu/zipball/e17e1e86bff8037b81df24b6bde5e2bd5e127a66",
+                "reference": "e17e1e86bff8037b81df24b6bde5e2bd5e127a66",
                 "shasum": ""
             },
             "require": {
@@ -41,9 +41,9 @@
             "description": "AcrossAI Admin Dashboard — parent menu, shared Settings page (Settings API, flat or tabbed), and reusable Tabs base for other admin screens.",
             "support": {
                 "issues": "https://github.com/acrossai-co/main-menu/issues",
-                "source": "https://github.com/acrossai-co/main-menu/tree/0.0.32"
+                "source": "https://github.com/acrossai-co/main-menu/tree/0.0.33"
             },
-            "time": "2026-08-10T12:00:45+00:00"
+            "time": "2026-08-10T18:03:14+00:00"
         },
         {
             "name": "automattic/jetpack-autoloader",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d280e7cb1172c454a799decd5e5a9b79",
+    "content-hash": "1eea1fb79b16993f97658fd49eb2a9c6",
     "packages": [
         {
             "name": "acrossai-co/main-menu",
-            "version": "0.0.30",
+            "version": "0.0.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/acrossai-co/main-menu.git",
-                "reference": "13337690bc52b21fa177b47138f0c045e15896c5"
+                "reference": "e1faed188c84c71f366397c33f595aca3ab13c88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/acrossai-co/main-menu/zipball/13337690bc52b21fa177b47138f0c045e15896c5",
-                "reference": "13337690bc52b21fa177b47138f0c045e15896c5",
+                "url": "https://api.github.com/repos/acrossai-co/main-menu/zipball/e1faed188c84c71f366397c33f595aca3ab13c88",
+                "reference": "e1faed188c84c71f366397c33f595aca3ab13c88",
                 "shasum": ""
             },
             "require": {
@@ -41,9 +41,9 @@
             "description": "AcrossAI Admin Dashboard — parent menu, shared Settings page (Settings API, flat or tabbed), and reusable Tabs base for other admin screens.",
             "support": {
                 "issues": "https://github.com/acrossai-co/main-menu/issues",
-                "source": "https://github.com/acrossai-co/main-menu/tree/0.0.30"
+                "source": "https://github.com/acrossai-co/main-menu/tree/0.0.32"
             },
-            "time": "2026-08-02T14:00:49+00:00"
+            "time": "2026-08-10T12:00:45+00:00"
         },
         {
             "name": "automattic/jetpack-autoloader",


### PR DESCRIPTION
## Summary
- Bumps `acrossai-co/main-menu` from `0.0.30` → `0.0.33` in `composer.json`.
- Regenerates `composer.lock` — new dist reference `e17e1e8`. No other packages changed.
- (Branch name still reads `-0.0.32` from the initial push; the pinned version is `0.0.33`.)

## Test plan
- [ ] `composer install` produces a clean vendor tree.
- [ ] Admin dashboard/menu renders and Settings/Add-ons pages load without notices.
- [ ] `composer run test` / `composer run phpstan` / `composer run phpcs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)