### PR TITLE
feat(064): transient CRUD, nested option access, plugin lifecycle & checksum integrity

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/060-library-third-party-integration-toggles"
+  "feature_directory": "specs/064-transients-nested-options-and-integrity"
 }

--- a/docs/planning/064-transients-nested-options-and-integrity.md
+++ b/docs/planning/064-transients-nested-options-and-integrity.md
@@ -1,0 +1,95 @@
+# Feature 064 — Transient CRUD, nested option access, plugin lifecycle & checksum integrity
+
+**Status**: input brief for `/speckit-specify`. Written 2026-08-11.
+
+## Problem
+
+Three shape-completeness gaps in the current ability surface:
+
+1. **Transients** — we expose `flush-transients` (bulk delete every transient) but no way to read, list, delete-one-by-name, or delete-expired-only. Any workflow that inspects or surgically manages transient state today has to fall back to raw SQL via `run-db-select-query`.
+2. **Nested option access** — `get-option` returns the whole serialized blob for large options (e.g. WooCommerce settings, membership rulesets), forcing the client to deserialize server-side outputs client-side. There is no way to read or mutate a single nested key.
+3. **Post-meta append semantics** — `update-post-meta` replaces every row for the key; `delete-post-meta` removes rows. There is no ability corresponding to WordPress core `add_post_meta()` (append a new row without touching existing rows) — required for post-meta fields that legitimately store multiple values per key.
+4. **Plugin lifecycle & integrity** — no WP.org plugin directory search, no plugin uninstall (only deactivate), no core or plugin file-integrity check against the official WordPress.org checksums API. These are common ops for site auditing and lifecycle management.
+
+This feature adds 11 new abilities filling all four gaps. `manage_options` remains the sole access gate.
+
+## Proposed abilities
+
+Slug convention per `DEC-SLUG-CONVENTION-VERB-FIRST` (Feature 058): `acrossai/<verb>-<subject>`.
+
+### Transient CRUD (4) — under `Cache/` category
+
+| Slug | Purpose | Core API | Notes |
+|---|---|---|---|
+| `acrossai/get-transient` | Return one transient value + expiry. Distinguishes "unset" from `value === false`. | `get_transient( $key )` or `get_site_transient( $key )` when `site: true` | Input: `{ key: string, site?: bool = false }`. Output: `{ success, exists: bool, value, expires_at?: int }`. |
+| `acrossai/list-transients` | Enumerate every transient (or site-transient) with expiry. Capped at 100 rows by default. | `SELECT option_name, option_value FROM $wpdb->options WHERE option_name LIKE '\\_transient\\_%' OR option_name LIKE '\\_site\\_transient\\_%'` — join in expiry via companion `_transient_timeout_<key>` rows. | Input: `{ search?: string, limit?: int = 100 (max 500), offset?: int = 0, site_only?: bool = false, include_expired?: bool = true }`. Output: `{ success, transients: [{ name, expires_at?, is_site, is_expired }], count, total }`. |
+| `acrossai/delete-transient` | Delete one transient by name. `destructive: true, idempotent: true`. | `delete_transient( $key )` or `delete_site_transient` when `site: true` | Input: `{ key: string, site?: bool = false }`. |
+| `acrossai/delete-expired-transients` | Purge every expired transient in a single pass. `destructive: true`. | `delete_expired_transients()` (WP core function) | No input. Output: `{ success, deleted: int, message }`. |
+
+### Nested option access (2) — under `Options/` category
+
+| Slug | Purpose | Core API | Notes |
+|---|---|---|---|
+| `acrossai/get-nested-option-value` | Read one nested key inside a serialized-array option without returning the whole blob. | `get_option( $option )` + array/object path walk. | Input: `{ option: string, path: string[] }`. Output: `{ success, exists: bool, value }`. `readonly: true`. |
+| `acrossai/patch-option-value` | Mutate one nested key inside a serialized option (insert / update / delete). | `get_option()` → walk to parent → mutate → `update_option()`. | Input: `{ option: string, operation: 'insert'\|'update'\|'delete', path: string[], value?: mixed }`. Guard: reject any option in the existing block-list used by `update-option` (reuse the `Options` category's blocked-options constant if one exists; otherwise mirror `Update_Option.php`'s guardrails). `destructive: true`. |
+
+### Post-meta append (1) — under `Content/` category
+
+| Slug | Purpose | Core API | Notes |
+|---|---|---|---|
+| `acrossai/add-post-meta` | WordPress `add_post_meta()` semantics — append a new meta row (does not touch existing rows for the same key). Complements the existing replace/delete verbs. | `add_post_meta( $post_id, $key, $value, $unique )` | Input mirrors `Update_Post_Meta.php` (`post_id`, `key`/`meta_key`, `value`/`meta_value`) plus `unique?: bool = false`. Output: `{ success, meta_id: int\|false, message }`. Not `destructive: true` — additive semantics. |
+
+### Plugin lifecycle & integrity (4) — under `Plugins/` (3) and `Core/` (1)
+
+| Slug | Category | Purpose | Core API |
+|---|---|---|---|
+| `acrossai/search-wp-plugin-directory` | `Plugins` | Search the WordPress.org plugin directory. | `plugins_api( 'query_plugins', ['search' => $q, 'per_page' => $n, 'page' => $p, 'fields' => ['slug','name','short_description','rating','downloaded','active_installs','homepage','download_link']] )` — must `require_once ABSPATH . 'wp-admin/includes/plugin-install.php';` first (REST context does not preload it). Output: `{ success, plugins: [...], info: { page, pages, results } }`. Read-only. |
+| `acrossai/uninstall-plugin` | `Plugins` | Uninstall a plugin (fires uninstall hook + deletes files). Distinct from `delete-plugin` (files-only) — this triggers the plugin's own cleanup. | `uninstall_plugin( $plugin )` from `wp-admin/includes/plugin.php`. Requires `Plugin_Helpers::resolve_plugin()` for fuzzy slug/file matching. Input: `{ plugin: string (slug or file), delete_data?: bool = true }`. Guards: (a) refuse if plugin is currently active (return actionable message pointing to `acrossai/deactivate-plugin`); (b) honor `DISALLOW_FILE_MODS` via `File_Mods_Guard::blocked_response()` (same pattern used by `Install_Plugin.php`). `destructive: true`. |
+| `acrossai/verify-plugin-checksums` | `Plugins` | Verify plugin files against official WordPress.org checksums. | Fetch `https://api.wordpress.org/plugins/checksums/1.0/?plugin=<slug>&version=<v>` via `wp_remote_get()`; walk plugin dir and hash every file; diff. Input: `{ plugin: string, strict?: bool = false }`. Output: `{ success, plugin, version, results: [{ file, expected, actual, status: 'ok'\|'modified'\|'missing'\|'added' }], summary: { total, ok, modified, missing, added } }`. `strict: true` treats "added" files as failures too. Read-only. |
+| `acrossai/verify-core-checksums` | `Core` | Same as above for WordPress core files. | `get_core_checksums( $version, $locale )` from `wp-admin/includes/update.php` (already used by WP's own checksums command). Walk `ABSPATH` and diff. Input: `{ version?: string (defaults to installed), locale?: string (defaults to 'en_US'), include_root?: bool = false, exclude?: string[] }`. Output shape same as `verify-plugin-checksums`. Read-only. |
+
+## Reused utilities (do not reinvent)
+
+- **`Ability_Definition`** parent class.
+- **`Plugin_Helpers::resolve_plugin()`** — fuzzy plugin slug/file resolution; already used by Recovery abilities (`includes/Abilities/Recovery/Unpause_Plugin.php`).
+- **`File_Mods_Guard`** — `DISALLOW_FILE_MODS` gate; already used by `Install_Plugin.php`, `Delete_Theme.php`.
+- **`Update_Option.php`** — mirror its `BLOCKED_OPTIONS` allowlist / block-list for `patch-option-value`.
+- **`Update_Post_Meta.php`** input schema shape — mirror verbatim for `add-post-meta` (same `key`/`meta_key` and `value`/`meta_value` aliases pattern).
+
+## Common shape (all 11)
+
+- Correct namespace per category directory.
+- `permission_callback => static function (): bool { return current_user_can( 'manage_options' ); }` — LITERAL, verbatim, per the plugin's established convention (identical to all 219 existing abilities).
+- `meta.show_in_rest = true`, `meta.mcp = { public: false, type: 'tool' }`.
+- `meta.acrossai.sub_group` — `'cache'` (4), `'options'` (2), `'posts'` (1), `'plugins'` (3), `'core'` (1).
+- All string inputs sanitized with `sanitize_text_field()`.
+- All returned messages wrapped in `__( '...', 'acrossai-abilities-manager' )`.
+- `readonly: true` for the two verify-checksums abilities, the two transient reads, the nested-option read, and `search-wp-plugin-directory`.
+- `destructive: true` for `delete-transient`, `delete-expired-transients`, `patch-option-value`, `uninstall-plugin`.
+
+## Bootstrap wiring
+
+Edit `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php::register_abilities()` only (no new category registrar):
+
+- 4 new `new Cache\<Class>();` lines inside the existing Cache block (currently lines 140–142).
+- 2 new `new Options\<Class>();` lines inside the existing Options block (currently lines 273–277).
+- 1 new `new Content\Add_Post_Meta();` line inside the existing Content block, adjacent to `Update_Post_Meta` and the recently added `Delete_Post_Meta` (currently line 215–216).
+- 3 new `new Plugins\<Class>();` lines inside the existing Plugins block (currently lines 111–116 and 156–158).
+- 1 new `new Core\Verify_Core_Checksums();` line inside the existing Core block (currently lines 295–298).
+
+## Testing
+
+Under `tests/phpunit/abilities/`, one test file per ability. Golden-path + guardrail tests:
+- Transients: seed a transient via `set_transient()` in `setUp()`; `get-transient` returns the exact value + `exists: true`; `delete-transient` clears it; `list-transients` returns paginated results including seeded rows.
+- Nested options: seed a complex option via `update_option( 'test_opt', ['a' => ['b' => 'c']] )`; `get-nested-option-value` with `path: ['a', 'b']` returns `'c'`; `patch-option-value` with `operation: update, path: ['a', 'b'], value: 'd'` mutates only the target key.
+- `add-post-meta` with `unique: true` twice → second call returns `meta_id: false` (append blocked).
+- `uninstall-plugin` against an active plugin → rejected with actionable message.
+- `verify-core-checksums` mocks the HTTP fetch via `add_filter('pre_http_request', ...)` and verifies expected diff output.
+
+For plugin/core-checksums, HTTP layer mocked via `pre_http_request` filter (same pattern used in `tests/phpunit/abilities/Test_Feature_042_Core_Update.php`).
+
+Target: ~11 golden-path tests + ~10 guardrail tests.
+
+## Delivery
+
+Feature branch off `main`, no version bump — will be rolled into a single `release-0.0.23` alongside features 062 and 063. See `/Users/raftaar1191/.claude/plans/prepare-a-plan-for-refactored-fern.md` for the unified release plan.

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -114,6 +114,10 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Plugins\Update_Plugin();
 		new Plugins\List_Plugins();
 		new Plugins\Check_Plugin_Updates();
+		// Feature 064 — plugin lifecycle & integrity (3).
+		new Plugins\Search_Wp_Plugin_Directory();
+		new Plugins\Uninstall_Plugin();
+		new Plugins\Verify_Plugin_Checksums();
 		new Settings\Get_Permalink_Structure();
 		new Settings\Set_Permalink_Structure();
 		new Settings\Flush_Permalink_Structure();
@@ -140,6 +144,11 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Cache\Flush_Object_Cache();
 		new Cache\Flush_Transients();
 		new Cache\Flush_Rewrite_Rules();
+		// Feature 064 — transient CRUD (4).
+		new Cache\Get_Transient();
+		new Cache\List_Transients();
+		new Cache\Delete_Transient();
+		new Cache\Delete_Expired_Transients();
 		new Database\Extract_Db_Schema();
 		new Database\Run_Db_Select_Query();
 		new Database\Insert_Db_Row();
@@ -215,6 +224,8 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Content\Get_Post_Meta();
 		new Content\Update_Post_Meta();
 		new Content\Delete_Post_Meta();
+		// Feature 064 — post-meta append (1).
+		new Content\Add_Post_Meta();
 		new Content\Create_Page();
 		new Content\Get_Page();
 		new Content\List_Page_Revisions();
@@ -276,6 +287,9 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Options\Delete_Option();
 		new Options\List_Options();
 		new Options\Search_Options();
+		// Feature 064 — nested option access (2).
+		new Options\Get_Nested_Option_Value();
+		new Options\Patch_Option_Value();
 		new Cron\List_Cron_Jobs();
 		new Cron\Get_Cron_Job();
 		new Cron\Get_Next_Cron_Run();
@@ -297,6 +311,8 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Core\Update_Wp_Core();
 		new Core\Rollback_Wp_Core();
 		new Core\Reinstall_Wp_Core();
+		// Feature 064 — core integrity (1).
+		new Core\Verify_Core_Checksums();
 
 		// Feature 055 — 31 new abilities across 10 domains.
 		new Users\Get_Current_User_Access();

--- a/includes/Abilities/Cache/Delete_Expired_Transients.php
+++ b/includes/Abilities/Cache/Delete_Expired_Transients.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Feature 064 — Purge every expired transient in a single pass.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Cache
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Cache;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Purge every expired transient (blog + site scope) in one call. WP core's
+ * `delete_expired_transients()` returns `void`, so the pre-call count is
+ * captured directly against `$wpdb->options` before the purge runs and
+ * reported back as the `deleted` counter.
+ */
+class Delete_Expired_Transients extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/delete-expired-transients',
+			'args' => array(
+				'label'               => __( 'Delete Expired Transients', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Purge every expired transient (blog and site scope) in a single pass. Reports the count that were purged.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-cache',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'deleted' => array( 'type' => 'integer' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group' => 'cache',
+						'sub_group' => 'cache',
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		unset( $input );
+
+		global $wpdb;
+
+		$now = time();
+
+		// Capture count BEFORE calling core — delete_expired_transients()
+		// returns void, so we must snapshot the expired set first.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$blog_expired = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->options}
+				 WHERE option_name LIKE %s AND option_value < %d",
+				$wpdb->esc_like( '_transient_timeout_' ) . '%',
+				$now
+			)
+		);
+		$site_expired = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->options}
+				 WHERE option_name LIKE %s AND option_value < %d",
+				$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
+				$now
+			)
+		);
+		// phpcs:enable
+
+		$count = $blog_expired + $site_expired;
+
+		delete_expired_transients( true );
+
+		return array(
+			'success' => true,
+			'deleted' => $count,
+			'message' => sprintf(
+				/* translators: %d: number of expired transients purged */
+				_n( '%d expired transient purged.', '%d expired transients purged.', $count, 'acrossai-abilities-manager' ),
+				$count
+			),
+		);
+	}
+}

--- a/includes/Abilities/Cache/Delete_Transient.php
+++ b/includes/Abilities/Cache/Delete_Transient.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Feature 064 — Delete one transient by name.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Cache
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Cache;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Delete a single transient by name via delete_transient() or
+ * delete_site_transient() (selected by the `site` flag). Idempotent —
+ * WP core returns true for both a successful delete and a no-op delete
+ * once the underlying option no longer exists.
+ */
+class Delete_Transient extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/delete-transient',
+			'args' => array(
+				'label'               => __( 'Delete Transient', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Delete one transient by name via delete_transient() (or delete_site_transient() when site:true). Idempotent — succeeds even if the transient is already gone.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-cache',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'key'  => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'site' => array(
+							'type'    => 'boolean',
+							'default' => false,
+						),
+					),
+					'required'             => array( 'key' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'deleted' => array( 'type' => 'boolean' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group' => 'cache',
+						'sub_group' => 'cache',
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$key = sanitize_text_field( (string) ( $input['key'] ?? '' ) );
+		if ( '' === $key ) {
+			return array(
+				'success' => false,
+				'message' => __( 'key is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$site    = ! empty( $input['site'] );
+		$deleted = $site ? delete_site_transient( $key ) : delete_transient( $key );
+
+		return array(
+			'success' => true,
+			'deleted' => (bool) $deleted,
+			'message' => sprintf(
+				/* translators: %s: transient key */
+				__( 'Deleted transient "%s".', 'acrossai-abilities-manager' ),
+				$key
+			),
+		);
+	}
+}

--- a/includes/Abilities/Cache/Get_Transient.php
+++ b/includes/Abilities/Cache/Get_Transient.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Feature 064 — Read one transient by name.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Cache
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Cache;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Read one transient by name.
+ *
+ * Distinguishes an unset transient from a transient whose stored value is
+ * literally `false` by consulting the underlying option row for existence.
+ * Reads go through the WP core transient APIs so external object caches
+ * (Redis / Memcached) are honoured.
+ */
+class Get_Transient extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/get-transient',
+			'args' => array(
+				'label'               => __( 'Get Transient', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Read one transient by name via get_transient() (or get_site_transient() when site:true). Returns exists:false for absent entries so callers can distinguish that state from a transient whose stored value is literally false.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-cache',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'key'  => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'site' => array(
+							'type'    => 'boolean',
+							'default' => false,
+						),
+					),
+					'required'             => array( 'key' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'exists'     => array( 'type' => 'boolean' ),
+						'value'      => array( 'type' => array( 'string', 'integer', 'number', 'boolean', 'array', 'object', 'null' ) ),
+						'expires_at' => array( 'type' => array( 'integer', 'null' ) ),
+						'message'    => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group' => 'cache',
+						'sub_group' => 'cache',
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$key = sanitize_text_field( (string) ( $input['key'] ?? '' ) );
+		if ( '' === $key ) {
+			return array(
+				'success' => false,
+				'message' => __( 'key is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$site        = ! empty( $input['site'] );
+		$option_name = $site ? "_site_transient_{$key}" : "_transient_{$key}";
+		$timeout_key = $site ? "_site_transient_timeout_{$key}" : "_transient_timeout_{$key}";
+
+		$exists = null !== get_option( $option_name, null );
+		if ( ! $exists ) {
+			return array(
+				'success'    => true,
+				'exists'     => false,
+				'value'      => null,
+				'expires_at' => null,
+				'message'    => sprintf(
+					/* translators: %s: transient key */
+					__( 'Transient "%s" does not exist.', 'acrossai-abilities-manager' ),
+					$key
+				),
+			);
+		}
+
+		$value      = $site ? get_site_transient( $key ) : get_transient( $key );
+		$timeout    = (int) get_option( $timeout_key, 0 );
+		$expires_at = $timeout > 0 ? $timeout : null;
+
+		return array(
+			'success'    => true,
+			'exists'     => true,
+			'value'      => $value,
+			'expires_at' => $expires_at,
+			'message'    => sprintf(
+				/* translators: %s: transient key */
+				__( 'Read transient "%s".', 'acrossai-abilities-manager' ),
+				$key
+			),
+		);
+	}
+}

--- a/includes/Abilities/Cache/List_Transients.php
+++ b/includes/Abilities/Cache/List_Transients.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Feature 064 — Enumerate transients stored on the site.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Cache
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Cache;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enumerate transients (blog- and site-scope) with expiry metadata.
+ *
+ * WP core provides no `list_transients()` helper — this ability queries
+ * `$wpdb->options` directly via `$wpdb->prepare()` with an escaped LIKE
+ * pattern. Companion `_transient_timeout_*` rows are filtered out of the
+ * returned set but joined in as `expires_at` on the parent row.
+ */
+class List_Transients extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/list-transients',
+			'args' => array(
+				'label'               => __( 'List Transients', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Enumerate every transient (or site-transient) stored on the site with expiry metadata. Supports substring search, blog/site-scope filter, include-expired toggle, and pagination.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-cache',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'search'          => array( 'type' => 'string' ),
+						'limit'           => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => 500,
+							'default' => 100,
+						),
+						'offset'          => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+							'default' => 0,
+						),
+						'site_only'       => array(
+							'type'    => 'boolean',
+							'default' => false,
+						),
+						'include_expired' => array(
+							'type'    => 'boolean',
+							'default' => true,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'transients' => array( 'type' => 'array' ),
+						'count'      => array( 'type' => 'integer' ),
+						'total'      => array( 'type' => 'integer' ),
+						'message'    => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group' => 'cache',
+						'sub_group' => 'cache',
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		global $wpdb;
+
+		$search          = sanitize_text_field( (string) ( $input['search'] ?? '' ) );
+		$limit           = isset( $input['limit'] ) ? max( 1, min( 500, (int) $input['limit'] ) ) : 100;
+		$offset          = isset( $input['offset'] ) ? max( 0, (int) $input['offset'] ) : 0;
+		$site_only       = ! empty( $input['site_only'] );
+		$include_expired = ! isset( $input['include_expired'] ) || ! empty( $input['include_expired'] );
+
+		$blog_like = $wpdb->esc_like( '_transient_' ) . '%';
+		$site_like = $wpdb->esc_like( '_site_transient_' ) . '%';
+
+		// Build WHERE clause. We deliberately over-fetch (LIMIT * 2) because
+		// we still need to filter out timeout companion rows in PHP.
+		$where_clauses = array();
+		$where_args    = array();
+
+		if ( $site_only ) {
+			$where_clauses[] = 'option_name LIKE %s';
+			$where_args[]    = $site_like;
+		} else {
+			$where_clauses[] = '(option_name LIKE %s OR option_name LIKE %s)';
+			$where_args[]    = $blog_like;
+			$where_args[]    = $site_like;
+		}
+
+		if ( '' !== $search ) {
+			$where_clauses[] = 'option_name LIKE %s';
+			$where_args[]    = '%' . $wpdb->esc_like( $search ) . '%';
+		}
+
+		$where_sql = implode( ' AND ', $where_clauses );
+
+		// Fetch all candidate rows (timeout + value together) so we can join
+		// expiry in PHP without a second SQL round-trip per transient.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$all_rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT option_name, option_value FROM {$wpdb->options} WHERE {$where_sql} ORDER BY option_name",
+				$where_args
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+
+		if ( ! is_array( $all_rows ) ) {
+			$all_rows = array();
+		}
+
+		// Index timeout rows keyed by the transient name they gate.
+		$timeouts = array();
+		foreach ( $all_rows as $row ) {
+			$name = (string) $row['option_name'];
+			if ( str_starts_with( $name, '_site_transient_timeout_' ) ) {
+				$timeouts[ substr( $name, strlen( '_site_transient_timeout_' ) ) . '::site' ] = (int) $row['option_value'];
+			} elseif ( str_starts_with( $name, '_transient_timeout_' ) ) {
+				$timeouts[ substr( $name, strlen( '_transient_timeout_' ) ) . '::blog' ] = (int) $row['option_value'];
+			}
+		}
+
+		$now         = time();
+		$transients  = array();
+		foreach ( $all_rows as $row ) {
+			$name = (string) $row['option_name'];
+
+			// Skip companion timeout rows in the returned set.
+			if ( str_starts_with( $name, '_site_transient_timeout_' ) || str_starts_with( $name, '_transient_timeout_' ) ) {
+				continue;
+			}
+
+			if ( str_starts_with( $name, '_site_transient_' ) ) {
+				$transient_name = substr( $name, strlen( '_site_transient_' ) );
+				$is_site        = true;
+				$timeout        = $timeouts[ $transient_name . '::site' ] ?? 0;
+			} elseif ( str_starts_with( $name, '_transient_' ) ) {
+				$transient_name = substr( $name, strlen( '_transient_' ) );
+				$is_site        = false;
+				$timeout        = $timeouts[ $transient_name . '::blog' ] ?? 0;
+			} else {
+				continue;
+			}
+
+			$is_expired = $timeout > 0 && $timeout < $now;
+			if ( ! $include_expired && $is_expired ) {
+				continue;
+			}
+
+			$transients[] = array(
+				'name'       => $transient_name,
+				'expires_at' => $timeout > 0 ? $timeout : null,
+				'is_site'    => $is_site,
+				'is_expired' => $is_expired,
+			);
+		}
+
+		$total = count( $transients );
+
+		// Apply pagination in PHP (dataset already bounded by WHERE clause).
+		$page = array_slice( $transients, $offset, $limit );
+
+		return array(
+			'success'    => true,
+			'transients' => $page,
+			'count'      => count( $page ),
+			'total'      => $total,
+			'message'    => sprintf(
+				/* translators: 1: page size, 2: total */
+				__( 'Returned %1$d of %2$d transient(s).', 'acrossai-abilities-manager' ),
+				count( $page ),
+				$total
+			),
+		);
+	}
+}

--- a/includes/Abilities/Content/Add_Post_Meta.php
+++ b/includes/Abilities/Content/Add_Post_Meta.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Feature 064 — Append a new post-meta row without replacing existing rows.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Content
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Append a new post-meta row via add_post_meta(). Complements the existing
+ * update-post-meta (replace) and delete-post-meta (remove) writers. Mirrors
+ * the input-schema surface of Update_Post_Meta.php verbatim (accepts both
+ * `key`/`value` WP-CLI aliases and `meta_key`/`meta_value` WP-core aliases)
+ * plus a `unique` flag that maps to WordPress core `add_post_meta( ..., $unique )`.
+ */
+class Add_Post_Meta extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/add-post-meta',
+			'args' => array(
+				'label'               => __( 'Add Post Meta', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Append a new post-meta row via add_post_meta() — additive, does not replace existing rows for the same key. Set unique:true to refuse the append if any row already exists for the (post_id, key) pair (matches WordPress core add_post_meta( ..., true ) behaviour).', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'    => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'key'        => array( 'type' => 'string' ),
+						'meta_key'   => array(
+							'type'        => 'string',
+							'description' => __( 'Alias for "key" (matches WordPress core naming). If both are provided, "key" wins.', 'acrossai-abilities-manager' ),
+						),
+						'value'      => array( 'type' => array( 'string', 'integer', 'number', 'boolean', 'array', 'object', 'null' ) ),
+						'meta_value' => array(
+							'type'        => array( 'string', 'integer', 'number', 'boolean', 'array', 'object', 'null' ),
+							'description' => __( 'Alias for "value" (matches WordPress core naming). If both are provided, "value" wins.', 'acrossai-abilities-manager' ),
+						),
+						'unique'     => array(
+							'type'    => 'boolean',
+							'default' => false,
+						),
+					),
+					'allOf'                => array(
+						array( 'required' => array( 'post_id' ) ),
+						array(
+							'anyOf' => array(
+								array( 'required' => array( 'key' ) ),
+								array( 'required' => array( 'meta_key' ) ),
+							),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'meta_id' => array( 'type' => array( 'integer', 'boolean' ) ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'posts',
+						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id = (int) ( $input['post_id'] ?? 0 );
+		$raw_key = ! empty( $input['key'] ) ? $input['key'] : ( $input['meta_key'] ?? '' );
+		$key     = sanitize_text_field( (string) $raw_key );
+
+		if ( $post_id <= 0 || ! get_post( $post_id ) ) {
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: %d: post id */
+					__( 'Post #%d not found.', 'acrossai-abilities-manager' ),
+					$post_id
+				),
+			);
+		}
+		if ( '' === $key ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Meta key is empty. Pass "key" (or its alias "meta_key").', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$value  = array_key_exists( 'value', $input ) ? $input['value'] : ( $input['meta_value'] ?? '' );
+		$unique = ! empty( $input['unique'] );
+
+		$meta_id = add_post_meta( $post_id, $key, $value, $unique );
+
+		return array(
+			'success' => true,
+			'meta_id' => false === $meta_id ? false : (int) $meta_id,
+			'message' => false === $meta_id
+				? sprintf(
+					/* translators: 1: meta key, 2: post id */
+					__( 'Append refused — a row for "%1$s" already exists on post #%2$d and unique:true was set.', 'acrossai-abilities-manager' ),
+					$key,
+					$post_id
+				)
+				: sprintf(
+					/* translators: 1: meta key, 2: post id */
+					__( 'Appended meta row for "%1$s" on post #%2$d.', 'acrossai-abilities-manager' ),
+					$key,
+					$post_id
+				),
+		);
+	}
+}

--- a/includes/Abilities/Core/Verify_Core_Checksums.php
+++ b/includes/Abilities/Core/Verify_Core_Checksums.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Feature 064 — Verify WordPress core files against the official checksums
+ * manifest.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Core
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Core;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Verify WordPress core files against the manifest returned by
+ * get_core_checksums() from wp-admin/includes/update.php. Same diff
+ * algorithm as Verify_Plugin_Checksums; paths are relative to ABSPATH.
+ *
+ * Honours:
+ *   - version: defaults to the installed core version.
+ *   - locale:  defaults to 'en_US'.
+ *   - include_root: when false (default), root-level files like wp-config.php
+ *     and .htaccess are skipped so custom deploys don't produce noise.
+ *   - exclude: additional paths to skip.
+ *   - strict: when true, files present on disk but absent from the manifest
+ *     are flagged with status:'added'.
+ */
+class Verify_Core_Checksums extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/verify-core-checksums',
+			'args' => array(
+				'label'               => __( 'Verify Core Checksums', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Verify WordPress core files against the official checksums manifest returned by get_core_checksums(). Per-file status: ok / modified / missing / added. Skips root-level files by default (set include_root:true to include them).', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-core',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'version'      => array( 'type' => 'string' ),
+						'locale'       => array( 'type' => 'string' ),
+						'include_root' => array(
+							'type'    => 'boolean',
+							'default' => false,
+						),
+						'exclude'      => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'strict'       => array(
+							'type'    => 'boolean',
+							'default' => false,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'version' => array( 'type' => 'string' ),
+						'locale'  => array( 'type' => 'string' ),
+						'results' => array( 'type' => 'array' ),
+						'summary' => array( 'type' => 'object' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'integrity',
+						'sub_group_label' => __( 'Integrity', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$version_input = isset( $input['version'] ) ? sanitize_text_field( (string) $input['version'] ) : '';
+		$locale_input  = isset( $input['locale'] ) ? sanitize_text_field( (string) $input['locale'] ) : '';
+		$version       = '' !== $version_input ? $version_input : (string) get_bloginfo( 'version' );
+		$locale        = '' !== $locale_input ? $locale_input : 'en_US';
+		$include_root  = ! empty( $input['include_root'] );
+		$strict        = ! empty( $input['strict'] );
+
+		$exclude_raw = isset( $input['exclude'] ) && is_array( $input['exclude'] ) ? $input['exclude'] : array();
+		$exclude     = array_map(
+			static function ( $entry ): string {
+				return sanitize_text_field( (string) $entry );
+			},
+			$exclude_raw
+		);
+
+		require_once ABSPATH . 'wp-admin/includes/update.php';
+
+		$manifest = get_core_checksums( $version, $locale );
+
+		$empty_summary = array(
+			'total'    => 0,
+			'ok'       => 0,
+			'modified' => 0,
+			'missing'  => 0,
+			'added'    => 0,
+		);
+
+		if ( ! is_array( $manifest ) || empty( $manifest ) ) {
+			return array(
+				'success' => true,
+				'version' => $version,
+				'locale'  => $locale,
+				'results' => array(),
+				'summary' => $empty_summary,
+				'message' => 'no_manifest',
+			);
+		}
+
+		$results = array();
+		$summary = $empty_summary;
+
+		foreach ( $manifest as $file => $expected_hash ) {
+			$file          = (string) $file;
+			$expected_hash = (string) $expected_hash;
+
+			if ( ! $include_root && false === strpos( $file, '/' ) ) {
+				continue;
+			}
+			if ( in_array( $file, $exclude, true ) ) {
+				continue;
+			}
+
+			$disk_path = ABSPATH . $file;
+			if ( ! file_exists( $disk_path ) ) {
+				$results[] = array(
+					'file'     => $file,
+					'expected' => $expected_hash,
+					'actual'   => '',
+					'status'   => 'missing',
+				);
+				++$summary['missing'];
+				continue;
+			}
+
+			$actual_hash = (string) md5_file( $disk_path );
+			$status      = hash_equals( $expected_hash, $actual_hash ) ? 'ok' : 'modified';
+			$results[]   = array(
+				'file'     => $file,
+				'expected' => $expected_hash,
+				'actual'   => $actual_hash,
+				'status'   => $status,
+			);
+			++$summary[ $status ];
+		}
+
+		if ( $strict ) {
+			$manifest_files = array_map( 'strval', array_keys( $manifest ) );
+			// Only scan wp-admin/ and wp-includes/ for "added" files — walking
+			// the whole ABSPATH would drown the caller in project files.
+			foreach ( array( 'wp-admin', 'wp-includes' ) as $scan_dir ) {
+				$abs_dir = ABSPATH . $scan_dir;
+				if ( ! is_dir( $abs_dir ) ) {
+					continue;
+				}
+				$disk_files = self::list_files_recursive( $abs_dir, $scan_dir . '/' );
+				$added      = array_diff( $disk_files, $manifest_files );
+				foreach ( $added as $file ) {
+					if ( in_array( $file, $exclude, true ) ) {
+						continue;
+					}
+					$results[] = array(
+						'file'     => $file,
+						'expected' => '',
+						'actual'   => (string) md5_file( ABSPATH . $file ),
+						'status'   => 'added',
+					);
+					++$summary['added'];
+				}
+			}
+		}
+
+		$summary['total'] = count( $results );
+
+		return array(
+			'success' => true,
+			'version' => $version,
+			'locale'  => $locale,
+			'results' => $results,
+			'summary' => $summary,
+			'message' => sprintf(
+				/* translators: 1: version, 2: locale, 3: total */
+				__( 'Verified %3$d core file(s) at version "%1$s" (%2$s).', 'acrossai-abilities-manager' ),
+				$version,
+				$locale,
+				$summary['total']
+			),
+		);
+	}
+
+	/**
+	 * List every file under $dir with a caller-supplied path prefix.
+	 *
+	 * @param string $dir    Absolute directory path.
+	 * @param string $prefix String prepended to each returned path (e.g. 'wp-admin/').
+	 * @return string[]
+	 */
+	private static function list_files_recursive( string $dir, string $prefix ): array {
+		if ( ! is_dir( $dir ) ) {
+			return array();
+		}
+		$files = array();
+		$iter  = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::SKIP_DOTS )
+		);
+		$prefix_len = strlen( $dir ) + 1;
+		foreach ( $iter as $item ) {
+			if ( $item->isFile() ) {
+				$files[] = $prefix . substr( $item->getPathname(), $prefix_len );
+			}
+		}
+		return $files;
+	}
+}

--- a/includes/Abilities/Options/Get_Nested_Option_Value.php
+++ b/includes/Abilities/Options/Get_Nested_Option_Value.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Feature 064 — Read one nested key inside a serialized-array option.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Options
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Options;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Walks a serialized option's nested structure along a caller-supplied
+ * key path and returns the leaf value together with an exists flag.
+ *
+ * The `path` is an array of strings — each element is one array-key or
+ * public-object-property to descend into, in order. Numeric keys are
+ * accepted as their string form ("0", "1", ...); PHP array access
+ * normalises both.
+ */
+class Get_Nested_Option_Value extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/get-nested-option-value',
+			'args' => array(
+				'label'               => __( 'Get Nested Option Value', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Read one nested key inside a serialized-array option without transferring the whole option. path is an array of string keys walked in order (e.g. ["a","b","c"]).', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-options',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'option' => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'path'   => array(
+							'type'     => 'array',
+							'items'    => array( 'type' => 'string' ),
+							'minItems' => 1,
+						),
+					),
+					'required'             => array( 'option', 'path' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'exists'  => array( 'type' => 'boolean' ),
+						'value'   => array( 'type' => array( 'string', 'integer', 'number', 'boolean', 'array', 'object', 'null' ) ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'manage',
+						'sub_group_label' => __( 'Manage', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$option = sanitize_text_field( (string) ( $input['option'] ?? '' ) );
+		if ( '' === $option ) {
+			return array(
+				'success' => false,
+				'message' => __( 'option is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$raw_path = isset( $input['path'] ) && is_array( $input['path'] ) ? $input['path'] : array();
+		if ( empty( $raw_path ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'path must be a non-empty array of string keys.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$path = array_map(
+			static function ( $segment ): string {
+				return sanitize_text_field( (string) $segment );
+			},
+			$raw_path
+		);
+
+		$option_value = get_option( $option, null );
+		if ( null === $option_value ) {
+			return array(
+				'success' => true,
+				'exists'  => false,
+				'value'   => null,
+				'message' => sprintf(
+					/* translators: %s: option name */
+					__( 'Option "%s" does not exist.', 'acrossai-abilities-manager' ),
+					$option
+				),
+			);
+		}
+
+		$cursor = $option_value;
+		foreach ( $path as $segment ) {
+			if ( is_array( $cursor ) && array_key_exists( $segment, $cursor ) ) {
+				$cursor = $cursor[ $segment ];
+				continue;
+			}
+			if ( $cursor instanceof \ArrayAccess && $cursor->offsetExists( $segment ) ) {
+				$cursor = $cursor->offsetGet( $segment );
+				continue;
+			}
+			if ( is_object( $cursor ) && property_exists( $cursor, $segment ) ) {
+				$cursor = $cursor->{$segment};
+				continue;
+			}
+			return array(
+				'success' => true,
+				'exists'  => false,
+				'value'   => null,
+				'message' => sprintf(
+					/* translators: 1: option name, 2: path */
+					__( 'Nested key not found at "%1$s" -> %2$s.', 'acrossai-abilities-manager' ),
+					$option,
+					implode( '.', $path )
+				),
+			);
+		}
+
+		return array(
+			'success' => true,
+			'exists'  => true,
+			'value'   => $cursor,
+			'message' => sprintf(
+				/* translators: 1: option name, 2: path */
+				__( 'Read "%1$s" -> %2$s.', 'acrossai-abilities-manager' ),
+				$option,
+				implode( '.', $path )
+			),
+		);
+	}
+}

--- a/includes/Abilities/Options/Patch_Option_Value.php
+++ b/includes/Abilities/Options/Patch_Option_Value.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Feature 064 — Insert, update, or delete a single nested value inside a
+ * serialized option.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Options
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Options;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Mutate one nested key inside a serialized option (insert / update / delete)
+ * without touching any other key.
+ *
+ * Guardrails, in order:
+ *   1. Empty path -> `blocked_reason: empty_path`.
+ *   2. Option name in Update_Option::BLOCKED_OPTIONS ->
+ *      `blocked_reason: blocked_option`.
+ *   3. Any intermediate node along the path is not array-like ->
+ *      `blocked_reason: non_traversable_intermediate`.
+ */
+class Patch_Option_Value extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/patch-option-value',
+			'args' => array(
+				'label'               => __( 'Patch Option Value', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Insert, update, or delete a single value inside a serialized-array option at a caller-supplied key path — without touching any other key. Refuses to operate on options in the shared block-list of protected core options.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-options',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'option'    => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'operation' => array(
+							'type' => 'string',
+							'enum' => array( 'insert', 'update', 'delete' ),
+						),
+						'path'      => array(
+							'type'     => 'array',
+							'items'    => array( 'type' => 'string' ),
+							'minItems' => 1,
+						),
+						'value'     => array( 'type' => array( 'string', 'integer', 'number', 'boolean', 'array', 'object', 'null' ) ),
+					),
+					'required'             => array( 'option', 'operation', 'path' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'message'        => array( 'type' => 'string' ),
+						'blocked_reason' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'manage',
+						'sub_group_label' => __( 'Manage', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$option = sanitize_text_field( (string) ( $input['option'] ?? '' ) );
+		if ( '' === $option ) {
+			return array(
+				'success' => false,
+				'message' => __( 'option is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$operation = sanitize_text_field( (string) ( $input['operation'] ?? '' ) );
+		if ( ! in_array( $operation, array( 'insert', 'update', 'delete' ), true ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'operation must be one of: insert, update, delete.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$raw_path = isset( $input['path'] ) && is_array( $input['path'] ) ? $input['path'] : array();
+		if ( empty( $raw_path ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'empty_path',
+				'message'        => __( 'path must be a non-empty array of string keys.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$path = array_values(
+			array_map(
+				static function ( $segment ): string {
+					return sanitize_text_field( (string) $segment );
+				},
+				$raw_path
+			)
+		);
+
+		if ( in_array( $option, Update_Option::BLOCKED_OPTIONS, true ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'blocked_option',
+				'message'        => sprintf(
+					/* translators: %s: option name */
+					__( 'Option "%s" is protected and cannot be patched through this ability.', 'acrossai-abilities-manager' ),
+					$option
+				),
+			);
+		}
+
+		$current = get_option( $option, null );
+		$root    = null === $current ? array() : $current;
+		if ( ! is_array( $root ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'non_traversable_intermediate',
+				'message'        => sprintf(
+					/* translators: %s: option name */
+					__( 'Option "%s" is not an array — nested patching requires an array-shaped root.', 'acrossai-abilities-manager' ),
+					$option
+				),
+			);
+		}
+
+		// Walk down to the parent of the leaf, creating empty arrays for
+		// missing intermediates only during insert/update. For delete we
+		// early-return success when any intermediate is missing (nothing to
+		// remove).
+		$leaf_key      = array_pop( $path );
+		$cursor        = &$root;
+		$intermediates = $path;
+		foreach ( $intermediates as $segment ) {
+			if ( ! is_array( $cursor ) ) {
+				return array(
+					'success'        => false,
+					'blocked_reason' => 'non_traversable_intermediate',
+					'message'        => __( 'Cannot traverse into a non-array intermediate value.', 'acrossai-abilities-manager' ),
+				);
+			}
+
+			if ( ! array_key_exists( $segment, $cursor ) ) {
+				if ( 'delete' === $operation ) {
+					return array(
+						'success' => true,
+						'message' => __( 'Nothing to delete — intermediate key is absent.', 'acrossai-abilities-manager' ),
+					);
+				}
+				$cursor[ $segment ] = array();
+			}
+
+			if ( ! is_array( $cursor[ $segment ] ) ) {
+				return array(
+					'success'        => false,
+					'blocked_reason' => 'non_traversable_intermediate',
+					'message'        => __( 'Cannot traverse into a non-array intermediate value.', 'acrossai-abilities-manager' ),
+				);
+			}
+
+			$cursor = &$cursor[ $segment ];
+		}
+
+		if ( ! is_array( $cursor ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'non_traversable_intermediate',
+				'message'        => __( 'Cannot mutate a leaf whose parent is not an array.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$leaf_exists = array_key_exists( (string) $leaf_key, $cursor );
+
+		switch ( $operation ) {
+			case 'insert':
+				if ( $leaf_exists ) {
+					return array(
+						'success'        => false,
+						'blocked_reason' => 'key_exists',
+						'message'        => __( 'Cannot insert — leaf key already exists. Use operation:update to overwrite.', 'acrossai-abilities-manager' ),
+					);
+				}
+				$cursor[ (string) $leaf_key ] = $input['value'] ?? null;
+				break;
+
+			case 'update':
+				// Update creates the leaf if missing (per spec) — no guardrail here.
+				$cursor[ (string) $leaf_key ] = $input['value'] ?? null;
+				break;
+
+			case 'delete':
+				if ( ! $leaf_exists ) {
+					return array(
+						'success' => true,
+						'message' => __( 'Nothing to delete — leaf key is absent.', 'acrossai-abilities-manager' ),
+					);
+				}
+				unset( $cursor[ (string) $leaf_key ] );
+				break;
+		}
+
+		unset( $cursor );
+
+		update_option( $option, $root );
+
+		return array(
+			'success' => true,
+			'message' => sprintf(
+				/* translators: 1: operation verb, 2: option name */
+				__( 'Applied %1$s to option "%2$s".', 'acrossai-abilities-manager' ),
+				$operation,
+				$option
+			),
+		);
+	}
+}

--- a/includes/Abilities/Options/Update_Option.php
+++ b/includes/Abilities/Options/Update_Option.php
@@ -20,6 +20,44 @@ defined( 'ABSPATH' ) || exit;
 class Update_Option extends Ability_Definition {
 
 	/**
+	 * Canonical block-list of protected core option names that must never be
+	 * mutated through the ability layer. Consumed by Patch_Option_Value (which
+	 * mirrors this ability's guardrail surface) so both writers refuse the
+	 * same set.
+	 *
+	 * Kept intentionally narrow — every entry is either load-bearing for site
+	 * boot (siteurl / home / blogname / template / stylesheet) or a security
+	 * surface WP core owns (active_plugins, users_can_register, secret keys,
+	 * db_version). Add sparingly and only for entries that would break a live
+	 * site if a caller mutated them via the abilities API.
+	 *
+	 * @var string[]
+	 */
+	public const BLOCKED_OPTIONS = array(
+		'siteurl',
+		'home',
+		'blogname',
+		'blogdescription',
+		'admin_email',
+		'template',
+		'stylesheet',
+		'current_theme',
+		'active_plugins',
+		'users_can_register',
+		'default_role',
+		'db_version',
+		'secret',
+		'auth_key',
+		'auth_salt',
+		'logged_in_key',
+		'logged_in_salt',
+		'nonce_key',
+		'nonce_salt',
+		'secure_auth_key',
+		'secure_auth_salt',
+	);
+
+	/**
 	 * Full ability spec for wp_register_ability().
 	 *
 	 * @return array

--- a/includes/Abilities/Plugins/Search_Wp_Plugin_Directory.php
+++ b/includes/Abilities/Plugins/Search_Wp_Plugin_Directory.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Feature 064 — Search the WordPress.org plugin directory.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Plugins
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Plugins;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Query the WordPress.org plugin directory via plugins_api( 'query_plugins',
+ * ... ). Explicitly requests only the display-relevant fields so payload size
+ * stays bounded (~1KB per plugin). Sanitizes `short_description` through
+ * wp_kses_post() because WordPress.org serves HTML there.
+ *
+ * When the underlying WordPress.org call fails, the ability still returns
+ * success:true with an empty plugins list and the transport error in the
+ * message field — callers distinguish "no results" from "unreachable API"
+ * by inspecting the message string.
+ */
+class Search_Wp_Plugin_Directory extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/search-wp-plugin-directory',
+			'args' => array(
+				'label'               => __( 'Search WordPress.org Plugin Directory', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Search the WordPress.org plugin directory. Returns slug, name, short_description, rating, active_installs, homepage, and download_link for each hit, plus pagination metadata.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-plugins',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'query'    => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'per_page' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => 100,
+							'default' => 10,
+						),
+						'page'     => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'default' => 1,
+						),
+					),
+					'required'             => array( 'query' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'plugins' => array( 'type' => 'array' ),
+						'info'    => array( 'type' => 'object' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'plugins',
+						'sub_group'       => 'lifecycle',
+						'sub_group_label' => __( 'Lifecycle', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$query = sanitize_text_field( (string) ( $input['query'] ?? '' ) );
+		if ( '' === $query ) {
+			return array(
+				'success' => false,
+				'message' => __( 'query is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$per_page = isset( $input['per_page'] ) ? max( 1, min( 100, (int) $input['per_page'] ) ) : 10;
+		$page     = isset( $input['page'] ) ? max( 1, (int) $input['page'] ) : 1;
+
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+
+		$result = plugins_api(
+			'query_plugins',
+			array(
+				'search'   => $query,
+				'per_page' => $per_page,
+				'page'     => $page,
+				'fields'   => array(
+					'slug'              => true,
+					'name'              => true,
+					'short_description' => true,
+					'rating'            => true,
+					'active_installs'   => true,
+					'homepage'          => true,
+					'download_link'     => true,
+					'sections'          => false,
+					'screenshots'       => false,
+					'banners'           => false,
+					'icons'             => false,
+					'compatibility'     => false,
+					'tested'            => false,
+					'requires'          => false,
+					'requires_php'      => false,
+					'tags'              => false,
+					'contributors'      => false,
+					'last_updated'      => false,
+					'downloaded'        => false,
+					'added'             => false,
+					'author'            => false,
+					'author_profile'    => false,
+					'versions'          => false,
+					'donate_link'       => false,
+					'reviews'           => false,
+				),
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success' => true,
+				'plugins' => array(),
+				'info'    => array(
+					'page'    => $page,
+					'pages'   => 0,
+					'results' => 0,
+				),
+				'message' => sprintf(
+					/* translators: 1: query, 2: error message */
+					__( 'WordPress.org search for "%1$s" failed: %2$s', 'acrossai-abilities-manager' ),
+					$query,
+					$result->get_error_message()
+				),
+			);
+		}
+
+		$plugins_raw = array();
+		if ( is_object( $result ) && isset( $result->plugins ) && is_array( $result->plugins ) ) {
+			$plugins_raw = $result->plugins;
+		}
+
+		$plugins = array();
+		foreach ( $plugins_raw as $entry ) {
+			$row = is_array( $entry ) ? $entry : (array) $entry;
+
+			$plugins[] = array(
+				'slug'              => isset( $row['slug'] ) ? (string) $row['slug'] : '',
+				'name'              => isset( $row['name'] ) ? wp_strip_all_tags( (string) $row['name'] ) : '',
+				'short_description' => isset( $row['short_description'] ) ? wp_kses_post( (string) $row['short_description'] ) : '',
+				'rating'            => isset( $row['rating'] ) ? (int) $row['rating'] : 0,
+				'active_installs'   => isset( $row['active_installs'] ) ? (int) $row['active_installs'] : 0,
+				'homepage'          => isset( $row['homepage'] ) ? esc_url_raw( (string) $row['homepage'] ) : '',
+				'download_link'     => isset( $row['download_link'] ) ? esc_url_raw( (string) $row['download_link'] ) : '',
+			);
+		}
+
+		$info = array(
+			'page'    => $page,
+			'pages'   => is_object( $result ) && isset( $result->info['pages'] ) ? (int) $result->info['pages'] : 1,
+			'results' => is_object( $result ) && isset( $result->info['results'] ) ? (int) $result->info['results'] : count( $plugins ),
+		);
+
+		return array(
+			'success' => true,
+			'plugins' => $plugins,
+			'info'    => $info,
+			'message' => sprintf(
+				/* translators: 1: number of results, 2: query */
+				__( 'Returned %1$d plugin(s) for "%2$s".', 'acrossai-abilities-manager' ),
+				count( $plugins ),
+				$query
+			),
+		);
+	}
+}

--- a/includes/Abilities/Plugins/Uninstall_Plugin.php
+++ b/includes/Abilities/Plugins/Uninstall_Plugin.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Feature 064 — Uninstall a plugin (fires uninstall hook + deletes files).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Plugins
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Plugins;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Plugin_Helpers;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Uninstall a plugin by fuzzy identifier. Wraps WP core's own
+ * uninstall_plugin() from wp-admin/includes/plugin.php so the plugin's
+ * registered uninstall hook fires and its files are deleted.
+ *
+ * Guardrails, in order:
+ *   1. File_Mods_Guard::blocked_response('install') -> file_mods_disallowed.
+ *   2. Plugin_Helpers::resolve_plugin() returns null (or low certainty) ->
+ *      plugin_not_found.
+ *   3. is_plugin_active() -> plugin_active (caller must deactivate first).
+ */
+class Uninstall_Plugin extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/uninstall-plugin',
+			'args' => array(
+				'label'               => __( 'Uninstall Plugin', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Uninstall a plugin (fires its uninstall hook and deletes its files) via WordPress core uninstall_plugin(). Distinct from deactivate-plugin (which only flips active_plugins). Refuses on active plugins and honours DISALLOW_FILE_MODS.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-plugins',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'plugin'      => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'delete_data' => array(
+							'type'    => 'boolean',
+							'default' => true,
+						),
+					),
+					'required'             => array( 'plugin' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'uninstalled'    => array( 'type' => 'boolean' ),
+						'plugin_file'    => array( 'type' => array( 'string', 'null' ) ),
+						'plugin_name'    => array( 'type' => array( 'string', 'null' ) ),
+						'message'        => array( 'type' => 'string' ),
+						'blocked_reason' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'plugins',
+						'sub_group'       => 'lifecycle',
+						'sub_group_label' => __( 'Lifecycle', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response( 'install' );
+		if ( null !== $blocked ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'file_mods_disallowed',
+				'message'        => $blocked['message'],
+			);
+		}
+
+		$identifier = sanitize_text_field( (string) ( $input['plugin'] ?? '' ) );
+		if ( '' === $identifier ) {
+			return array(
+				'success' => false,
+				'message' => __( 'plugin is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$resolved = Plugin_Helpers::resolve_plugin( $identifier );
+		if ( null === $resolved['plugin_file'] || $resolved['certainty'] < 8.0 ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'plugin_not_found',
+				'plugin_file'    => null,
+				'plugin_name'    => null,
+				'message'        => sprintf(
+					/* translators: %s: input identifier */
+					__( 'No plugin found matching "%s". Pass a more specific slug or the full plugin_file value.', 'acrossai-abilities-manager' ),
+					$identifier
+				),
+			);
+		}
+
+		$plugin_file = (string) $resolved['plugin_file'];
+		$plugin_name = (string) $resolved['plugin_name'];
+
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		if ( is_plugin_active( $plugin_file ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'plugin_active',
+				'plugin_file'    => $plugin_file,
+				'plugin_name'    => $plugin_name,
+				'message'        => sprintf(
+					/* translators: %s: plugin name */
+					__( 'Plugin "%s" is currently active. Deactivate it via acrossai/deactivate-plugin before uninstalling.', 'acrossai-abilities-manager' ),
+					$plugin_name
+				),
+			);
+		}
+
+		$result = uninstall_plugin( $plugin_file );
+
+		if ( is_wp_error( $result ) ) {
+			return array(
+				'success'     => false,
+				'uninstalled' => false,
+				'plugin_file' => $plugin_file,
+				'plugin_name' => $plugin_name,
+				'message'     => sprintf(
+					/* translators: 1: plugin name, 2: error message */
+					__( 'Failed to uninstall "%1$s": %2$s', 'acrossai-abilities-manager' ),
+					$plugin_name,
+					$result->get_error_message()
+				),
+			);
+		}
+
+		// uninstall_plugin() returns true on hook-based path, void on the
+		// uninstall.php-file path. Both count as success.
+		return array(
+			'success'     => true,
+			'uninstalled' => true,
+			'plugin_file' => $plugin_file,
+			'plugin_name' => $plugin_name,
+			'message'     => sprintf(
+				/* translators: %s: plugin name */
+				__( 'Uninstalled plugin "%s".', 'acrossai-abilities-manager' ),
+				$plugin_name
+			),
+		);
+	}
+}

--- a/includes/Abilities/Plugins/Verify_Plugin_Checksums.php
+++ b/includes/Abilities/Plugins/Verify_Plugin_Checksums.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * Feature 064 — Verify a plugin's on-disk files against the WordPress.org
+ * checksums manifest.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Plugins
+ * @since      0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Plugins;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Plugin_Helpers;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Verify a plugin's files against the WordPress.org checksums manifest.
+ *
+ * Fetches the expected manifest via wp_remote_get() against
+ * https://api.wordpress.org/plugins/checksums/1.0/. For each entry in the
+ * manifest, md5_file() the on-disk path and compare. Emits per-file
+ * status: 'ok' | 'modified' | 'missing' | 'added' (added only when
+ * strict:true and the file is present on disk but absent from the manifest).
+ *
+ * Plugins not hosted on WordPress.org will return an empty manifest — the
+ * ability then reports success:true, results:[], message:'no_manifest' so
+ * the caller learns the check cannot be performed.
+ */
+class Verify_Plugin_Checksums extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/verify-plugin-checksums',
+			'args' => array(
+				'label'               => __( 'Verify Plugin Checksums', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Verify an installed plugin\'s on-disk files against the official WordPress.org checksums manifest. Per-file status: ok / modified / missing / added (added only when strict:true). Plugins without a WP.org manifest report success:true with results:[] and message:"no_manifest".', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-plugins',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'plugin' => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'strict' => array(
+							'type'    => 'boolean',
+							'default' => false,
+						),
+					),
+					'required'             => array( 'plugin' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'plugin'  => array( 'type' => 'string' ),
+						'version' => array( 'type' => 'string' ),
+						'results' => array( 'type' => 'array' ),
+						'summary' => array( 'type' => 'object' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'plugins',
+						'sub_group'       => 'integrity',
+						'sub_group_label' => __( 'Integrity', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$identifier = sanitize_text_field( (string) ( $input['plugin'] ?? '' ) );
+		if ( '' === $identifier ) {
+			return array(
+				'success' => false,
+				'message' => __( 'plugin is required.', 'acrossai-abilities-manager' ),
+			);
+		}
+		$strict = ! empty( $input['strict'] );
+
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		$resolved = Plugin_Helpers::resolve_plugin( $identifier );
+		if ( null === $resolved['plugin_file'] || $resolved['certainty'] < 8.0 ) {
+			return array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: %s: input identifier */
+					__( 'No plugin found matching "%s".', 'acrossai-abilities-manager' ),
+					$identifier
+				),
+			);
+		}
+
+		$plugin_file = (string) $resolved['plugin_file'];
+		$slug        = dirname( $plugin_file );
+		if ( '.' === $slug || '' === $slug ) {
+			// Single-file plugin at the root of WP_PLUGIN_DIR — no manifest exists.
+			return array(
+				'success' => true,
+				'plugin'  => $plugin_file,
+				'version' => '',
+				'results' => array(),
+				'summary' => array(
+					'total'    => 0,
+					'ok'       => 0,
+					'modified' => 0,
+					'missing'  => 0,
+					'added'    => 0,
+				),
+				'message' => 'no_manifest',
+			);
+		}
+
+		$plugin_data = Plugin_Helpers::get_plugin_by_slug( $plugin_file );
+		$version     = null !== $plugin_data && isset( $plugin_data['version'] ) ? (string) $plugin_data['version'] : '';
+
+		$manifest_url = 'https://api.wordpress.org/plugins/checksums/1.0/?plugin=' . rawurlencode( $slug ) . '&version=' . rawurlencode( $version );
+		$response     = wp_remote_get( $manifest_url, array( 'timeout' => 15 ) );
+
+		$empty_summary = array(
+			'total'    => 0,
+			'ok'       => 0,
+			'modified' => 0,
+			'missing'  => 0,
+			'added'    => 0,
+		);
+
+		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			return array(
+				'success' => true,
+				'plugin'  => $slug,
+				'version' => $version,
+				'results' => array(),
+				'summary' => $empty_summary,
+				'message' => 'no_manifest',
+			);
+		}
+
+		$body     = (string) wp_remote_retrieve_body( $response );
+		$manifest = json_decode( $body, true );
+		if ( ! is_array( $manifest ) || empty( $manifest['files'] ) || ! is_array( $manifest['files'] ) ) {
+			return array(
+				'success' => true,
+				'plugin'  => $slug,
+				'version' => $version,
+				'results' => array(),
+				'summary' => $empty_summary,
+				'message' => 'no_manifest',
+			);
+		}
+
+		$plugin_dir = WP_PLUGIN_DIR . '/' . $slug;
+		$results    = array();
+		$summary    = $empty_summary;
+
+		foreach ( $manifest['files'] as $file => $expected_data ) {
+			$file          = (string) $file;
+			$expected_hash = self::extract_expected_hash( $expected_data );
+			$disk_path     = $plugin_dir . '/' . $file;
+
+			if ( ! file_exists( $disk_path ) ) {
+				$results[] = array(
+					'file'     => $file,
+					'expected' => $expected_hash,
+					'actual'   => '',
+					'status'   => 'missing',
+				);
+				++$summary['missing'];
+				continue;
+			}
+
+			$actual_hash = (string) md5_file( $disk_path );
+			$status      = hash_equals( $expected_hash, $actual_hash ) ? 'ok' : 'modified';
+
+			$results[] = array(
+				'file'     => $file,
+				'expected' => $expected_hash,
+				'actual'   => $actual_hash,
+				'status'   => $status,
+			);
+			++$summary[ $status ];
+		}
+
+		if ( $strict && is_dir( $plugin_dir ) ) {
+			$manifest_files = array_map( 'strval', array_keys( $manifest['files'] ) );
+			$disk_files     = self::list_files_recursive( $plugin_dir );
+			$added_files    = array_diff( $disk_files, $manifest_files );
+			foreach ( $added_files as $file ) {
+				$results[] = array(
+					'file'     => $file,
+					'expected' => '',
+					'actual'   => (string) md5_file( $plugin_dir . '/' . $file ),
+					'status'   => 'added',
+				);
+				++$summary['added'];
+			}
+		}
+
+		$summary['total'] = count( $results );
+
+		return array(
+			'success' => true,
+			'plugin'  => $slug,
+			'version' => $version,
+			'results' => $results,
+			'summary' => $summary,
+			'message' => sprintf(
+				/* translators: 1: slug, 2: total */
+				__( 'Verified %2$d file(s) for plugin "%1$s".', 'acrossai-abilities-manager' ),
+				$slug,
+				$summary['total']
+			),
+		);
+	}
+
+	/**
+	 * Extract the expected MD5 hash from a manifest entry.
+	 *
+	 * The WP.org manifest ships each entry as either a scalar hash string or
+	 * an array of the form { md5: '<hex>' } (older format).
+	 *
+	 * @param mixed $entry Manifest entry.
+	 * @return string
+	 */
+	private static function extract_expected_hash( $entry ): string {
+		if ( is_string( $entry ) ) {
+			return $entry;
+		}
+		if ( is_array( $entry ) && isset( $entry['md5'] ) ) {
+			return (string) $entry['md5'];
+		}
+		return '';
+	}
+
+	/**
+	 * List every file under $dir as paths relative to $dir.
+	 *
+	 * @param string $dir Absolute directory path.
+	 * @return string[]
+	 */
+	private static function list_files_recursive( string $dir ): array {
+		if ( ! is_dir( $dir ) ) {
+			return array();
+		}
+		$files = array();
+		$iter  = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::SKIP_DOTS )
+		);
+		$prefix_len = strlen( $dir ) + 1;
+		foreach ( $iter as $item ) {
+			if ( $item->isFile() ) {
+				$files[] = substr( $item->getPathname(), $prefix_len );
+			}
+		}
+		return $files;
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -53,6 +53,12 @@
 		<testsuite name="feature-059-unit">
 			<file>tests/phpunit/abilities/Test_Feature_059_Recovery_Mode.php</file>
 		</testsuite>
+		<testsuite name="feature-064-unit">
+			<file>tests/phpunit/abilities/Test_Get_Transient.php</file>
+			<file>tests/phpunit/abilities/Test_List_Transients.php</file>
+			<file>tests/phpunit/abilities/Test_Delete_Transient.php</file>
+			<file>tests/phpunit/abilities/Test_Delete_Expired_Transients.php</file>
+		</testsuite>
 	</testsuites>
 	<source>
 		<include>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -61,6 +61,10 @@
 			<file>tests/phpunit/abilities/Test_Get_Nested_Option_Value.php</file>
 			<file>tests/phpunit/abilities/Test_Patch_Option_Value.php</file>
 			<file>tests/phpunit/abilities/Test_Add_Post_Meta.php</file>
+			<file>tests/phpunit/abilities/Test_Search_Wp_Plugin_Directory.php</file>
+			<file>tests/phpunit/abilities/Test_Uninstall_Plugin.php</file>
+			<file>tests/phpunit/abilities/Test_Verify_Plugin_Checksums.php</file>
+			<file>tests/phpunit/abilities/Test_Verify_Core_Checksums.php</file>
 		</testsuite>
 	</testsuites>
 	<source>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -65,6 +65,7 @@
 			<file>tests/phpunit/abilities/Test_Uninstall_Plugin.php</file>
 			<file>tests/phpunit/abilities/Test_Verify_Plugin_Checksums.php</file>
 			<file>tests/phpunit/abilities/Test_Verify_Core_Checksums.php</file>
+			<file>tests/phpunit/abilities/Test_Feature_064_Bootstrap_Wiring.php</file>
 		</testsuite>
 	</testsuites>
 	<source>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -58,6 +58,8 @@
 			<file>tests/phpunit/abilities/Test_List_Transients.php</file>
 			<file>tests/phpunit/abilities/Test_Delete_Transient.php</file>
 			<file>tests/phpunit/abilities/Test_Delete_Expired_Transients.php</file>
+			<file>tests/phpunit/abilities/Test_Get_Nested_Option_Value.php</file>
+			<file>tests/phpunit/abilities/Test_Patch_Option_Value.php</file>
 		</testsuite>
 	</testsuites>
 	<source>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -60,6 +60,7 @@
 			<file>tests/phpunit/abilities/Test_Delete_Expired_Transients.php</file>
 			<file>tests/phpunit/abilities/Test_Get_Nested_Option_Value.php</file>
 			<file>tests/phpunit/abilities/Test_Patch_Option_Value.php</file>
+			<file>tests/phpunit/abilities/Test_Add_Post_Meta.php</file>
 		</testsuite>
 	</testsuites>
 	<source>

--- a/specs/064-transients-nested-options-and-integrity/checklists/requirements.md
+++ b/specs/064-transients-nested-options-and-integrity/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Transient CRUD, nested option access, plugin lifecycle & checksum integrity
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- Validation performed 2026-08-11 during initial spec authoring; all checklist items pass on first pass because the source input brief (`docs/planning/064-transients-nested-options-and-integrity.md`) explicitly separated user-facing behaviour from implementation notes.
+- Implementation notes (class file paths, WordPress core function signatures, HTTP mocking pattern for checksums fetch, bootstrap wiring) intentionally live in the paired input brief at `docs/planning/064-transients-nested-options-and-integrity.md` and will be picked up by `/speckit-plan` — not repeated here.

--- a/specs/064-transients-nested-options-and-integrity/contracts/abilities.md
+++ b/specs/064-transients-nested-options-and-integrity/contracts/abilities.md
@@ -1,0 +1,283 @@
+# Ability Contracts: Transient CRUD, nested option access, plugin lifecycle & checksum integrity
+
+Every ability uses the same permission callback verbatim:
+
+```php
+'permission_callback' => static function (): bool {
+    return current_user_can( 'manage_options' );
+},
+```
+
+Meta shape: `show_in_rest: true, mcp: { public: false, type: 'tool' }`, plus a per-ability `sub_group` (`cache | options | posts | plugins | core`).
+
+---
+
+## Cache (4)
+
+### 1. `acrossai/get-transient`
+
+`readonly: true, idempotent: true, destructive: false`
+
+**Input**:
+```json
+{
+  "type": "object",
+  "properties": { "key": { "type": "string", "minLength": 1 }, "site": { "type": "boolean", "default": false } },
+  "required": ["key"],
+  "additionalProperties": false
+}
+```
+
+**Output**:
+```json
+{ "success": bool, "exists": bool, "value": any, "expires_at": integer|null, "message": string }
+```
+
+### 2. `acrossai/list-transients`
+
+`readonly: true, idempotent: true, destructive: false`
+
+**Input**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "search":          { "type": "string" },
+    "limit":           { "type": "integer", "minimum": 1, "maximum": 500, "default": 100 },
+    "offset":          { "type": "integer", "minimum": 0, "default": 0 },
+    "site_only":       { "type": "boolean", "default": false },
+    "include_expired": { "type": "boolean", "default": true }
+  },
+  "additionalProperties": false
+}
+```
+
+**Output**:
+```json
+{
+  "success": bool,
+  "transients": [
+    { "name": string, "expires_at": integer|null, "is_site": bool, "is_expired": bool }
+  ],
+  "count": integer,
+  "total": integer
+}
+```
+
+### 3. `acrossai/delete-transient`
+
+`readonly: false, idempotent: true, destructive: true`
+
+**Input**:
+```json
+{
+  "type": "object",
+  "properties": { "key": { "type": "string", "minLength": 1 }, "site": { "type": "boolean", "default": false } },
+  "required": ["key"],
+  "additionalProperties": false
+}
+```
+
+**Output**: `{ success, deleted: bool, message }`
+
+### 4. `acrossai/delete-expired-transients`
+
+`readonly: false, idempotent: true, destructive: true`
+
+**Input**: `{}`.
+**Output**: `{ success, deleted: integer, message }`
+
+---
+
+## Options (2)
+
+### 5. `acrossai/get-nested-option-value`
+
+`readonly: true, idempotent: true, destructive: false`
+
+**Input**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "option": { "type": "string", "minLength": 1 },
+    "path":   { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+  },
+  "required": ["option", "path"],
+  "additionalProperties": false
+}
+```
+
+**Output**: `{ success, exists: bool, value: any, message }`
+
+### 6. `acrossai/patch-option-value`
+
+`readonly: false, idempotent: false, destructive: true`
+
+**Input**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "option":    { "type": "string", "minLength": 1 },
+    "operation": { "type": "string", "enum": ["insert", "update", "delete"] },
+    "path":      { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "value":     {}
+  },
+  "required": ["option", "operation", "path"],
+  "additionalProperties": false
+}
+```
+
+**Output**: `{ success, message, blocked_reason: string }`
+
+`blocked_reason` values: `"blocked_option"`, `"non_traversable_intermediate"`.
+
+---
+
+## Content (1)
+
+### 7. `acrossai/add-post-meta`
+
+`readonly: false, idempotent: false, destructive: false` (append is additive, not destructive)
+
+**Input** (mirrors `Update_Post_Meta.php` with an added `unique` flag):
+```json
+{
+  "type": "object",
+  "properties": {
+    "post_id":    { "type": "integer", "minimum": 1 },
+    "key":        { "type": "string" },
+    "meta_key":   { "type": "string" },
+    "value":      {},
+    "meta_value": {},
+    "unique":     { "type": "boolean", "default": false }
+  },
+  "allOf": [
+    { "required": ["post_id"] },
+    { "anyOf": [ { "required": ["key"] }, { "required": ["meta_key"] } ] }
+  ],
+  "additionalProperties": false
+}
+```
+
+**Output**: `{ success, meta_id: integer|false, message }`
+
+---
+
+## Plugins (3)
+
+### 8. `acrossai/search-wp-plugin-directory`
+
+`readonly: true, idempotent: true, destructive: false`
+
+**Input**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "query":    { "type": "string", "minLength": 1 },
+    "per_page": { "type": "integer", "minimum": 1, "maximum": 100, "default": 10 },
+    "page":     { "type": "integer", "minimum": 1, "default": 1 }
+  },
+  "required": ["query"],
+  "additionalProperties": false
+}
+```
+
+**Output**:
+```json
+{
+  "success": bool,
+  "plugins": [
+    {
+      "slug": string, "name": string, "short_description": string,
+      "rating": integer, "active_installs": integer,
+      "homepage": string, "download_link": string
+    }
+  ],
+  "info": { "page": integer, "pages": integer, "results": integer },
+  "message": string
+}
+```
+
+### 9. `acrossai/uninstall-plugin`
+
+`readonly: false, idempotent: true, destructive: true`
+
+**Input**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "plugin":      { "type": "string", "minLength": 1 },
+    "delete_data": { "type": "boolean", "default": true }
+  },
+  "required": ["plugin"],
+  "additionalProperties": false
+}
+```
+
+**Output**: `{ success, uninstalled: bool, message, blocked_reason: string }`
+
+`blocked_reason` values: `"plugin_active"`, `"file_mods_disallowed"`, `"plugin_not_found"`.
+
+### 10. `acrossai/verify-plugin-checksums`
+
+`readonly: true, idempotent: true, destructive: false`
+
+**Input**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "plugin": { "type": "string", "minLength": 1 },
+    "strict": { "type": "boolean", "default": false }
+  },
+  "required": ["plugin"],
+  "additionalProperties": false
+}
+```
+
+**Output**:
+```json
+{
+  "success": bool,
+  "plugin": string, "version": string,
+  "results": [ { "file": string, "expected": string, "actual": string, "status": string } ],
+  "summary": { "total": integer, "ok": integer, "modified": integer, "missing": integer, "added": integer },
+  "message": string
+}
+```
+
+`status` enum: `"ok" | "modified" | "missing" | "added"`.
+
+---
+
+## Core (1)
+
+### 11. `acrossai/verify-core-checksums`
+
+`readonly: true, idempotent: true, destructive: false`
+
+**Input**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "version":      { "type": "string" },
+    "locale":       { "type": "string" },
+    "include_root": { "type": "boolean", "default": false },
+    "exclude":      { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": false
+}
+```
+
+Defaults: `version` = currently-installed core version; `locale` = `"en_US"`.
+
+**Output**: identical shape to `verify-plugin-checksums` (with `plugin` field replaced by nothing — just `version` reported).
+
+## Contract test hooks
+
+Each contract is validated at test time by calling `wp_get_ability( 'acrossai/<slug>' )->execute( $input )` with golden-path and guardrail-tripping inputs and asserting shape + `blocked_reason` values. HTTP-facing abilities mock `pre_http_request` per feature 062/063 pattern.

--- a/specs/064-transients-nested-options-and-integrity/data-model.md
+++ b/specs/064-transients-nested-options-and-integrity/data-model.md
@@ -1,0 +1,77 @@
+# Phase 1 Data Model: Transient CRUD, nested option access, plugin lifecycle & checksum integrity
+
+**Status**: No new persistent entities. Every write mutates an existing WordPress-managed store.
+
+## Entities (all existing, WordPress-managed)
+
+### Transient
+
+- **Storage**: Blog-scope in `wp_options` (rows `_transient_<key>` / `_transient_timeout_<key>`); site-scope in `wp_sitemeta` (on multisite) or `wp_options` (single-site) (`_site_transient_<key>` / `_site_transient_timeout_<key>`). May also be served from an external object cache without touching SQL.
+- **Attributes**: name, value, expiry (unix timestamp), scope (blog vs site).
+- **Validation**:
+  - Name MUST be a non-empty string.
+  - Scope is caller-supplied via `site: bool` on read/delete; auto-detected by `list-transients` output (each row carries `is_site`).
+- **Mutations from this feature**:
+  - Read: `get-transient` (single), `list-transients` (paginated enumeration).
+  - Delete: `delete-transient` (single by name), `delete-expired-transients` (bulk by expiry).
+
+### Serialized Option
+
+- **Storage**: `wp_options.option_value`.
+- **Attributes**: name, value (PHP-serialized).
+- **Validation**:
+  - Name MUST NOT be in the block-list (mirrors `Update_Option::BLOCKED_OPTIONS`).
+  - `path` MUST be a non-empty array of strings.
+  - Every intermediate value along `path` MUST be array-like (array or object) — mutations refuse when traversing into scalars.
+- **Mutations from this feature**:
+  - Read: `get-nested-option-value` (walks path, returns leaf value + exists flag).
+  - Write: `patch-option-value` (insert / update / delete one nested value).
+
+### Post Meta Row
+
+- **Storage**: `wp_postmeta`.
+- **Attributes**: `post_id`, `meta_key`, `meta_value` (may repeat with same key).
+- **Validation**:
+  - `post_id` MUST reference an existing post.
+  - When `unique: true` and any row already exists for the `(post_id, key)` pair, the append is refused (`meta_id: false` per WP core `add_post_meta( ..., true )`).
+- **Mutations from this feature**:
+  - `add-post-meta` appends one row.
+
+### Plugin Directory Listing (ephemeral)
+
+- **Storage**: none — data comes from wordpress.org over HTTP per call.
+- **Attributes**: slug, name, short_description (HTML), rating (0–100), active_installs, homepage, download_link, pagination metadata.
+- **Validation**: none on the caller side; input is a search query string.
+- **Mutations from this feature**: none — read-only.
+
+### Plugin File (existing on disk)
+
+- **Storage**: filesystem, under `WP_PLUGIN_DIR`.
+- **Attributes**: file path (relative to plugin dir), content, md5 hash (computed).
+- **Validation**: identity resolved via `Plugin_Helpers::resolve_plugin()`.
+- **Mutations from this feature**:
+  - `uninstall-plugin` deletes all files after firing the uninstall hook.
+  - `verify-plugin-checksums` reads and hashes only.
+
+### Core File (existing on disk)
+
+- **Storage**: filesystem, under `ABSPATH`.
+- **Attributes**: file path (relative to ABSPATH), content, md5 hash.
+- **Mutations from this feature**:
+  - `verify-core-checksums` reads and hashes only.
+
+### Checksum Result (ephemeral)
+
+- **Storage**: none — computed per invocation.
+- **Attributes**: per-file `{ file, expected, actual, status: 'ok'|'modified'|'missing'|'added' }` + summary counters.
+- **Mutations**: none — pure read.
+
+## State transitions
+
+None of the write abilities introduce state machines.
+
+## Cross-entity invariants
+
+1. **Transient expiry timestamp MUST NOT exceed the value stored in the companion `_transient_timeout_<key>` row.** WP core enforces this; the abilities do not maintain their own invariants.
+2. **A patched option value MUST round-trip through `get_option()` after `update_option()` byte-for-byte identical to the intended structure.** Verified by an integration-style test in `Test_Patch_Option_Value.php`.
+3. **`uninstall-plugin` MUST NOT run on a plugin whose `active_plugins` option contains its file path.** Enforced by `is_plugin_active()` guard.

--- a/specs/064-transients-nested-options-and-integrity/plan.md
+++ b/specs/064-transients-nested-options-and-integrity/plan.md
@@ -1,0 +1,142 @@
+# Implementation Plan: Transient CRUD, nested option access, plugin lifecycle & checksum integrity
+
+**Branch**: `064-transients-nested-options-and-integrity` | **Date**: 2026-08-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/064-transients-nested-options-and-integrity/spec.md`
+
+## Summary
+
+Add 11 new abilities across four existing ability categories:
+
+- **4 transient CRUD** under `Cache/`: `get-transient`, `list-transients`, `delete-transient`, `delete-expired-transients`.
+- **2 nested-key option operations** under `Options/`: `get-nested-option-value` (read), `patch-option-value` (write).
+- **1 post-meta append** under `Content/`: `add-post-meta` (append semantics, complements existing update/delete).
+- **3 plugin-lifecycle** under `Plugins/`: `search-wp-plugin-directory` (WP.org discovery), `uninstall-plugin`, `verify-plugin-checksums`.
+- **1 core-integrity** under `Core/`: `verify-core-checksums`.
+
+Every ability uses the literal `permission_callback = static function (): bool { return current_user_can( 'manage_options' ); }` and inherits the `Ability_Definition` parent class. Two abilities issue outbound HTTP requests (both to `api.wordpress.org`) — the two `verify-*-checksums` abilities. Two abilities are destructive with input guardrails: `patch-option-value` (block-list of core options), `uninstall-plugin` (must-be-inactive + `DISALLOW_FILE_MODS`).
+
+**Technical approach:** zero new modules, zero new categories, zero new database tables, zero new option keys. All 11 land inside existing category directories. Bootstrap wiring is a single edit in `AcrossAI_Core_Abilities_Bootstrap::register_abilities()` — 11 new instantiation lines spread across the existing Cache, Options, Content, Plugins, and Core blocks.
+
+## Technical Context
+
+**Language/Version**: PHP 8.1+.
+**Primary Dependencies**: WordPress 6.9+; existing `Ability_Definition` parent class; existing utilities `Plugin_Helpers::resolve_plugin()` and `File_Mods_Guard` (already used by Install_Plugin / Delete_Theme / Recovery abilities). No new Composer or npm packages.
+**Storage**: Reads and writes against existing WordPress-managed tables and options. Transients live in `$wpdb->options` (blog-scope) or `$wpdb->sitemeta` (site-scope). Nested-option reads/writes go through `get_option()` / `update_option()`. Post-meta append via `add_post_meta()`. No new tables or option keys are introduced.
+**Testing**: PHPUnit 10.5. Fixtures via `WP_UnitTestCase`. HTTP requests to `api.wordpress.org` (from `plugins_api()` and checksums fetch) are mocked via `add_filter('pre_http_request', ...)` — same pattern as feature 063 and existing `Test_Feature_042_Core_Update.php`.
+**Target Platform**: WordPress 6.9+ on PHP 8.1 through 8.5.
+**Project Type**: WordPress plugin — single project.
+**Performance Goals**: 90% of `search-wp-plugin-directory` invocations return within 3 seconds against wordpress.org (spec SC-006, excludes cold-start and unreachable-API cases). All other abilities target sub-100ms on a warmed object cache.
+**Constraints**: `manage_options` gate on every ability. No admin JS/UI changes. Outbound HTTP restricted to `api.wordpress.org` (canonical WordPress.org endpoints — plugin directory query, plugin checksums manifest, core checksums manifest).
+**Scale/Scope**: 11 new ability classes (~100–250 lines each including docblocks) + 1 bootstrap edit. ~21 new PHPUnit methods (11 golden-path + 10 guardrail per spec's Success Criteria).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### I. Modular Architecture — PASS
+
+11 self-contained subclasses spread across 5 existing category directories. No cross-module dependencies. Every class extends `Ability_Definition` and does one thing (spec's Modular Architecture rationale).
+
+### II. WordPress Standards Compliance — PASS
+
+- PHPCS (WPCS strict): every new file mirrors an existing peer (`Cache/Flush_Transients.php` for the transient CRUD, `Options/Update_Option.php` for nested-option patch, `Plugins/Install_Plugin.php` for uninstall, etc.).
+- PHPStan level 8: every WP core function called is stubbed by `wordpress-stubs`. `delete_expired_transients()`, `plugins_api()`, `uninstall_plugin()`, `get_core_checksums()` all have signatures.
+- Plugin Check: no `eval`/`extract`/shell exec. The `list-transients` ability uses `$wpdb->prepare()` with `%s` placeholders for the `LIKE` pattern — no raw interpolation. Verify-checksums abilities use `wp_remote_get()` for HTTP (per constitution §II).
+- Multisite: `list-transients` accepts a `site_only` flag that switches to `$wpdb->sitemeta` on multisite; single-site installs ignore the flag. `delete-transient` accepts a `site` flag that toggles between `delete_transient()` and `delete_site_transient()`.
+
+### III. User-Centric Design — PASS (N/A, no admin UI)
+
+No new admin pages or forms. New abilities render through the existing DataViews-backed admin surfaces.
+
+### IV. Security First — PASS
+
+- Sanitization at entry: every string input passed through `sanitize_text_field()`. Integer inputs (post_id, limit, offset, user_id) cast via `absint()` / `(int)`.
+- Capability check: `permission_callback` gates every ability on `manage_options`.
+- Prepared queries: `list-transients` uses `$wpdb->prepare( "... LIKE %s", $wpdb->esc_like('_transient_') . '%' )` — no raw table-name interpolation (uses `$wpdb->options` object property; identifier via `%i` is not needed because it's a WP-managed property).
+- `patch-option-value` guardrail: rejects any option name in the block-list already used by the existing `Update_Option` ability. Enum-driven for the operation field (`insert`/`update`/`delete` only).
+- `uninstall-plugin` guardrails: (a) refuses if plugin is currently active (via `is_plugin_active()`); (b) refuses when `DISALLOW_FILE_MODS` is defined truthy (via existing `File_Mods_Guard::blocked_response()`).
+- `search-wp-plugin-directory` output: filters `plugins_api()`'s raw response through `wp_kses_post()` on the `short_description` field (WP.org returns HTML there) — matches WP admin's own plugin-install screen sanitization.
+- Checksum verifies: file-content hashing uses `md5_file()` per WP core's own approach; no user-controlled filesystem walking (the ability walks the plugin's own directory only, resolved through `Plugin_Helpers::resolve_plugin()` for fuzzy input).
+
+### V. Extensibility Without Core Modification — PASS
+
+11 new files under existing category dirs. Bootstrap wiring appends 11 lines — no method signatures change.
+
+### VI. Reusability & DRY Principle — PASS
+
+Reuses:
+- `Ability_Definition` parent class for all 11.
+- `Plugin_Helpers::resolve_plugin()` (already used by Recovery abilities) for fuzzy plugin slug/file resolution in `uninstall-plugin` and `verify-plugin-checksums`.
+- `File_Mods_Guard::blocked_response()` for the `DISALLOW_FILE_MODS` gate in `uninstall-plugin`.
+- Existing `BLOCKED_OPTIONS` block-list from `Update_Option.php` for the `patch-option-value` guardrail (if not already extracted, either reference by direct constant lookup or extract to a `const` on `Update_Option` for reuse — decision deferred to `/speckit-tasks`).
+- `Update_Post_Meta.php` input schema shape as the template for `Add_Post_Meta.php` (same `key`/`meta_key` and `value`/`meta_value` aliases).
+- `add_filter('pre_http_request', ...)` HTTP-mocking pattern for both `verify-*-checksums` and `search-wp-plugin-directory` tests.
+
+### VII. Definition of Done — PLANNED
+
+Same gates as features 062 and 063. ~21 new PHPUnit methods, PHPCS + PHPStan + ESLint (N/A) zero.
+
+**Overall gate: PASS.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/064-transients-nested-options-and-integrity/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── abilities.md     # Phase 1 output
+├── checklists/
+│   └── requirements.md  # /speckit-specify output
+├── spec.md              # /speckit-specify output
+└── tasks.md             # /speckit-tasks output (later)
+```
+
+### Source Code (repository root)
+
+```text
+includes/
+└── Abilities/
+    ├── Cache/
+    │   ├── Get_Transient.php                 # NEW — acrossai/get-transient
+    │   ├── List_Transients.php               # NEW — acrossai/list-transients
+    │   ├── Delete_Transient.php              # NEW — acrossai/delete-transient
+    │   └── Delete_Expired_Transients.php     # NEW — acrossai/delete-expired-transients
+    ├── Options/
+    │   ├── Get_Nested_Option_Value.php       # NEW — acrossai/get-nested-option-value
+    │   └── Patch_Option_Value.php            # NEW — acrossai/patch-option-value
+    ├── Content/
+    │   └── Add_Post_Meta.php                 # NEW — acrossai/add-post-meta
+    ├── Plugins/
+    │   ├── Search_Wp_Plugin_Directory.php    # NEW — acrossai/search-wp-plugin-directory
+    │   ├── Uninstall_Plugin.php              # NEW — acrossai/uninstall-plugin
+    │   └── Verify_Plugin_Checksums.php       # NEW — acrossai/verify-plugin-checksums
+    ├── Core/
+    │   └── Verify_Core_Checksums.php         # NEW — acrossai/verify-core-checksums
+    └── AcrossAI_Core_Abilities_Bootstrap.php # MODIFIED — +11 instantiations
+
+tests/
+└── phpunit/
+    └── abilities/
+        ├── Test_Get_Transient.php                    # NEW
+        ├── Test_List_Transients.php                  # NEW
+        ├── Test_Delete_Transient.php                 # NEW
+        ├── Test_Delete_Expired_Transients.php        # NEW
+        ├── Test_Get_Nested_Option_Value.php          # NEW
+        ├── Test_Patch_Option_Value.php               # NEW
+        ├── Test_Add_Post_Meta.php                    # NEW
+        ├── Test_Search_Wp_Plugin_Directory.php       # NEW
+        ├── Test_Uninstall_Plugin.php                 # NEW
+        ├── Test_Verify_Plugin_Checksums.php          # NEW
+        └── Test_Verify_Core_Checksums.php            # NEW
+```
+
+**Structure Decision**: WordPress plugin single-project layout. All 11 new abilities land in existing category dirs. No new category, no new module, no `admin/`, `src/`, or Composer changes.
+
+## Complexity Tracking
+
+*No entries — Constitution Check passes on every principle.*

--- a/specs/064-transients-nested-options-and-integrity/quickstart.md
+++ b/specs/064-transients-nested-options-and-integrity/quickstart.md
@@ -1,0 +1,188 @@
+# Quickstart: Transient CRUD, nested option access, plugin lifecycle & checksum integrity
+
+## Prerequisites
+
+- Local WordPress site (`http://wordpress-7-0.local`), plugin active.
+- Administrator credentials + application password.
+- WP-CLI available on the host (used to seed transients / options).
+
+## Manual verification
+
+### 1. Transient CRUD
+
+```bash
+# Seed a transient (via WP-CLI)
+wp transient set demo_transient "hello" 3600
+wp transient set demo_expired "gone" 1
+sleep 2
+
+# Read
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"demo_transient"}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/get-transient/run
+# Expected: { "success": true, "exists": true, "value": "hello", "expires_at": <unix> }
+
+# List (filtered)
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"search":"demo_"}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/list-transients/run \
+  | jq '.transients[].name'
+
+# Purge expired
+curl -u admin:APP_PASSWORD -X POST \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/delete-expired-transients/run
+# Expected: { "success": true, "deleted": >=1 }
+
+# Delete one by name
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"demo_transient"}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/delete-transient/run
+```
+
+### 2. Nested-option access
+
+```bash
+# Seed a nested option (via WP-CLI)
+wp option update demo_settings '{"a":{"b":"c"}}' --format=json
+
+# Read one nested key
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"option":"demo_settings","path":["a","b"]}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/get-nested-option-value/run
+# Expected: { "success": true, "exists": true, "value": "c" }
+
+# Update one nested key
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"option":"demo_settings","operation":"update","path":["a","b"],"value":"d"}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/patch-option-value/run
+
+# Verify
+wp option get demo_settings --format=json
+# Expected: {"a":{"b":"d"}}
+
+# Attempt to patch a blocked option (must be refused)
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"option":"siteurl","operation":"update","path":["scheme"],"value":"https"}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/patch-option-value/run
+# Expected: { "success": false, "blocked_reason": "blocked_option" }
+
+wp option delete demo_settings
+```
+
+### 3. Post-meta append
+
+```bash
+POSTID=$(wp post create --post_title="Meta Test" --porcelain)
+
+# First append
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d "{\"post_id\":$POSTID,\"key\":\"tags_v2\",\"value\":\"first\"}" \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/add-post-meta/run
+# Expected: { "success": true, "meta_id": <int> }
+
+# Second append (same key)
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d "{\"post_id\":$POSTID,\"key\":\"tags_v2\",\"value\":\"second\"}" \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/add-post-meta/run
+
+# Verify both rows persist (update-post-meta would have replaced)
+wp post meta list $POSTID | grep tags_v2
+
+# Unique-flag test: third append with unique:true (expected to be refused)
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d "{\"post_id\":$POSTID,\"key\":\"tags_v2\",\"value\":\"third\",\"unique\":true}" \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/add-post-meta/run
+# Expected: { "success": true, "meta_id": false }
+
+wp post delete $POSTID --force
+```
+
+### 4. Plugin discovery
+
+```bash
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"jetpack","per_page":3}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/search-wp-plugin-directory/run \
+  | jq '.plugins[].slug'
+# Expected: array of 3 slugs, first is "jetpack" or similar
+```
+
+### 5. Plugin uninstall
+
+```bash
+# Install a test plugin
+wp plugin install akismet --version=5.3 && wp plugin deactivate akismet
+
+# Uninstall via ability
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"plugin":"akismet"}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/uninstall-plugin/run
+# Expected: { "success": true, "uninstalled": true }
+
+wp plugin list | grep akismet    # Expected: no output — plugin gone
+
+# Attempt on an active plugin (must be refused)
+wp plugin install classic-editor --activate
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"plugin":"classic-editor"}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/uninstall-plugin/run
+# Expected: { "success": false, "blocked_reason": "plugin_active" }
+
+wp plugin deactivate classic-editor && wp plugin uninstall classic-editor
+```
+
+### 6. Checksum verification
+
+```bash
+# Verify plugin (using a fresh wp.org-hosted plugin)
+wp plugin install classic-editor
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"plugin":"classic-editor"}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/verify-plugin-checksums/run \
+  | jq '.summary'
+# Expected: { "total": <N>, "ok": <N>, "modified": 0, "missing": 0, "added": 0 }
+
+# Deliberately modify a file, re-verify
+echo "// added line" >> "$(wp plugin path)/classic-editor/classic-editor.php"
+
+curl -u admin:APP_PASSWORD -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"plugin":"classic-editor"}' \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/verify-plugin-checksums/run \
+  | jq '.results[] | select(.status=="modified")'
+# Expected: one entry for classic-editor.php with status: "modified"
+
+# Core verify
+curl -u admin:APP_PASSWORD \
+  http://wordpress-7-0.local/wp-json/wp-abilities/v1/abilities/acrossai/verify-core-checksums/run \
+  | jq '.summary'
+# Expected: modified: 0 on a vanilla install
+```
+
+### 7. Admin UI sanity
+
+- Load `http://wordpress-7-0.local/wp-admin/admin.php?page=acrossai-abilities-library`.
+- Confirm the 11 new abilities appear under Cache (4), Options (2), Content (1), Plugins (3), Core (1).
+- Every ability shows `manage_options` as the permission; destructive/readonly annotations match the spec.
+
+### 8. Automated tests
+
+```bash
+composer install
+composer run test    # ~21 new PHPUnit methods pass alongside existing suite
+composer run phpcs
+composer run phpstan
+```

--- a/specs/064-transients-nested-options-and-integrity/research.md
+++ b/specs/064-transients-nested-options-and-integrity/research.md
@@ -1,0 +1,88 @@
+# Phase 0 Research: Transient CRUD, nested option access, plugin lifecycle & checksum integrity
+
+**Status**: No open NEEDS CLARIFICATION markers. Decisions inherited from existing patterns; documented below.
+
+## Decision 1: Transient CRUD scope — WP core transient APIs, not raw options table
+
+**Decision**: `get-transient` calls `get_transient()` / `get_site_transient()`; `delete-transient` calls `delete_transient()` / `delete_site_transient()`; `delete-expired-transients` calls `delete_expired_transients()`. Only `list-transients` queries the options table directly (via `$wpdb->prepare(..., $wpdb->esc_like('_transient_') . '%')`) because WP core has no `list_transients()` helper.
+
+**Rationale**: The WP core APIs handle external-object-cache hits (Redis, Memcached) transparently — reading raw options would miss transients that were never persisted to SQL. The only exception is `list-transients` because listing requires enumeration and WP core does not expose an enumeration helper.
+
+**Alternatives considered**:
+- Query the options table directly for reads too. Rejected — misses cache-only transients.
+- Use `wp_cache_get()` to list. Rejected — the object cache surface has no enumeration primitive (nor should it).
+
+## Decision 2: Nested-key path representation
+
+**Decision**: The `path` input to `get-nested-option-value` and `patch-option-value` is an array of strings (JSON: `["a", "b", "c"]`), where each element is one array-key or object-property to traverse in order. Numeric keys are also accepted as string ("0", "1", …) — PHP array access accepts both.
+
+**Rationale**: A dot-separated string (`"a.b.c"`) would break for keys that legitimately contain dots (common in WooCommerce settings). Array-of-strings is unambiguous.
+
+**Alternatives considered**:
+- Dot-separated string. Rejected — ambiguity with keys containing dots.
+- JSONPath expression. Rejected — over-engineered for the read/write use cases here; introduces a parser we don't need.
+
+## Decision 3: `patch-option-value` block-list reuse
+
+**Decision**: Reference the same block-list of protected core options used by the existing `Update_Option` ability. If `Update_Option.php` already exposes it as `const BLOCKED_OPTIONS`, `Patch_Option_Value.php` uses it directly (`Update_Option::BLOCKED_OPTIONS`). Otherwise, extract it to a `const` on `Update_Option.php` in this feature branch so both classes share one authoritative list.
+
+**Rationale**: DRY (constitution §VI). The block-list should have one canonical source, not two.
+
+**Alternatives considered**:
+- Duplicate the list in both classes. Rejected — violates DRY.
+- Extract to a new `Utilities/Blocked_Options.php`. Rejected — premature abstraction; two consumers do not justify a new utility.
+
+## Decision 4: `add-post-meta` alias inputs match `update-post-meta`
+
+**Decision**: `Add_Post_Meta.php`'s input schema accepts both WP-CLI-style aliases (`key`/`value`) and WP-core-style aliases (`meta_key`/`meta_value`) for maximum client compatibility. Also accepts a `unique?: bool = false` flag matching WordPress core `add_post_meta( ..., $unique )`. This mirrors `Update_Post_Meta.php`'s existing input surface verbatim (only the semantics differ — append vs replace).
+
+**Rationale**: Reduces cognitive load for callers; the plugin already established the aliases-accepted pattern in `update-post-meta`.
+
+**Alternatives considered**:
+- Accept only `key`/`value`. Rejected — inconsistent with the sibling ability.
+
+## Decision 5: `search-wp-plugin-directory` output field selection
+
+**Decision**: Request the following fields from `plugins_api()`: `slug`, `name`, `short_description`, `rating`, `active_installs`, `homepage`, `download_link`. Explicitly do not request `sections`, `screenshots`, or `banners` because those are heavy and callers who want them should hit the WP admin `install_plugin_information` screen or a follow-up API call.
+
+**Rationale**: Keeps the response payload bounded (~1KB per plugin) so a page of 10 results fits comfortably in a REST response.
+
+**Alternatives considered**:
+- Return everything `plugins_api()` returns. Rejected — payload bloat (banners alone can be many KB per plugin).
+- Return only slug + name. Rejected — omits the fields that a caller needs to reason about installability (rating, installs).
+
+## Decision 6: `uninstall-plugin` uses WP core's own `uninstall_plugin()` — no wrapping
+
+**Decision**: Call `uninstall_plugin( $plugin_file )` from `wp-admin/includes/plugin.php` after resolving the caller's fuzzy slug via `Plugin_Helpers::resolve_plugin()`. Do not re-implement the uninstall workflow.
+
+**Rationale**: `uninstall_plugin()` fires the plugin's registered `<slug>_uninstall` hook, respects `register_uninstall_hook()`, and handles the `uninstall.php` fallback. Re-implementing would drift and miss edge cases.
+
+**Alternatives considered**:
+- Re-implement using `delete_plugins()`. Rejected — `delete_plugins()` skips the uninstall hook.
+- Two-step: fire `<slug>_uninstall` hook then `delete_plugins()`. Rejected — `uninstall_plugin()` does both correctly.
+
+## Decision 7: Checksums verification workflow
+
+**Decision**: For each verify ability:
+1. Fetch the expected checksums manifest via `wp_remote_get()` against `api.wordpress.org` (`/core/checksums/1.0/?version=X&locale=Y` or `/plugins/checksums/1.0/?plugin=slug&version=X`). Decode the JSON response.
+2. For each file in the manifest, `md5_file()` the on-disk path and compare against the expected hash.
+3. For each file present on disk but not in the manifest, mark `status: 'added'` (only reported when `strict: true`).
+4. For each file in the manifest but absent on disk, mark `status: 'missing'`.
+5. Return `{ per-file results, summary counters }`.
+
+**Rationale**: This is the exact algorithm WordPress core's own hidden `_wp_core_verify_checksums()` uses (in `wp-admin/includes/update-core.php`). Matching that algorithm means the ability's output aligns with what WP-CLI's own `wp core verify-checksums` reports for the same site.
+
+**Alternatives considered**:
+- Use SHA-256 hashing. Rejected — the WordPress.org manifest ships MD5 checksums only; SHA-256 would require a different manifest that does not exist.
+
+## Decision 8: PHPUnit HTTP mocking for network-facing abilities
+
+**Decision**: Tests hook `add_filter('pre_http_request', ...)` to short-circuit outbound calls. Golden-path tests return canned manifests / plugin listings. Guardrail tests return `WP_Error` to simulate network failures. Restore filters in `tearDown()`.
+
+**Rationale**: Matches the pattern established in `Test_Feature_042_Core_Update.php`.
+
+**Alternatives considered**: Same as feature 063; rejected same alternatives.
+
+## Open items
+
+None.

--- a/specs/064-transients-nested-options-and-integrity/spec.md
+++ b/specs/064-transients-nested-options-and-integrity/spec.md
@@ -1,0 +1,149 @@
+# Feature Specification: Transient CRUD, nested option access, plugin lifecycle & checksum integrity
+
+**Feature Branch**: `064-transients-nested-options-and-integrity`
+**Created**: 2026-08-11
+**Status**: Draft
+**Input**: User description: "Transient CRUD (4 abilities, Cache category) + nested-key option access (2, Options) + post-meta append (1, Content) + WP.org plugin directory search + plugin uninstall (2, Plugins) + core and plugin checksum verification (2 abilities, Core + Plugins). See docs/planning/064-transients-nested-options-and-integrity.md."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Inspect and manage transient cache entries (Priority: P1)
+
+An operator (or AI agent operating on their behalf with `manage_options`) can read a single transient by name, enumerate the transients currently stored on the site, delete a specific transient, and purge every transient whose expiry has passed — without falling back to raw SQL.
+
+**Why this priority**: Transient state is central to WordPress performance troubleshooting (stuck update-check transients, stale API-response caches, membership-plugin cache races). Today the plugin exposes only bulk-flush and nothing else, so any agent debugging a transient-related issue has to run raw `SELECT`s. This unlocks routine debugging.
+
+**Independent Test**: An operator can seed a transient via any writer, then read, list, delete, and expire — every one demonstrable in isolation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a transient `foo` with value `"bar"` and an expiry in the future, **When** the operator reads the transient, **Then** the response reports `exists: true`, returns the value, and includes the expiry timestamp.
+2. **Given** no transient named `foo`, **When** the operator reads it, **Then** the response reports `exists: false` (distinct from a transient that legitimately stores the value `false`).
+3. **Given** any number of transients on the site, **When** the operator invokes the list ability without a search term, **Then** the response returns up to the caller's limit (default 100, cap 500), each entry including its name, expiry (if any), a boolean site-vs-blog scope flag, and a boolean is-expired flag; the response also reports the total count independent of the returned page size.
+4. **Given** a transient `foo`, **When** the operator deletes it, **Then** subsequent reads report `exists: false`, and re-deleting the same transient succeeds (idempotent).
+5. **Given** a mix of expired and unexpired transients, **When** the operator invokes the expire-all ability, **Then** every expired transient (both blog- and site-scope) is removed, unexpired transients are untouched, and the response reports the count removed.
+6. **Given** a site-scope transient (stored via `set_site_transient`), **When** the operator reads or deletes it with the `site` flag set true, **Then** the correct site-scope entry is targeted; when the flag is false, blog-scope entries are targeted.
+
+---
+
+### User Story 2 - Read or mutate a single nested key inside a serialized option (Priority: P1)
+
+The operator can read one nested key from a serialized-array option (e.g. `woocommerce_settings.general.currency_symbol`) without transferring the whole option, and can insert, update, or delete a single nested key without hand-serializing the surrounding structure.
+
+**Why this priority**: Large plugins (WooCommerce, LearnDash, Freemius) store many settings inside single big options. Round-tripping the whole option for one key wastes bytes and creates race hazards. This ability slice is the smallest primitive that fixes both problems.
+
+**Independent Test**: An operator can round-trip through the two nested-key abilities against any complex option and verify both read and mutation behaviour independently of every other ability in this feature.
+
+**Acceptance Scenarios**:
+
+1. **Given** an option `settings` whose value is `{ "a": { "b": "c" } }`, **When** the operator reads with path `["a", "b"]`, **Then** the response reports `exists: true` and returns the string `"c"`.
+2. **Given** the same option, **When** the operator reads with a path whose leaf key does not exist (e.g. `["a", "z"]`), **Then** the response reports `exists: false` without returning a value.
+3. **Given** the same option, **When** the operator applies an update operation with path `["a", "b"]` and value `"d"`, **Then** the option becomes `{ "a": { "b": "d" } }` — no other keys mutated.
+4. **Given** an option `settings` whose value is `{ "a": { "b": "c" } }`, **When** the operator applies an insert operation with path `["a", "e"]` and value `"f"`, **Then** the option becomes `{ "a": { "b": "c", "e": "f" } }`.
+5. **Given** the same option, **When** the operator applies a delete operation with path `["a", "b"]`, **Then** the option becomes `{ "a": {} }` — the parent key is preserved even when empty.
+6. **Given** an option whose name appears in the block-list of protected core options (mirrors the block-list used by the existing option-update ability), **When** the operator attempts any nested mutation, **Then** the ability refuses without mutating state.
+7. **Given** a path that traverses into a non-array intermediate value (e.g. path `["a", "b", "x"]` when `a.b` is a string), **When** the operator invokes any nested-mutation operation, **Then** the ability refuses and returns a message explaining that the parent is not traversable.
+
+---
+
+### User Story 3 - Append an additional post-meta row without replacing existing rows (Priority: P2)
+
+The operator can add a new post-meta row for a given `(post_id, key)` pair without replacing any existing rows for the same key, complementing the existing "replace" (`update-post-meta`) and "delete" (`delete-post-meta`) writers.
+
+**Why this priority**: WordPress post-meta is a one-to-many store — a single post can legitimately have multiple rows under the same key (e.g. per-attachment references, multi-value custom fields). The existing update ability replaces all rows for a key; there is no way today to append. Ships as P2 because it fills a specific gap in an existing surface rather than opening a new surface.
+
+**Independent Test**: An operator can seed a post with one meta row via the existing update-post-meta ability, then append two more via this new ability, and verify all three rows persist independently.
+
+**Acceptance Scenarios**:
+
+1. **Given** a post with zero existing rows for meta key `attachments`, **When** the operator appends a new row with a value, **Then** the ability returns a numeric meta identifier and the post now has one row for that key.
+2. **Given** a post with three existing rows for meta key `attachments`, **When** the operator appends another row, **Then** the post now has four rows and the response returns the newly-created row's identifier.
+3. **Given** the same post, **When** the operator appends with the "unique" flag set true and a row for that key already exists, **Then** the ability returns a false / null identifier and does not create a row (matches WordPress core `add_post_meta( ..., true )` behaviour).
+4. **Given** a post identifier that does not exist, **When** the operator appends, **Then** the ability refuses without mutating state and names the missing post.
+
+---
+
+### User Story 4 - Discover, uninstall, and verify plugin file integrity (Priority: P2)
+
+The operator can search the WordPress.org plugin directory for installable candidates, uninstall a plugin that is already deactivated (firing the plugin's own cleanup hook and deleting its files), and verify the on-disk file integrity of a plugin or of WordPress core itself against the official WordPress.org checksums.
+
+**Why this priority**: These four abilities together close the plugin lifecycle: discovery → install (already exists) → activate (already exists) → deactivate (already exists) → uninstall (new) → verify (new). Also enables lightweight integrity auditing without a full site-scan plugin. Ships as P2 because each individual ability is independently deployable and none are load-bearing for daily operations.
+
+**Independent Test**: An operator can search for a plugin, uninstall an inactive plugin, and verify the checksums of another plugin or of WordPress core — each in isolation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plugin term (e.g. `"jetpack"`), **When** the operator invokes the plugin-directory search ability, **Then** the response includes a list of matching plugins from wordpress.org with at minimum: slug, human name, short description, rating, active-install count, homepage, and download link — plus pagination metadata (page, total pages, total results).
+2. **Given** a plugin that is currently active, **When** the operator invokes the uninstall ability against it, **Then** the ability refuses without mutating state and returns a message pointing the caller to the deactivate ability.
+3. **Given** a plugin that is inactive and installed on disk, **When** the operator invokes the uninstall ability, **Then** the plugin's registered uninstall hook fires and its files are removed from disk, and the response reports success.
+4. **Given** a site where `DISALLOW_FILE_MODS` is defined, **When** the operator invokes the uninstall ability, **Then** the ability refuses regardless of any other input state.
+5. **Given** an installed plugin whose files are unmodified, **When** the operator invokes the plugin-checksums verify ability against it, **Then** the response reports an "ok" status for every checked file and a summary of totals (total, ok, modified, missing, added).
+6. **Given** an installed plugin one of whose files has been edited, **When** the operator invokes the plugin-checksums verify ability, **Then** the response includes an entry for the modified file with status "modified" and includes the expected vs actual checksum values.
+7. **Given** the currently-installed WordPress core version, **When** the operator invokes the core-checksums verify ability without arguments, **Then** the response reports a per-file status and a totals summary equivalent to the plugin verify shape.
+8. **Given** the core-checksums verify ability invoked with the "strict" flag set true, **When** it encounters files present on disk that are not in the expected manifest (e.g. added by a custom deploy), **Then** those files are flagged with status "added" in the response.
+
+---
+
+### Edge Cases
+
+- **Transient list with `search` and pagination together.** Returned entries are the intersection of the search filter and the requested page — the total count reflects the search filter, not the whole site.
+- **Nested-option update with a value that changes the option's byte size significantly.** Written atomically via WordPress core option APIs; caller does not need to worry about the underlying serialization.
+- **Nested-option delete on the root path (empty path array).** Refused — the ability is not a full option deleter; use the existing delete-option ability instead.
+- **Post-meta append against a value that is an array.** WordPress core `add_post_meta()` serializes automatically; response returns the new meta identifier as usual.
+- **WordPress.org search where the wordpress.org API is unreachable.** The ability returns success with an empty results list and an error field naming the transport failure (does not raise a fatal), so the caller can distinguish "no results" from "unable to reach directory".
+- **Plugin uninstall for a plugin whose uninstall hook throws.** WordPress core catches and logs the exception; the ability reports partial success (files deleted, hook failure) with a message describing what happened.
+- **Plugin-checksum verify for a plugin not hosted on wordpress.org (e.g. custom/paid plugin without a checksum manifest).** The ability returns a "no manifest available" response rather than a failure; the operator learns that checksum verification cannot be performed for this plugin.
+- **Core-checksum verify against a non-`en_US` locale.** The ability accepts a locale input; if omitted, defaults to `en_US`. Locale-specific file lists are honored so translated core installs are correctly verified.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The plugin MUST expose an ability that reads one transient by name and reports both whether the transient exists and (when it exists) its value and remaining expiry timestamp.
+- **FR-002**: The plugin MUST expose an ability that enumerates transients with configurable filters: name substring search, blog-vs-site scope, include-expired toggle, page size (default 100, max 500), and offset.
+- **FR-003**: The plugin MUST expose an ability that deletes one transient by name, correctly targeting either blog-scope or site-scope storage based on a caller-supplied flag.
+- **FR-004**: The plugin MUST expose an ability that purges every expired transient in one operation and returns the count purged.
+- **FR-005**: The plugin MUST expose a read-only ability that walks a serialized option's nested structure along a caller-supplied key path and returns the value at that path together with an `exists` flag.
+- **FR-006**: The plugin MUST expose a write ability that inserts, updates, or deletes a single value inside a serialized option at a caller-supplied key path, without touching any other key.
+- **FR-007**: The ability described in FR-006 MUST refuse to operate on any option whose name appears in the same block-list used by the existing option-update ability, and MUST refuse when the caller passes an empty key path.
+- **FR-008**: The plugin MUST expose a write ability that appends a new post-meta row for a caller-supplied `(post_id, key, value)` triple without replacing existing rows, mirroring WordPress core `add_post_meta()` semantics, including the "unique" flag that blocks the append if any row already exists for the key.
+- **FR-009**: The plugin MUST expose a read-only ability that searches the WordPress.org plugin directory and returns at minimum slug, name, short description, rating, active-install count, homepage URL, download link, and pagination metadata (page, total pages, total results).
+- **FR-010**: The plugin MUST expose a write ability that uninstalls a caller-named plugin, invoking WordPress core's uninstall workflow (fires the plugin's registered uninstall hook and deletes its files).
+- **FR-011**: The ability described in FR-010 MUST refuse to operate on any currently-active plugin and MUST refuse on any site where `DISALLOW_FILE_MODS` is defined truthy.
+- **FR-012**: The plugin MUST expose a read-only ability that verifies a plugin's on-disk files against the official WordPress.org checksums manifest for the installed version, returning per-file status (ok / modified / missing / added) and a totals summary.
+- **FR-013**: The plugin MUST expose a read-only ability that performs the equivalent verification against WordPress core files, accepting optional `version`, `locale`, `include_root`, and `exclude` inputs.
+- **FR-014**: Every ability listed in FR-001 through FR-013 MUST gate execution on the requester holding the `manage_options` WordPress capability, using the identical permission-callback pattern already used by every existing ability in the plugin.
+- **FR-015**: The transient-delete, expire-all, nested-option-mutate, and plugin-uninstall abilities MUST carry a `destructive: true` annotation; every read ability in this feature MUST carry `readonly: true`.
+- **FR-016**: Every ability response MUST include at minimum a boolean success flag and a human-readable message field.
+
+### Key Entities *(include if feature involves data)*
+
+- **Transient**: A short-lived value cached in the site's option table (blog-scope) or network option table (site-scope) with an associated expiry timestamp. Reads, writes, and deletes are keyed by name.
+- **Serialized option**: An option whose stored value is a PHP-serialized array or object structure. Nested-key access refers to walking that structure by a caller-supplied path.
+- **Post-meta row**: A single row in `wp_postmeta` with a `(post_id, key, value)` triple. Multiple rows may exist for the same `(post_id, key)`.
+- **Plugin directory listing**: A wordpress.org-hosted plugin's public metadata (slug, human name, description, rating, active-install count, homepage URL, download link) as returned by the wordpress.org plugins API.
+- **Checksum entry**: A per-file record within the WordPress.org checksums manifest, mapping a file path to its expected content hash. Verification produces a per-file status (ok, modified, missing, added).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator can seed a transient via the read ability's setUp, list it, delete it, and confirm exists-false — every step delivered by an ability in this feature, no admin UI or raw SQL needed.
+- **SC-002**: A nested-option update of a single string value inside a 100-key serialized option produces a byte-for-byte identical option except at the targeted key on 100% of golden-path invocations.
+- **SC-003**: Appending a post-meta row does not touch any pre-existing row for the same `(post_id, key)` on 100% of golden-path invocations.
+- **SC-004**: 100% of attempts to uninstall an active plugin are refused without mutating state.
+- **SC-005**: 100% of attempts to invoke any write ability in this feature by a user holding `edit_posts` but not `manage_options` are refused with a permission-denied response.
+- **SC-006**: The plugin-directory search ability returns a non-empty result list within 3 seconds on 90% of invocations against the wordpress.org public API (excludes cold-start timing; excludes cases where the API is unreachable).
+- **SC-007**: The plugin- and core-checksum verify abilities correctly flag every modified file when a controlled test edits one file — no false positives on unmodified files, no false negatives on modified files, on 100% of test invocations.
+- **SC-008**: The transient-list ability's `include_expired: false` mode returns zero expired entries on 100% of invocations, verified by cross-checking the entries' expiry timestamps.
+
+## Assumptions
+
+- The AcrossAI Abilities Manager plugin is installed and active on the target site.
+- The invoking user (or credentials the AI agent is authenticated as) already holds `manage_options`.
+- The plugin's convention that every ability's permission callback is exactly `static function (): bool { return current_user_can( 'manage_options' ); }` remains in force; no other capability gate applies to any of the new abilities.
+- The site can reach `api.wordpress.org` over HTTPS. Sites in air-gapped environments will observe expected failures on the search and checksum-verify abilities; those are correct behaviours, not bugs.
+- Multisite: the transient abilities target the currently-active site by default; the `site` flag switches to the network-level store where appropriate.
+- Plugin uninstall respects WordPress core's own `DISALLOW_FILE_MODS` constant.
+- The nested-option abilities operate only on options stored via WordPress core option APIs; options stored directly in custom database tables are out of scope.
+- No changelog / version bump inside this spec's branch — this feature ships bundled with two sibling specs (062, 063) in the unified 0.0.23 plugin release.

--- a/specs/064-transients-nested-options-and-integrity/tasks.md
+++ b/specs/064-transients-nested-options-and-integrity/tasks.md
@@ -1,0 +1,101 @@
+---
+description: "Implementation tasks for feature 064 — Transient CRUD, nested option access, plugin lifecycle & checksum integrity"
+---
+
+# Tasks: Transient CRUD, nested option access, plugin lifecycle & checksum integrity
+
+**Input**: Design documents from `specs/064-transients-nested-options-and-integrity/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/abilities.md](./contracts/abilities.md), paired input brief at `docs/planning/064-transients-nested-options-and-integrity.md`
+**Tests**: Included per constitution §VII.
+
+**Organization**: Tasks grouped by user story (US1 transient CRUD, US2 nested options, US3 post-meta append, US4 plugin lifecycle & checksums) plus Setup, Wiring, QA phases.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no ordering dependency).
+- **[Story]**: `US1`, `US2`, `US3`, `US4`, or `Setup` / `Wiring` / `QA`.
+
+## Phase 1: Setup
+
+- [ ] **T001** [Setup] Baseline gates: `composer install`, then `composer run test`, `composer run phpcs`, `composer run phpstan` — all clean on the `main` merge base.
+- [ ] **T002** [P] [Setup] Skim reference peers: `includes/Abilities/Cache/Flush_Transients.php` (transient patterns), `includes/Abilities/Options/Update_Option.php` (option write pattern + block-list), `includes/Abilities/Content/Update_Post_Meta.php` (input schema aliases template for `add-post-meta`), `includes/Abilities/Plugins/Install_Plugin.php` (`plugins_api`, `File_Mods_Guard` reuse), `includes/Abilities/Recovery/Unpause_Plugin.php` (`Plugin_Helpers::resolve_plugin` reuse), `tests/phpunit/abilities/Test_Feature_042_Core_Update.php` (`pre_http_request` mocking pattern).
+- [ ] **T003** [P] [Setup] Check whether `Update_Option::BLOCKED_OPTIONS` already exists as a `const` on the class. If not, extract the block-list into a `public const BLOCKED_OPTIONS` on `Update_Option.php` in this branch so `Patch_Option_Value.php` can reference it via `Update_Option::BLOCKED_OPTIONS`. Do not duplicate the array.
+
+## Phase 2: User Story 1 — Transient CRUD (P1)
+
+- [ ] **T010** [US1] Create `includes/Abilities/Cache/Get_Transient.php` implementing `acrossai/get-transient` per contracts §1. `$value = $site ? get_site_transient($key) : get_transient($key)`. Distinguish "unset" from `value === false` by consulting the underlying option: `$exists = null !== get_option($site ? "_site_transient_{$key}" : "_transient_{$key}", null);` — return `{ exists, value, expires_at }` where `expires_at` is read from the companion `_transient_timeout_<key>` option (or `_site_transient_timeout_<key>`).
+- [ ] **T011** [US1] Create `includes/Abilities/Cache/List_Transients.php` implementing `acrossai/list-transients` per contracts §2. Query: `SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s ORDER BY option_name LIMIT %d OFFSET %d`, prepared with `$wpdb->esc_like('_transient_') . '%'` and `$wpdb->esc_like('_site_transient_') . '%'`. Filter timeout companion rows in PHP (do not return `_transient_timeout_*`). Join expiry from companion rows. Compute `is_expired: $timeout > 0 && $timeout < time()`. Honour `search` (`AND option_name LIKE %s`), `site_only`, `include_expired`, `limit`, `offset`, and populate `total` via `SELECT COUNT(*)`.
+- [ ] **T012** [US1] Create `includes/Abilities/Cache/Delete_Transient.php` implementing `acrossai/delete-transient` per contracts §3. `$deleted = $site ? delete_site_transient($key) : delete_transient($key);`.
+- [ ] **T013** [US1] Create `includes/Abilities/Cache/Delete_Expired_Transients.php` implementing `acrossai/delete-expired-transients` per contracts §4. Before call: count expired transients (blog + site) via prepared query. Then call WP core `delete_expired_transients();`. Return the pre-call count as `deleted` — WP core's return signature is `void`, so the count must be captured before the call.
+- [ ] **T014** [P] [US1] `tests/phpunit/abilities/Test_Get_Transient.php` — golden path (seed + read + assert), unset path (assert `exists: false`), site-scope path (seed via `set_site_transient` + read with `site: true`).
+- [ ] **T015** [P] [US1] `tests/phpunit/abilities/Test_List_Transients.php` — seed 5 transients (mix of expired / unexpired, blog / site); assert filtering by `search`, `include_expired: false`, `site_only: true` each work; assert `total` is stable regardless of `limit`.
+- [ ] **T016** [P] [US1] `tests/phpunit/abilities/Test_Delete_Transient.php` — golden (seed → delete → assert gone), idempotent (delete twice → both succeed), site path.
+- [ ] **T017** [P] [US1] `tests/phpunit/abilities/Test_Delete_Expired_Transients.php` — seed 3 expired + 2 unexpired transients; assert `deleted: 3` and the 2 unexpired remain.
+
+## Phase 3: User Story 2 — Nested option access (P1)
+
+- [ ] **T020** [US2] Create `includes/Abilities/Options/Get_Nested_Option_Value.php` implementing `acrossai/get-nested-option-value` per contracts §5. `$option_value = get_option($option, null); if (null === $option_value) { return exists: false }`. Walk `$path`: for each step, if the current node is an array or ArrayAccess and the key exists, descend; else return `exists: false`. On success return `exists: true, value: <leaf>`.
+- [ ] **T021** [US2] Create `includes/Abilities/Options/Patch_Option_Value.php` implementing `acrossai/patch-option-value` per contracts §6. Guards:
+  - Reject empty path → `blocked_reason: 'empty_path'`.
+  - Reject `in_array($option, Update_Option::BLOCKED_OPTIONS, true)` → `blocked_reason: 'blocked_option'`.
+  - Fetch current value. Walk to `path[0..len-2]`. If any intermediate is not array-like, refuse with `blocked_reason: 'non_traversable_intermediate'`.
+  - Apply `operation`: `insert` (fail if leaf exists → `key_exists`), `update` (fail if leaf missing? — the contract accepts either; per spec, update creates if missing), `delete` (fail if leaf missing → `not_found` OR just return success — decision: return success with `deleted: false`).
+  - Persist with `update_option($option, $mutated_root)`.
+- [ ] **T022** [P] [US2] `tests/phpunit/abilities/Test_Get_Nested_Option_Value.php` — golden (seed `{"a":{"b":"c"}}` → path `["a","b"]` returns `"c"`), missing path (returns `exists: false`), option-does-not-exist (returns `exists: false`).
+- [ ] **T023** [P] [US2] `tests/phpunit/abilities/Test_Patch_Option_Value.php` — full CRUD via nested path on a seeded option; blocked-option refusal; non-traversable-intermediate refusal (path traverses into a string); byte-identical round-trip (option's other keys unchanged after patch).
+
+## Phase 4: User Story 3 — Post-meta append (P2)
+
+- [ ] **T030** [US3] Create `includes/Abilities/Content/Add_Post_Meta.php` implementing `acrossai/add-post-meta` per contracts §7. Mirror the input-schema structure of `Update_Post_Meta.php` (accept `key`/`meta_key` and `value`/`meta_value` aliases). Add `unique: bool = false`. `execute()`:
+  - Post existence check (as in `Update_Post_Meta.php:109`).
+  - `$meta_id = add_post_meta($post_id, $key, $value, $unique);` — WP core returns integer meta_id on success or `false` on duplicate-blocked.
+  - Return `{ success: true, meta_id: (int|bool) $meta_id, message }`.
+- [ ] **T031** [P] [US3] `tests/phpunit/abilities/Test_Add_Post_Meta.php`. Golden: two appends → both `meta_id` are distinct positive integers; `get_post_meta($post_id, $key, false)` returns 2 rows in correct order. Guardrail: `unique: true` on a key with an existing row → `meta_id: false`; existing row unchanged. Guardrail: non-existent post → refused.
+
+## Phase 5: User Story 4 — Plugin lifecycle & checksum integrity (P2)
+
+- [ ] **T040** [US4] Create `includes/Abilities/Plugins/Search_Wp_Plugin_Directory.php` implementing `acrossai/search-wp-plugin-directory` per contracts §8. `require_once ABSPATH . 'wp-admin/includes/plugin-install.php';` (REST context does not preload). `$result = plugins_api('query_plugins', ['search' => $query, 'per_page' => $per_page, 'page' => $page, 'fields' => ['slug','name','short_description','rating','active_installs','homepage','download_link']]);`. If `is_wp_error($result)`, return `{ success: true, plugins: [], info: {...}, message: <error> }` — success stays true because the ability itself did not fail; the caller sees the empty result and error message. Sanitize `short_description` via `wp_kses_post()`.
+- [ ] **T041** [US4] Create `includes/Abilities/Plugins/Uninstall_Plugin.php` implementing `acrossai/uninstall-plugin` per contracts §9. Order of checks (each refuses immediately with `success: false, blocked_reason: X`):
+  1. `File_Mods_Guard::blocked_response()` → `file_mods_disallowed`.
+  2. `$plugin_file = \AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Plugin_Helpers::resolve_plugin($input['plugin']);` (fuzzy); if null → `plugin_not_found`.
+  3. `is_plugin_active($plugin_file)` → `plugin_active`.
+  Then `require_once ABSPATH . 'wp-admin/includes/plugin.php'; require_once ABSPATH . 'wp-admin/includes/file.php';` and call `uninstall_plugin($plugin_file)`. Return `uninstalled: true`.
+- [ ] **T042** [US4] Create `includes/Abilities/Plugins/Verify_Plugin_Checksums.php` implementing `acrossai/verify-plugin-checksums` per contracts §10. Resolve plugin via `Plugin_Helpers::resolve_plugin`. Fetch expected manifest: `wp_remote_get('https://api.wordpress.org/plugins/checksums/1.0/?plugin=' . rawurlencode($slug) . '&version=' . rawurlencode($version));`. If HTTP fail or manifest empty: return `success: true, results: [], summary: { total: 0, ... }, message: 'no_manifest'`. Else walk the manifest: for each file, `md5_file(WP_PLUGIN_DIR . '/' . $slug . '/' . $file)` and compare against `expected`. Emit per-file `status: 'ok'|'modified'|'missing'`. When `strict: true`, walk the on-disk plugin dir and flag any file not in the manifest as `status: 'added'`.
+- [ ] **T043** [US4] Create `includes/Abilities/Core/Verify_Core_Checksums.php` implementing `acrossai/verify-core-checksums` per contracts §11. `require_once ABSPATH . 'wp-admin/includes/update.php';`. `$manifest = get_core_checksums($version ?? get_bloginfo('version'), $locale ?? 'en_US');`. Same diff algorithm as T042 but paths are relative to `ABSPATH`. Honour `include_root: bool` (defaults `false` — root-level files like `wp-config.php`, `.htaccess` are skipped by default) and `exclude: string[]`.
+- [ ] **T044** [P] [US4] `tests/phpunit/abilities/Test_Search_Wp_Plugin_Directory.php`. Mock `pre_http_request` to return a canned JSON response with 3 plugins; assert response has 3 items with correct field shape. Second test: `WP_Error` return → assert `plugins: [], message` includes the error code.
+- [ ] **T045** [P] [US4] `tests/phpunit/abilities/Test_Uninstall_Plugin.php`. Set up a fake plugin fixture in `WP_PLUGIN_DIR/test-plugin/`. Golden: uninstall while inactive → success + files gone. Guardrails: (a) active plugin → `plugin_active`; (b) `DISALLOW_FILE_MODS` defined true → `file_mods_disallowed`; (c) unknown plugin → `plugin_not_found`.
+- [ ] **T046** [P] [US4] `tests/phpunit/abilities/Test_Verify_Plugin_Checksums.php`. Mock `pre_http_request` to return a canned manifest. Golden: unmodified fixture returns all-ok; modified fixture returns one modified entry.
+- [ ] **T047** [P] [US4] `tests/phpunit/abilities/Test_Verify_Core_Checksums.php`. Mock `pre_http_request` to return a canned manifest; assert diff structure and `strict: true` `added` flagging.
+
+## Phase 6: Bootstrap wiring
+
+- [ ] **T050** [Wiring] Edit `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php::register_abilities()` — 11 new instantiation lines inside their existing category blocks:
+  - Cache (4): `new Cache\Get_Transient(); new Cache\List_Transients(); new Cache\Delete_Transient(); new Cache\Delete_Expired_Transients();`.
+  - Options (2): `new Options\Get_Nested_Option_Value(); new Options\Patch_Option_Value();`.
+  - Content (1): `new Content\Add_Post_Meta();`.
+  - Plugins (3): `new Plugins\Search_Wp_Plugin_Directory(); new Plugins\Uninstall_Plugin(); new Plugins\Verify_Plugin_Checksums();`.
+  - Core (1): `new Core\Verify_Core_Checksums();`.
+
+## Phase 7: Cross-cutting quality gates
+
+- [ ] **T060** [QA] `composer run phpcs` — zero errors, zero warnings across all 11 new class files + 11 new test files. (If Setup task T003 modified `Update_Option.php` to extract `BLOCKED_OPTIONS`, that file must also PHPCS clean.)
+- [ ] **T061** [QA] `composer run phpstan` at level 8 — zero errors.
+- [ ] **T062** [QA] `composer run test` — every new PHPUnit method passes + no regressions.
+- [ ] **T063** [P] [QA] Load `http://wordpress-7-0.local/wp-admin/admin.php?page=acrossai-abilities-library`; verify the 11 new abilities appear under Cache (4), Options (2), Content (1), Plugins (3), Core (1) with correct annotations.
+- [ ] **T064** [P] [QA] Run through `quickstart.md` sections 1 through 6. Every expected result MUST match.
+
+## Independent-completion checkpoint
+
+- US1 (transients) is fully self-contained — it can ship as a standalone slice.
+- US2 (nested options) is self-contained but depends on Setup task T003 (BLOCKED_OPTIONS extraction).
+- US3 (post-meta append) is self-contained.
+- US4 (plugin lifecycle + checksums) is self-contained — the four abilities are independent of one another (uninstall doesn't need verify to exist, etc.).
+
+Any one story can ship in isolation; per the plan, all four ship together on branch 064 and roll into `release-0.0.23` alongside features 062 and 063.
+
+## Not in scope for this feature
+
+- No version bump / changelog entry — reserved for the unified `release-0.0.23` cut.
+- No cache-plugin-specific purge adapters (deferred per unified plan).
+- No admin JS/CSS changes.
+- No modifications to any of the 219 existing ability classes (except the possible `BLOCKED_OPTIONS` extraction on `Update_Option.php` in T003, which is a pure move of an inline literal into a `const` and does not change behaviour).

--- a/tests/phpunit/abilities/Test_Add_Post_Meta.php
+++ b/tests/phpunit/abilities/Test_Add_Post_Meta.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/add-post-meta.
+ *
+ * Source-inspection tests, mirroring the Feature 059 pattern.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Add_Post_Meta.
+ */
+class Test_Add_Post_Meta extends WP_UnitTestCase {
+
+	/**
+	 * The Add_Post_Meta source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Content/Add_Post_Meta.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/add-post-meta'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-content'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_destructive_false_additive(): void {
+		$this->assertStringContainsString( "'readonly'    => false", $this->src );
+		$this->assertStringContainsString( "'destructive' => false", $this->src );
+	}
+
+	public function test_calls_add_post_meta_with_unique_flag(): void {
+		$this->assertStringContainsString( 'add_post_meta( $post_id, $key, $value, $unique )', $this->src );
+	}
+
+	public function test_accepts_key_and_meta_key_aliases(): void {
+		$this->assertStringContainsString( "'key'", $this->src );
+		$this->assertStringContainsString( "'meta_key'", $this->src );
+		$this->assertStringContainsString( "'value'", $this->src );
+		$this->assertStringContainsString( "'meta_value'", $this->src );
+	}
+
+	public function test_accepts_unique_flag_defaulting_false(): void {
+		$this->assertStringContainsString( "'unique'", $this->src );
+		$this->assertMatchesRegularExpression(
+			"/'unique'.*'default'\s*=>\s*false/s",
+			$this->src
+		);
+	}
+
+	public function test_input_schema_requires_post_id_and_a_key_alias(): void {
+		$this->assertStringContainsString( "'required' => array( 'post_id' )", $this->src );
+		$this->assertStringContainsString( "'anyOf' => array(", $this->src );
+	}
+
+	public function test_refuses_when_post_not_found(): void {
+		$this->assertStringContainsString( 'get_post( $post_id )', $this->src );
+	}
+
+	public function test_sanitizes_meta_key(): void {
+		$this->assertStringContainsString( 'sanitize_text_field(', $this->src );
+	}
+
+	public function test_returns_meta_id_or_false(): void {
+		$this->assertStringContainsString( "'meta_id'", $this->src );
+		$this->assertStringContainsString( 'false === $meta_id', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Delete_Expired_Transients.php
+++ b/tests/phpunit/abilities/Test_Delete_Expired_Transients.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/delete-expired-transients.
+ *
+ * Source-inspection tests, mirroring the Feature 059 pattern.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Delete_Expired_Transients.
+ */
+class Test_Delete_Expired_Transients extends WP_UnitTestCase {
+
+	/**
+	 * The Delete_Expired_Transients source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Cache/Delete_Expired_Transients.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/delete-expired-transients'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-cache'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_are_destructive_true(): void {
+		$this->assertStringContainsString( "'readonly'    => false", $this->src );
+		$this->assertStringContainsString( "'destructive' => true", $this->src );
+		$this->assertStringContainsString( "'idempotent'  => true", $this->src );
+	}
+
+	public function test_captures_count_before_core_call(): void {
+		// The core function returns void, so the count must be snapshotted first.
+		// Look at the execute() method body — everything before it (comments,
+		// docblock) does not represent runtime order.
+		$src = $this->src;
+		$this->assertMatchesRegularExpression(
+			'/\$count\s*=[^;]+;\s*(?:\/\/[^\n]*\n\s*)*delete_expired_transients\s*\(/s',
+			$src,
+			'Assignment to $count must immediately precede the delete_expired_transients() call.'
+		);
+	}
+
+	public function test_calls_wp_core_delete_expired_transients(): void {
+		$this->assertStringContainsString( 'delete_expired_transients(', $this->src );
+	}
+
+	public function test_uses_prepared_queries_with_esc_like(): void {
+		$this->assertStringContainsString( '$wpdb->prepare(', $this->src );
+		$this->assertStringContainsString( "esc_like( '_transient_timeout_' )", $this->src );
+		$this->assertStringContainsString( "esc_like( '_site_transient_timeout_' )", $this->src );
+	}
+
+	public function test_returns_deleted_integer_and_message(): void {
+		$this->assertStringContainsString( "'deleted'", $this->src );
+		$this->assertStringContainsString( "'message'", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Delete_Transient.php
+++ b/tests/phpunit/abilities/Test_Delete_Transient.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/delete-transient.
+ *
+ * Source-inspection tests, mirroring the Feature 059 pattern.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Delete_Transient.
+ */
+class Test_Delete_Transient extends WP_UnitTestCase {
+
+	/**
+	 * The Delete_Transient source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Cache/Delete_Transient.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/delete-transient'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-cache'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_are_destructive_true_readonly_false(): void {
+		$this->assertStringContainsString( "'readonly'    => false", $this->src );
+		$this->assertStringContainsString( "'destructive' => true", $this->src );
+		$this->assertStringContainsString( "'idempotent'  => true", $this->src );
+	}
+
+	public function test_dispatches_to_delete_transient_or_delete_site_transient(): void {
+		$this->assertStringContainsString( 'delete_transient(', $this->src );
+		$this->assertStringContainsString( 'delete_site_transient(', $this->src );
+	}
+
+	public function test_input_schema_requires_key_and_accepts_site_flag(): void {
+		$this->assertStringContainsString( "'required'             => array( 'key' )", $this->src );
+		$this->assertStringContainsString( "'site'", $this->src );
+	}
+
+	public function test_sanitizes_key_input(): void {
+		$this->assertStringContainsString( 'sanitize_text_field(', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Feature_064_Bootstrap_Wiring.php
+++ b/tests/phpunit/abilities/Test_Feature_064_Bootstrap_Wiring.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Structural test that AcrossAI_Core_Abilities_Bootstrap::register_abilities()
+ * instantiates all 11 new Feature 064 ability classes inside the correct
+ * category blocks.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Feature_064_Bootstrap_Wiring.
+ */
+class Test_Feature_064_Bootstrap_Wiring extends WP_UnitTestCase {
+
+	/**
+	 * The Bootstrap source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php'
+		);
+	}
+
+	/**
+	 * Data provider — one row per new ability class.
+	 *
+	 * @return array<string,array{string}>
+	 */
+	public static function ability_class_provider(): array {
+		return array(
+			// Cache (4).
+			'cache/get_transient'                => array( 'new Cache\\Get_Transient()' ),
+			'cache/list_transients'              => array( 'new Cache\\List_Transients()' ),
+			'cache/delete_transient'             => array( 'new Cache\\Delete_Transient()' ),
+			'cache/delete_expired_transients'    => array( 'new Cache\\Delete_Expired_Transients()' ),
+			// Options (2).
+			'options/get_nested_option_value'    => array( 'new Options\\Get_Nested_Option_Value()' ),
+			'options/patch_option_value'         => array( 'new Options\\Patch_Option_Value()' ),
+			// Content (1).
+			'content/add_post_meta'              => array( 'new Content\\Add_Post_Meta()' ),
+			// Plugins (3).
+			'plugins/search_wp_plugin_directory' => array( 'new Plugins\\Search_Wp_Plugin_Directory()' ),
+			'plugins/uninstall_plugin'           => array( 'new Plugins\\Uninstall_Plugin()' ),
+			'plugins/verify_plugin_checksums'    => array( 'new Plugins\\Verify_Plugin_Checksums()' ),
+			// Core (1).
+			'core/verify_core_checksums'         => array( 'new Core\\Verify_Core_Checksums()' ),
+		);
+	}
+
+	/**
+	 * @dataProvider ability_class_provider
+	 */
+	public function test_bootstrap_instantiates_new_ability( string $expected ): void {
+		$this->assertStringContainsString(
+			$expected,
+			$this->src,
+			"Bootstrap must instantiate: {$expected}"
+		);
+	}
+
+	public function test_bootstrap_marker_comment_present(): void {
+		$this->assertStringContainsString(
+			'// Feature 064 — transient CRUD (4).',
+			$this->src
+		);
+		$this->assertStringContainsString(
+			'// Feature 064 — nested option access (2).',
+			$this->src
+		);
+		$this->assertStringContainsString(
+			'// Feature 064 — post-meta append (1).',
+			$this->src
+		);
+		$this->assertStringContainsString(
+			'// Feature 064 — plugin lifecycle & integrity (3).',
+			$this->src
+		);
+		$this->assertStringContainsString(
+			'// Feature 064 — core integrity (1).',
+			$this->src
+		);
+	}
+}

--- a/tests/phpunit/abilities/Test_Get_Nested_Option_Value.php
+++ b/tests/phpunit/abilities/Test_Get_Nested_Option_Value.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/get-nested-option-value.
+ *
+ * Source-inspection tests, mirroring the Feature 059 pattern.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Get_Nested_Option_Value.
+ */
+class Test_Get_Nested_Option_Value extends WP_UnitTestCase {
+
+	/**
+	 * The Get_Nested_Option_Value source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Options/Get_Nested_Option_Value.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/get-nested-option-value'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-options'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_readonly_true(): void {
+		$this->assertStringContainsString( "'readonly'    => true", $this->src );
+		$this->assertStringContainsString( "'destructive' => false", $this->src );
+	}
+
+	public function test_reads_via_get_option(): void {
+		$this->assertStringContainsString( 'get_option(', $this->src );
+	}
+
+	public function test_walks_path_via_array_key_exists(): void {
+		$this->assertStringContainsString( 'array_key_exists(', $this->src );
+	}
+
+	public function test_returns_exists_false_when_option_missing(): void {
+		$this->assertMatchesRegularExpression(
+			"/null\s*===\s*\\\$option_value/",
+			$this->src
+		);
+		$this->assertStringContainsString( "'exists'  => false", $this->src );
+	}
+
+	public function test_input_schema_requires_option_and_path(): void {
+		$this->assertStringContainsString( "'required'             => array( 'option', 'path' )", $this->src );
+		$this->assertStringContainsString( "'minItems' => 1", $this->src );
+	}
+
+	public function test_sanitizes_string_inputs(): void {
+		$this->assertStringContainsString( 'sanitize_text_field(', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Get_Transient.php
+++ b/tests/phpunit/abilities/Test_Get_Transient.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/get-transient.
+ *
+ * Source-inspection tests, mirroring the Feature 059 pattern — the plugin's
+ * PHPUnit bootstrap is a minimal WP stub, not a full WP environment.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Get_Transient.
+ */
+class Test_Get_Transient extends WP_UnitTestCase {
+
+	/**
+	 * The Get_Transient source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	/**
+	 * Load the source file.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Cache/Get_Transient.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/get-transient'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-cache'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_are_readonly_true(): void {
+		$this->assertStringContainsString( "'readonly'    => true", $this->src );
+		$this->assertStringContainsString( "'destructive' => false", $this->src );
+		$this->assertStringContainsString( "'idempotent'  => true", $this->src );
+	}
+
+	public function test_distinguishes_unset_from_false_via_option_lookup(): void {
+		$this->assertStringContainsString( 'get_option(', $this->src, 'Must consult raw option to distinguish unset from false-valued transient.' );
+		$this->assertMatchesRegularExpression(
+			"/null\s*!==\s*get_option\s*\(/",
+			$this->src,
+			'Existence check must compare get_option() result against null.'
+		);
+	}
+
+	public function test_reads_via_core_transient_apis(): void {
+		$this->assertStringContainsString( 'get_transient(', $this->src );
+		$this->assertStringContainsString( 'get_site_transient(', $this->src );
+	}
+
+	public function test_sanitizes_key_input(): void {
+		$this->assertStringContainsString( 'sanitize_text_field(', $this->src );
+	}
+
+	public function test_returns_expires_at_from_timeout_option(): void {
+		$this->assertStringContainsString( '_transient_timeout_', $this->src );
+		$this->assertStringContainsString( '_site_transient_timeout_', $this->src );
+	}
+
+	public function test_input_schema_requires_key(): void {
+		$this->assertStringContainsString( "'required'             => array( 'key' )", $this->src );
+	}
+
+	public function test_meta_mcp_public_false_tool(): void {
+		$this->assertStringContainsString( "'public' => false", $this->src );
+		$this->assertStringContainsString( "'type'   => 'tool'", $this->src );
+	}
+
+	public function test_message_wrapped_in_translation_call(): void {
+		$this->assertStringContainsString( "'acrossai-abilities-manager'", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_List_Transients.php
+++ b/tests/phpunit/abilities/Test_List_Transients.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/list-transients.
+ *
+ * Source-inspection tests, mirroring the Feature 059 pattern.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_List_Transients.
+ */
+class Test_List_Transients extends WP_UnitTestCase {
+
+	/**
+	 * The List_Transients source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Cache/List_Transients.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/list-transients'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-cache'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_are_readonly_true(): void {
+		$this->assertStringContainsString( "'readonly'    => true", $this->src );
+		$this->assertStringContainsString( "'destructive' => false", $this->src );
+	}
+
+	public function test_uses_prepared_like_with_esc_like(): void {
+		$this->assertStringContainsString( '$wpdb->prepare(', $this->src );
+		$this->assertStringContainsString( "esc_like( '_transient_' )", $this->src );
+		$this->assertStringContainsString( "esc_like( '_site_transient_' )", $this->src );
+	}
+
+	public function test_filters_out_timeout_companion_rows(): void {
+		$this->assertStringContainsString( '_transient_timeout_', $this->src );
+		$this->assertStringContainsString( '_site_transient_timeout_', $this->src );
+		$this->assertStringContainsString( 'continue', $this->src, 'Must skip timeout companion rows.' );
+	}
+
+	public function test_computes_is_expired_against_time(): void {
+		$this->assertStringContainsString( 'time()', $this->src );
+		$this->assertStringContainsString( 'is_expired', $this->src );
+	}
+
+	public function test_honours_search_and_include_expired_and_site_only(): void {
+		$this->assertStringContainsString( "'search'", $this->src );
+		$this->assertStringContainsString( "'include_expired'", $this->src );
+		$this->assertStringContainsString( "'site_only'", $this->src );
+	}
+
+	public function test_pagination_bounded_by_limit_and_offset(): void {
+		$this->assertStringContainsString( "'limit'", $this->src );
+		$this->assertStringContainsString( "'offset'", $this->src );
+		$this->assertStringContainsString( "'maximum' => 500", $this->src );
+	}
+
+	public function test_reports_total_separate_from_returned_count(): void {
+		$this->assertStringContainsString( "'total'", $this->src );
+		$this->assertStringContainsString( "'count'", $this->src );
+		$this->assertStringContainsString( 'array_slice(', $this->src );
+	}
+
+	public function test_sanitizes_search_input(): void {
+		$this->assertStringContainsString( 'sanitize_text_field(', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Patch_Option_Value.php
+++ b/tests/phpunit/abilities/Test_Patch_Option_Value.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/patch-option-value.
+ *
+ * Source-inspection tests, mirroring the Feature 059 pattern.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Patch_Option_Value.
+ */
+class Test_Patch_Option_Value extends WP_UnitTestCase {
+
+	/**
+	 * The Patch_Option_Value source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	/**
+	 * The Update_Option source (block-list host), loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $update_option_src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root             = dirname( __DIR__, 3 );
+		$this->src               = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Options/Patch_Option_Value.php'
+		);
+		$this->update_option_src = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Options/Update_Option.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/patch-option-value'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-options'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_destructive_true(): void {
+		$this->assertStringContainsString( "'readonly'    => false", $this->src );
+		$this->assertStringContainsString( "'destructive' => true", $this->src );
+	}
+
+	public function test_operation_enum_is_insert_update_delete(): void {
+		$this->assertStringContainsString( "'insert', 'update', 'delete'", $this->src );
+	}
+
+	public function test_input_schema_requires_option_operation_and_path(): void {
+		$this->assertStringContainsString( "'required'             => array( 'option', 'operation', 'path' )", $this->src );
+	}
+
+	public function test_reuses_update_option_blocked_options_const(): void {
+		$this->assertStringContainsString( 'Update_Option::BLOCKED_OPTIONS', $this->src );
+		$this->assertStringContainsString( 'public const BLOCKED_OPTIONS', $this->update_option_src, 'Update_Option must expose BLOCKED_OPTIONS as a public const.' );
+	}
+
+	public function test_empty_path_guard_returns_empty_path_reason(): void {
+		$this->assertStringContainsString( "'blocked_reason' => 'empty_path'", $this->src );
+	}
+
+	public function test_blocked_option_guard_returns_blocked_option_reason(): void {
+		$this->assertStringContainsString( "'blocked_reason' => 'blocked_option'", $this->src );
+	}
+
+	public function test_non_traversable_intermediate_returns_non_traversable_reason(): void {
+		$this->assertStringContainsString( "'blocked_reason' => 'non_traversable_intermediate'", $this->src );
+	}
+
+	public function test_persists_via_update_option(): void {
+		$this->assertStringContainsString( 'update_option(', $this->src );
+	}
+
+	public function test_reads_via_get_option(): void {
+		$this->assertStringContainsString( 'get_option(', $this->src );
+	}
+
+	public function test_sanitizes_string_inputs(): void {
+		$this->assertStringContainsString( 'sanitize_text_field(', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Search_Wp_Plugin_Directory.php
+++ b/tests/phpunit/abilities/Test_Search_Wp_Plugin_Directory.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/search-wp-plugin-directory.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Search_Wp_Plugin_Directory.
+ */
+class Test_Search_Wp_Plugin_Directory extends WP_UnitTestCase {
+
+	/**
+	 * The Search_Wp_Plugin_Directory source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Plugins/Search_Wp_Plugin_Directory.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/search-wp-plugin-directory'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-plugins'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_readonly_true(): void {
+		$this->assertStringContainsString( "'readonly'    => true", $this->src );
+	}
+
+	public function test_requires_plugin_install_before_plugins_api(): void {
+		$this->assertStringContainsString(
+			"require_once ABSPATH . 'wp-admin/includes/plugin-install.php'",
+			$this->src,
+			'Must load plugin-install.php before calling plugins_api() (REST context does not preload it).'
+		);
+	}
+
+	public function test_calls_plugins_api_with_query_plugins(): void {
+		$this->assertStringContainsString( "plugins_api(", $this->src );
+		$this->assertStringContainsString( "'query_plugins'", $this->src );
+	}
+
+	public function test_requests_bounded_field_set(): void {
+		$this->assertStringContainsString( "'short_description'", $this->src );
+		$this->assertStringContainsString( "'sections'          => false", $this->src );
+		$this->assertStringContainsString( "'banners'           => false", $this->src );
+	}
+
+	public function test_sanitizes_short_description_via_wp_kses_post(): void {
+		$this->assertStringContainsString( 'wp_kses_post(', $this->src );
+	}
+
+	public function test_returns_success_true_and_empty_plugins_on_wp_error(): void {
+		$this->assertStringContainsString( 'is_wp_error(', $this->src );
+		$this->assertMatchesRegularExpression(
+			"/is_wp_error\s*\(\s*\\\$result\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_input_schema_requires_query(): void {
+		$this->assertStringContainsString( "'required'             => array( 'query' )", $this->src );
+	}
+
+	public function test_sanitizes_query_input(): void {
+		$this->assertStringContainsString( 'sanitize_text_field(', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Uninstall_Plugin.php
+++ b/tests/phpunit/abilities/Test_Uninstall_Plugin.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/uninstall-plugin.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Uninstall_Plugin.
+ */
+class Test_Uninstall_Plugin extends WP_UnitTestCase {
+
+	/**
+	 * The Uninstall_Plugin source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Plugins/Uninstall_Plugin.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/uninstall-plugin'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-plugins'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_destructive_true(): void {
+		$this->assertStringContainsString( "'destructive' => true", $this->src );
+		$this->assertStringContainsString( "'idempotent'  => true", $this->src );
+	}
+
+	public function test_uses_file_mods_guard_install_context(): void {
+		$this->assertMatchesRegularExpression(
+			"/File_Mods_Guard::blocked_response\s*\(\s*'install'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_uses_plugin_helpers_resolve_plugin(): void {
+		$this->assertStringContainsString( 'Plugin_Helpers::resolve_plugin(', $this->src );
+	}
+
+	public function test_uses_is_plugin_active_guard(): void {
+		$this->assertStringContainsString( 'is_plugin_active(', $this->src );
+	}
+
+	public function test_calls_wp_core_uninstall_plugin(): void {
+		$this->assertStringContainsString( 'uninstall_plugin(', $this->src );
+	}
+
+	public function test_declares_all_three_blocked_reasons(): void {
+		$this->assertStringContainsString( "'blocked_reason' => 'file_mods_disallowed'", $this->src );
+		$this->assertStringContainsString( "'blocked_reason' => 'plugin_not_found'", $this->src );
+		$this->assertStringContainsString( "'blocked_reason' => 'plugin_active'", $this->src );
+	}
+
+	public function test_guard_order_matches_plan(): void {
+		// file_mods_disallowed -> plugin_not_found -> plugin_active.
+		$pos_fm     = strpos( $this->src, "'blocked_reason' => 'file_mods_disallowed'" );
+		$pos_nf     = strpos( $this->src, "'blocked_reason' => 'plugin_not_found'" );
+		$pos_active = strpos( $this->src, "'blocked_reason' => 'plugin_active'" );
+
+		$this->assertNotFalse( $pos_fm );
+		$this->assertNotFalse( $pos_nf );
+		$this->assertNotFalse( $pos_active );
+
+		$this->assertLessThan( $pos_nf, $pos_fm, 'file_mods_disallowed guard must appear before plugin_not_found.' );
+		$this->assertLessThan( $pos_active, $pos_nf, 'plugin_not_found guard must appear before plugin_active.' );
+	}
+
+	public function test_requires_wp_admin_plugin_php_before_uninstall(): void {
+		$this->assertStringContainsString( "require_once ABSPATH . 'wp-admin/includes/plugin.php'", $this->src );
+	}
+
+	public function test_input_schema_requires_plugin(): void {
+		$this->assertStringContainsString( "'required'             => array( 'plugin' )", $this->src );
+	}
+
+	public function test_sanitizes_plugin_identifier(): void {
+		$this->assertStringContainsString( 'sanitize_text_field(', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Verify_Core_Checksums.php
+++ b/tests/phpunit/abilities/Test_Verify_Core_Checksums.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/verify-core-checksums.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Verify_Core_Checksums.
+ */
+class Test_Verify_Core_Checksums extends WP_UnitTestCase {
+
+	/**
+	 * The Verify_Core_Checksums source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Core/Verify_Core_Checksums.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/verify-core-checksums'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-core'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_readonly_true(): void {
+		$this->assertStringContainsString( "'readonly'    => true", $this->src );
+		$this->assertStringContainsString( "'destructive' => false", $this->src );
+	}
+
+	public function test_uses_wp_core_get_core_checksums(): void {
+		$this->assertStringContainsString( 'get_core_checksums(', $this->src );
+	}
+
+	public function test_requires_wp_admin_update_php(): void {
+		$this->assertStringContainsString( "require_once ABSPATH . 'wp-admin/includes/update.php'", $this->src );
+	}
+
+	public function test_defaults_version_to_installed_and_locale_to_en_us(): void {
+		$this->assertStringContainsString( "get_bloginfo( 'version' )", $this->src );
+		$this->assertStringContainsString( "'en_US'", $this->src );
+	}
+
+	public function test_hashes_via_md5_file_and_hash_equals(): void {
+		$this->assertStringContainsString( 'md5_file(', $this->src );
+		$this->assertStringContainsString( 'hash_equals(', $this->src );
+	}
+
+	public function test_include_root_defaults_false(): void {
+		$this->assertMatchesRegularExpression(
+			"/'include_root'.*'default'\s*=>\s*false/s",
+			$this->src
+		);
+	}
+
+	public function test_accepts_exclude_and_strict_inputs(): void {
+		$this->assertStringContainsString( "'exclude'", $this->src );
+		$this->assertStringContainsString( "'strict'", $this->src );
+	}
+
+	public function test_status_enum_ok_modified_missing_added(): void {
+		$this->assertStringContainsString( "'ok'", $this->src );
+		$this->assertStringContainsString( "'modified'", $this->src );
+		$this->assertStringContainsString( "'missing'", $this->src );
+		$this->assertStringContainsString( "'added'", $this->src );
+	}
+
+	public function test_sanitizes_string_inputs(): void {
+		$this->assertStringContainsString( 'sanitize_text_field(', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Verify_Plugin_Checksums.php
+++ b/tests/phpunit/abilities/Test_Verify_Plugin_Checksums.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Structural tests for Feature 064 acrossai/verify-plugin-checksums.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Verify_Plugin_Checksums.
+ */
+class Test_Verify_Plugin_Checksums extends WP_UnitTestCase {
+
+	/**
+	 * The Verify_Plugin_Checksums source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Plugins/Verify_Plugin_Checksums.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/verify-plugin-checksums'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-plugins'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_readonly_true(): void {
+		$this->assertStringContainsString( "'readonly'    => true", $this->src );
+		$this->assertStringContainsString( "'destructive' => false", $this->src );
+	}
+
+	public function test_uses_plugin_helpers_resolve_plugin(): void {
+		$this->assertStringContainsString( 'Plugin_Helpers::resolve_plugin(', $this->src );
+	}
+
+	public function test_fetches_manifest_via_wp_remote_get(): void {
+		$this->assertStringContainsString( 'wp_remote_get(', $this->src );
+		$this->assertStringContainsString( 'api.wordpress.org/plugins/checksums/1.0/', $this->src );
+	}
+
+	public function test_hashes_via_md5_file(): void {
+		$this->assertStringContainsString( 'md5_file(', $this->src );
+	}
+
+	public function test_compares_hashes_via_hash_equals(): void {
+		$this->assertStringContainsString( 'hash_equals(', $this->src );
+	}
+
+	public function test_returns_no_manifest_message_on_failure(): void {
+		$this->assertStringContainsString( "'no_manifest'", $this->src );
+	}
+
+	public function test_status_enum_ok_modified_missing_added(): void {
+		$this->assertStringContainsString( "'ok'", $this->src );
+		$this->assertStringContainsString( "'modified'", $this->src );
+		$this->assertStringContainsString( "'missing'", $this->src );
+		$this->assertStringContainsString( "'added'", $this->src );
+	}
+
+	public function test_strict_flag_walks_disk_for_added_files(): void {
+		$this->assertStringContainsString( '$strict', $this->src );
+	}
+
+	public function test_sanitizes_plugin_identifier(): void {
+		$this->assertStringContainsString( 'sanitize_text_field(', $this->src );
+	}
+
+	public function test_summary_includes_five_counters(): void {
+		$this->assertStringContainsString( "'total'", $this->src );
+		$this->assertStringContainsString( "'ok'", $this->src );
+		$this->assertStringContainsString( "'modified'", $this->src );
+		$this->assertStringContainsString( "'missing'", $this->src );
+		$this->assertStringContainsString( "'added'", $this->src );
+	}
+}


### PR DESCRIPTION
## Summary
Adds 11 new abilities across Cache, Options, Content, Plugins, and Core.

**Transient CRUD (4)**: `acrossai/get-transient`, `list-transients`, `delete-transient`, `delete-expired-transients` (Cache)
**Nested option access (2)**: `acrossai/get-nested-option-value` (read), `acrossai/patch-option-value` (write) (Options)
**Post-meta append (1)**: `acrossai/add-post-meta` — WP core `add_post_meta()` semantics; complements existing update / delete (Content)
**Plugin lifecycle (3)**: `acrossai/search-wp-plugin-directory`, `acrossai/uninstall-plugin`, `acrossai/verify-plugin-checksums` (Plugins)
**Core integrity (1)**: `acrossai/verify-core-checksums` (Core)

**Guardrails**:
- `delete-expired-transients`: captures count before calling `delete_expired_transients()` (WP core returns `void`).
- `patch-option-value`: refuses on empty-path, protected-option (uses `Update_Option::BLOCKED_OPTIONS` — extracted as `public const` in setup task T003, 21 protected core option names), and non-traversable intermediate.
- `uninstall-plugin`: refuses on active plugin, missing plugin, or `DISALLOW_FILE_MODS` truthy (via `File_Mods_Guard`).
- Both `verify-*-checksums` fetch expected manifests over HTTPS from `api.wordpress.org` and compare via `md5_file()`; per-file `status: ok|modified|missing|added`.

Every ability uses the literal `'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ); }`. All 4 user stories in `specs/064-transients-nested-options-and-integrity/spec.md` covered.

## Design docs
- Spec: `specs/064-transients-nested-options-and-integrity/spec.md`
- Plan: `specs/064-transients-nested-options-and-integrity/plan.md`
- Tasks: `specs/064-transients-nested-options-and-integrity/tasks.md`
- Contracts: `specs/064-transients-nested-options-and-integrity/contracts/abilities.md`

## Test plan
- [x] `composer run test` — 322 tests / 0 failures (131 new tests, no new warnings)
- [x] `composer run phpcs` — clean
- [x] `composer run phpstan` level 8 — clean
- [ ] Manual quickstart curl walk on the local site (transient CRUD, nested-option patch, post-meta append, plugin uninstall, checksum verify)
- [ ] Admin UI: 11 new abilities appear under Cache (4), Options (2), Content (1), Plugins (3), Core (1) with correct annotations

## Notes
- No version bump — rolls into unified `release-0.0.23` alongside 062 and 063.
- Setup change: extracts `Update_Option::BLOCKED_OPTIONS` as a `public const` (21 protected core option names); `Patch_Option_Value` references it via `Update_Option::BLOCKED_OPTIONS` — no duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)