### PR TITLE
feat(065): safety envelope + payload enrichment across 9 abilities

### DIFF
--- a/includes/Abilities/Content/Delete_Post.php
+++ b/includes/Abilities/Content/Delete_Post.php
@@ -30,7 +30,7 @@ class Delete_Post extends Ability_Definition {
 			'name' => 'acrossai/delete-post',
 			'args' => array(
 				'label'               => __( 'Delete Post', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Delete a post (any post type) via wp_delete_post(). Defaults to trash; pass force=true to delete permanently.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Delete a post (any post type) via wp_delete_post(). Defaults to trash; pass force=true to delete permanently. When a published post is force-deleted, the response includes a suggested_redirect target for the dead URL.', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-content',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {
@@ -54,10 +54,11 @@ class Delete_Post extends Ability_Definition {
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'id'      => array( 'type' => 'integer' ),
-						'force'   => array( 'type' => 'boolean' ),
-						'message' => array( 'type' => 'string' ),
+						'success'            => array( 'type' => 'boolean' ),
+						'id'                 => array( 'type' => 'integer' ),
+						'force'              => array( 'type' => 'boolean' ),
+						'suggested_redirect' => array( 'type' => 'object' ),
+						'message'            => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
 					'additionalProperties' => false,
@@ -93,7 +94,8 @@ class Delete_Post extends Ability_Definition {
 		$id    = (int) ( $input['id'] ?? 0 );
 		$force = ! empty( $input['force'] );
 
-		if ( $id <= 0 || ! get_post( $id ) ) {
+		$post = $id > 0 ? get_post( $id ) : null;
+		if ( ! ( $post instanceof \WP_Post ) ) {
 			return array(
 				'success' => false,
 				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
@@ -107,6 +109,13 @@ class Delete_Post extends Ability_Definition {
 			);
 		}
 
+		// Snapshot state that becomes unavailable after the delete so we can
+		// compute a suggested_redirect for published-post force deletes.
+		$was_publish = ( 'publish' === (string) $post->post_status );
+		$permalink   = (string) get_permalink( $post );
+		$parent_id   = (int) $post->post_parent;
+		$post_type   = (string) $post->post_type;
+
 		$result = $force ? wp_delete_post( $id, true ) : wp_trash_post( $id );
 		if ( ! $result ) {
 			return array(
@@ -115,7 +124,7 @@ class Delete_Post extends Ability_Definition {
 			);
 		}
 
-		return array(
+		$response = array(
 			'success' => true,
 			'id'      => $id,
 			'force'   => $force,
@@ -125,5 +134,31 @@ class Delete_Post extends Ability_Definition {
 				/* translators: %d: post ID */
 				: sprintf( __( 'Moved post #%d to trash.', 'acrossai-abilities-manager' ), $id ),
 		);
+
+		if ( $force && $was_publish ) {
+			$target = '';
+			if ( $parent_id > 0 ) {
+				$parent_post = get_post( $parent_id );
+				if ( $parent_post instanceof \WP_Post && 'publish' === (string) $parent_post->post_status ) {
+					$target = (string) get_permalink( $parent_post );
+				}
+			}
+			if ( '' === $target ) {
+				$archive = get_post_type_archive_link( $post_type );
+				if ( is_string( $archive ) && '' !== $archive ) {
+					$target = $archive;
+				}
+			}
+			if ( '' === $target ) {
+				$target = (string) home_url( '/' );
+			}
+
+			$response['suggested_redirect'] = array(
+				'from' => $permalink,
+				'to'   => $target,
+			);
+		}
+
+		return $response;
 	}
 }

--- a/includes/Abilities/Content/Get_Post.php
+++ b/includes/Abilities/Content/Get_Post.php
@@ -29,7 +29,7 @@ class Get_Post extends Ability_Definition {
 			'name' => 'acrossai/get-post',
 			'args' => array(
 				'label'               => __( 'Get Post', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Fetch a post (any post type) by ID via get_post().', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Fetch a post (any post type) by ID via get_post(). Returns the raw post row plus derived fields (terms, non-protected meta, featured image, permalink, edit link, author).', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-content',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {
@@ -53,9 +53,15 @@ class Get_Post extends Ability_Definition {
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'post'    => array( 'type' => 'object' ),
-						'message' => array( 'type' => 'string' ),
+						'success'        => array( 'type' => 'boolean' ),
+						'post'           => array( 'type' => 'object' ),
+						'terms'          => array( 'type' => 'object' ),
+						'meta'           => array( 'type' => 'object' ),
+						'featured_image' => array( 'type' => array( 'object', 'null' ) ),
+						'permalink'      => array( 'type' => 'string' ),
+						'edit_link'      => array( 'type' => 'string' ),
+						'author'         => array( 'type' => 'object' ),
+						'message'        => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
 					'additionalProperties' => false,
@@ -106,9 +112,76 @@ class Get_Post extends Ability_Definition {
 			);
 		}
 
+		// Terms grouped by taxonomy.
+		$terms      = array();
+		$taxonomies = get_object_taxonomies( (string) $post['post_type'] );
+		foreach ( (array) $taxonomies as $tax ) {
+			$t_objs = get_the_terms( $id, (string) $tax );
+			if ( is_array( $t_objs ) ) {
+				$terms[ (string) $tax ] = array_values(
+					array_map(
+						static function ( $t ): array {
+							return array(
+								'term_id' => (int) $t->term_id,
+								'name'    => (string) $t->name,
+								'slug'    => (string) $t->slug,
+							);
+						},
+						$t_objs
+					)
+				);
+			} else {
+				$terms[ (string) $tax ] = array();
+			}
+		}
+
+		// Non-protected meta.
+		$allowed = (array) apply_filters( 'acrossai_allowed_protected_meta', array() );
+		$raw     = (array) get_post_meta( $id );
+		$meta    = array();
+		foreach ( $raw as $key => $vals ) {
+			$key_str = (string) $key;
+			$is_prot = str_starts_with( $key_str, '_' ) || is_protected_meta( $key_str, 'post' );
+			if ( $is_prot && ! in_array( $key_str, $allowed, true ) ) {
+				continue;
+			}
+			$vals_arr = (array) $vals;
+			if ( 1 === count( $vals_arr ) ) {
+				$meta[ $key_str ] = maybe_unserialize( reset( $vals_arr ) );
+			} else {
+				$meta[ $key_str ] = array_map( 'maybe_unserialize', $vals_arr );
+			}
+		}
+
+		// Featured image.
+		$thumb_id = (int) get_post_thumbnail_id( $id );
+		if ( $thumb_id > 0 ) {
+			$featured_image = array(
+				'id'  => $thumb_id,
+				'url' => (string) wp_get_attachment_image_url( $thumb_id, 'full' ),
+				'alt' => (string) get_post_meta( $thumb_id, '_wp_attachment_image_alt', true ),
+			);
+		} else {
+			$featured_image = null;
+		}
+
+		// Author.
+		$author_id  = (int) $post['post_author'];
+		$author_obj = get_userdata( $author_id );
+		$author     = array(
+			'id'   => $author_id,
+			'name' => $author_obj ? (string) $author_obj->display_name : '',
+		);
+
 		return array(
-			'success' => true,
-			'post'    => $post,
+			'success'        => true,
+			'post'           => $post,
+			'terms'          => $terms,
+			'meta'           => $meta,
+			'featured_image' => $featured_image,
+			'permalink'      => (string) get_permalink( $id ),
+			'edit_link'      => (string) get_edit_post_link( $id, 'raw' ),
+			'author'         => $author,
 		);
 	}
 }

--- a/includes/Abilities/Content/Update_Post.php
+++ b/includes/Abilities/Content/Update_Post.php
@@ -30,7 +30,7 @@ class Update_Post extends Ability_Definition {
 			'name' => 'acrossai/update-post',
 			'args' => array(
 				'label'               => __( 'Update Post', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Update an existing post (any post type) via wp_update_post(). Only the supplied fields are changed.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Update an existing post (any post type) via wp_update_post(). Only the supplied fields are changed. Refuses non-writable post types and strips protected meta keys unless allow-listed.', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-content',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {
@@ -58,10 +58,15 @@ class Update_Post extends Ability_Definition {
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'id'      => array( 'type' => 'integer' ),
-						'post'    => array( 'type' => 'object' ),
-						'message' => array( 'type' => 'string' ),
+						'success'           => array( 'type' => 'boolean' ),
+						'id'                => array( 'type' => 'integer' ),
+						'post'              => array( 'type' => 'object' ),
+						'dropped_meta_keys' => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+						'blocked_reason'    => array( 'type' => 'string' ),
+						'message'           => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
 					'additionalProperties' => false,
@@ -94,11 +99,50 @@ class Update_Post extends Ability_Definition {
 	 * @return array
 	 */
 	public function execute( array $input = array() ): array {
-		$id = (int) ( $input['id'] ?? 0 );
-		if ( $id <= 0 || ! get_post( $id ) ) {
+		$id   = (int) ( $input['id'] ?? 0 );
+		$post = $id > 0 ? get_post( $id ) : null;
+		if ( ! ( $post instanceof \WP_Post ) ) {
 			return array(
 				'success' => false,
 				'message' => __( 'Post not found.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Writable-post-type gate: mirrors WP REST writability convention.
+		$pt_obj = get_post_type_object( (string) $post->post_type );
+		if ( null === $pt_obj || ! ( ! empty( $pt_obj->public ) || ! empty( $pt_obj->show_in_rest ) ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'non_writable_post_type',
+				/* translators: %s: post type name */
+				'message'        => sprintf( __( 'Post type "%s" is not writable via this ability.', 'acrossai-abilities-manager' ), (string) $post->post_type ),
+			);
+		}
+
+		// publish_posts capability gate on any status change into a public state.
+		if ( isset( $input['status'] ) ) {
+			$requested_status = sanitize_key( (string) $input['status'] );
+			$status_obj       = get_post_status_object( $requested_status );
+			if ( $status_obj && ! empty( $status_obj->public )
+				&& ! current_user_can( (string) $pt_obj->cap->publish_posts ) ) {
+				return array(
+					'success'        => false,
+					'blocked_reason' => 'publish_cap_required',
+					/* translators: 1: status, 2: post type */
+					'message'        => sprintf( __( 'You do not have permission to set status "%1$s" on post type "%2$s".', 'acrossai-abilities-manager' ), $requested_status, (string) $post->post_type ),
+				);
+			}
+		}
+
+		// edit_others_posts capability gate on author changes.
+		if ( isset( $input['author'] )
+			&& (int) $input['author'] !== (int) get_current_user_id()
+			&& ! current_user_can( (string) $pt_obj->cap->edit_others_posts ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'edit_others_posts_required',
+				/* translators: %s: post type name */
+				'message'        => sprintf( __( 'You do not have permission to change the author on post type "%s".', 'acrossai-abilities-manager' ), (string) $post->post_type ),
 			);
 		}
 
@@ -124,24 +168,43 @@ class Update_Post extends Ability_Definition {
 		if ( isset( $input['date'] ) ) {
 			$args['post_date'] = (string) $input['date'];
 		}
+
+		// Protected-meta filter. Strip keys that begin with `_` or are reported
+		// by is_protected_meta() unless allow-listed via acrossai_allowed_protected_meta.
+		$dropped_meta_keys = array();
 		if ( ! empty( $input['meta'] ) && is_array( $input['meta'] ) ) {
-			$args['meta_input'] = $input['meta'];
+			$allowed  = (array) apply_filters( 'acrossai_allowed_protected_meta', array() );
+			$filtered = array();
+			foreach ( $input['meta'] as $meta_key => $meta_value ) {
+				$key_str = (string) $meta_key;
+				$is_prot = str_starts_with( $key_str, '_' ) || is_protected_meta( $key_str, 'post' );
+				if ( $is_prot && ! in_array( $key_str, $allowed, true ) ) {
+					$dropped_meta_keys[] = $key_str;
+					continue;
+				}
+				$filtered[ $key_str ] = $meta_value;
+			}
+			if ( ! empty( $filtered ) ) {
+				$args['meta_input'] = $filtered;
+			}
 		}
 
 		$result = wp_update_post( $args, true );
 		if ( is_wp_error( $result ) ) {
 			return array(
-				'success' => false,
-				'message' => $result->get_error_message(),
+				'success'           => false,
+				'dropped_meta_keys' => $dropped_meta_keys,
+				'message'           => $result->get_error_message(),
 			);
 		}
 
 		return array(
-			'success' => true,
-			'id'      => (int) $result,
-			'post'    => (array) get_post( (int) $result, ARRAY_A ),
+			'success'           => true,
+			'id'                => (int) $result,
+			'post'              => (array) get_post( (int) $result, ARRAY_A ),
+			'dropped_meta_keys' => $dropped_meta_keys,
 			/* translators: %d: post ID */
-			'message' => sprintf( __( 'Updated post #%d.', 'acrossai-abilities-manager' ), $result ),
+			'message'           => sprintf( __( 'Updated post #%d.', 'acrossai-abilities-manager' ), $result ),
 		);
 	}
 }

--- a/includes/Abilities/FileManager/Delete_File.php
+++ b/includes/Abilities/FileManager/Delete_File.php
@@ -21,6 +21,17 @@ defined( 'ABSPATH' ) || exit;
 class Delete_File extends Ability_Definition {
 
 	/**
+	 * Hardcoded filenames (at ABSPATH root) that this ability must never
+	 * delete. Same list as Read_File::PROTECTED_FILES.
+	 *
+	 * @var array<int,string>
+	 */
+	private const PROTECTED_FILES = array(
+		'wp-config.php',
+		'.htaccess',
+	);
+
+	/**
 	 * Full ability spec for wp_register_ability().
 	 *
 	 * @return array
@@ -30,7 +41,7 @@ class Delete_File extends Ability_Definition {
 			'name' => 'acrossai/delete-file',
 			'args' => array(
 				'label'               => __( 'Delete File', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Deletes a file within the WordPress installation. Path must be relative to ABSPATH.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Deletes a file within the WordPress installation. Path must be relative to ABSPATH. Requires confirm:true, refuses wp-config.php and .htaccess, writes a .bak.<timestamp> copy before deleting, and invalidates OPcache when available.', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-file-manager',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {
@@ -39,19 +50,25 @@ class Delete_File extends Ability_Definition {
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'path' => array(
+						'path'    => array(
 							'type'        => 'string',
 							'description' => __( 'File path relative to ABSPATH.', 'acrossai-abilities-manager' ),
 						),
+						'confirm' => array(
+							'type'        => 'boolean',
+							'description' => __( 'Must be true to proceed. Guards against accidental deletes.', 'acrossai-abilities-manager' ),
+						),
 					),
-					'required'             => array( 'path' ),
+					'required'             => array( 'path', 'confirm' ),
 					'additionalProperties' => false,
 				),
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'message' => array( 'type' => 'string' ),
+						'success'        => array( 'type' => 'boolean' ),
+						'backup'         => array( 'type' => array( 'string', 'null' ) ),
+						'message'        => array( 'type' => 'string' ),
+						'blocked_reason' => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success', 'message' ),
 					'additionalProperties' => false,
@@ -84,6 +101,15 @@ class Delete_File extends Ability_Definition {
 	 * @return array
 	 */
 	public function execute( array $input = array() ): array {
+		// Explicit-confirmation guard. Refuse before any I/O.
+		if ( empty( $input['confirm'] ) || true !== (bool) $input['confirm'] ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'confirmation_required',
+				'message'        => __( 'Deleting a file is permanent. Pass confirm:true to proceed.', 'acrossai-abilities-manager' ),
+			);
+		}
+
 		$blocked = File_Mods_Guard::blocked_response();
 		if ( null !== $blocked ) {
 			return $blocked;
@@ -100,6 +126,18 @@ class Delete_File extends Ability_Definition {
 			);
 		}
 
+		// Protected-file guard: refuse to delete secret-holding files at
+		// ABSPATH root regardless of the caller's capability.
+		if ( in_array( basename( $real ), self::PROTECTED_FILES, true )
+			&& dirname( $real ) === $base ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'protected_write',
+				/* translators: %s: filename */
+				'message'        => sprintf( __( 'File "%s" is protected and cannot be deleted.', 'acrossai-abilities-manager' ), basename( $real ) ),
+			);
+		}
+
 		if ( ! is_file( $real ) ) {
 			return array(
 				'success' => false,
@@ -107,15 +145,30 @@ class Delete_File extends Ability_Definition {
 			);
 		}
 
+		// Best-effort backup: copy the file to <path>.bak.<timestamp> before
+		// deleting. If the copy fails we still proceed with the delete —
+		// backup is a convenience, not a hard prerequisite.
+		$backup = $real . '.bak.' . time();
+		if ( ! @copy( $real, $backup ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$backup = null;
+		}
+
 		if ( ! wp_delete_file( $real ) ) {
 			return array(
 				'success' => false,
+				'backup'  => $backup,
 				'message' => __( 'Could not delete file.', 'acrossai-abilities-manager' ),
 			);
 		}
 
+		// OPcache: invalidate the removed path so stale bytecode doesn't linger.
+		if ( function_exists( 'opcache_invalidate' ) ) {
+			opcache_invalidate( $real, true );
+		}
+
 		return array(
 			'success' => true,
+			'backup'  => $backup,
 			'message' => __( 'File deleted.', 'acrossai-abilities-manager' ),
 		);
 	}

--- a/includes/Abilities/FileManager/Read_File.php
+++ b/includes/Abilities/FileManager/Read_File.php
@@ -20,6 +20,27 @@ defined( 'ABSPATH' ) || exit;
 class Read_File extends Ability_Definition {
 
 	/**
+	 * Hardcoded filenames (at ABSPATH root) whose contents must never be
+	 * returned. wp-config.php holds the DB password and eight auth constants;
+	 * .htaccess can leak rewrite rules and access-control secrets.
+	 *
+	 * @var array<int,string>
+	 */
+	private const PROTECTED_FILES = array(
+		'wp-config.php',
+		'.htaccess',
+	);
+
+	/**
+	 * Maximum file size (bytes) that read-file will return as text. Files
+	 * larger than this are refused so the ability cannot exhaust PHP's
+	 * memory limit on an arbitrary path.
+	 *
+	 * @var int
+	 */
+	private const MAX_READ_BYTES = 5242880; // 5 * 1024 * 1024.
+
+	/**
 	 * Full ability spec for wp_register_ability().
 	 *
 	 * @return array
@@ -29,7 +50,7 @@ class Read_File extends Ability_Definition {
 			'name' => 'acrossai/read-file',
 			'args' => array(
 				'label'               => __( 'Read File', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Reads the contents of a file within the WordPress installation. Path must be relative to ABSPATH.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Reads the contents of a file within the WordPress installation. Path must be relative to ABSPATH. Refuses wp-config.php and .htaccess, refuses files larger than 5 MB, and reports binary content without returning raw bytes.', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-file-manager',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {
@@ -49,11 +70,14 @@ class Read_File extends Ability_Definition {
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'content' => array( 'type' => 'string' ),
-						'path'    => array( 'type' => 'string' ),
-						'size'    => array( 'type' => 'integer' ),
-						'message' => array( 'type' => 'string' ),
+						'success'        => array( 'type' => 'boolean' ),
+						'content'        => array( 'type' => 'string' ),
+						'path'           => array( 'type' => 'string' ),
+						'size'           => array( 'type' => 'integer' ),
+						'binary'         => array( 'type' => 'boolean' ),
+						'max_bytes'      => array( 'type' => 'integer' ),
+						'blocked_reason' => array( 'type' => 'string' ),
+						'message'        => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
 					'additionalProperties' => false,
@@ -98,10 +122,37 @@ class Read_File extends Ability_Definition {
 			);
 		}
 
+		// Protected-file guard: refuse to return contents of secret-holding
+		// files at ABSPATH root regardless of the caller's capability.
+		$real_for_check = realpath( $abs_path );
+		if ( false !== $real_for_check
+			&& in_array( basename( $real_for_check ), self::PROTECTED_FILES, true )
+			&& dirname( $real_for_check ) === $base ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'protected_read',
+				/* translators: %s: filename */
+				'message'        => sprintf( __( 'File "%s" is protected and cannot be read.', 'acrossai-abilities-manager' ), basename( $real_for_check ) ),
+			);
+		}
+
 		if ( ! is_file( $abs_path ) ) {
 			return array(
 				'success' => false,
 				'message' => __( 'File does not exist.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Size cap: refuse before loading the file into memory.
+		$size = (int) filesize( $abs_path );
+		if ( $size > self::MAX_READ_BYTES ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'file_too_large',
+				'size'           => $size,
+				'max_bytes'      => self::MAX_READ_BYTES,
+				/* translators: 1: observed size, 2: max size */
+				'message'        => sprintf( __( 'File size (%1$d bytes) exceeds the maximum readable size (%2$d bytes).', 'acrossai-abilities-manager' ), $size, self::MAX_READ_BYTES ),
 			);
 		}
 
@@ -114,11 +165,25 @@ class Read_File extends Ability_Definition {
 			);
 		}
 
+		$real_path = realpath( $abs_path ) ?: $abs_path;
+
+		// Binary detection: return a distinct shape without the raw bytes.
+		if ( ! mb_check_encoding( $content, 'UTF-8' ) ) {
+			return array(
+				'success' => true,
+				'binary'  => true,
+				'path'    => $real_path,
+				'size'    => $size,
+				'message' => __( 'Binary file; contents not returned as text.', 'acrossai-abilities-manager' ),
+			);
+		}
+
 		return array(
 			'success' => true,
 			'content' => $content,
-			'path'    => realpath( $abs_path ) ?: $abs_path,
-			'size'    => strlen( $content ),
+			'path'    => $real_path,
+			'size'    => $size,
+			'binary'  => false,
 		);
 	}
 }

--- a/includes/Abilities/Media/Delete_Media.php
+++ b/includes/Abilities/Media/Delete_Media.php
@@ -29,7 +29,7 @@ class Delete_Media extends Ability_Definition {
 			'name' => 'acrossai/delete-media',
 			'args' => array(
 				'label'               => __( 'Delete Media', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Permanently delete a media attachment via DELETE /wp/v2/media/{id}. Attachments do not support trash.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Delete a media attachment. Requires confirm:true. Honours MEDIA_TRASH when defined; pass force:true to skip trash and delete permanently.', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-media',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {
@@ -38,21 +38,34 @@ class Delete_Media extends Ability_Definition {
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'id' => array(
+						'id'      => array(
 							'type'    => 'integer',
 							'minimum' => 1,
 						),
+						'confirm' => array(
+							'type'        => 'boolean',
+							'description' => __( 'Must be true to proceed. Guards against accidental hard-deletes.', 'acrossai-abilities-manager' ),
+						),
+						'force'   => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'Skip trash even when MEDIA_TRASH is defined.', 'acrossai-abilities-manager' ),
+						),
 					),
-					'required'             => array( 'id' ),
+					'required'             => array( 'id', 'confirm' ),
 					'additionalProperties' => false,
 				),
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'deleted' => array( 'type' => 'boolean' ),
-						'media'   => array( 'type' => 'object' ),
-						'message' => array( 'type' => 'string' ),
+						'success'        => array( 'type' => 'boolean' ),
+						'deleted'        => array(
+							'type' => 'string',
+							'enum' => array( 'deleted', 'trashed' ),
+						),
+						'media'          => array( 'type' => 'object' ),
+						'message'        => array( 'type' => 'string' ),
+						'blocked_reason' => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
 					'additionalProperties' => false,
@@ -93,6 +106,15 @@ class Delete_Media extends Ability_Definition {
 			);
 		}
 
+		// Explicit-confirmation guard. Refuse without mutating state.
+		if ( empty( $input['confirm'] ) || true !== (bool) $input['confirm'] ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'confirmation_required',
+				'message'        => __( 'Deleting media is permanent unless MEDIA_TRASH is defined. Pass confirm:true to proceed.', 'acrossai-abilities-manager' ),
+			);
+		}
+
 		$post = get_post( $id );
 		if ( ! ( $post instanceof \WP_Post ) || 'attachment' !== $post->post_type ) {
 			return array(
@@ -103,10 +125,14 @@ class Delete_Media extends Ability_Definition {
 
 		$snapshot = Media_Formatter::to_array( $post );
 
-		// wp_delete_attachment (NOT wp_delete_post) removes the file from disk
-		// and cleans up intermediate image sizes too. force=true matches the
-		// REST controller, which always hard-deletes attachments.
-		$deleted = wp_delete_attachment( $id, true );
+		// Honour MEDIA_TRASH unless the caller explicitly forces a hard delete.
+		$force   = ! empty( $input['force'] );
+		$trashed = ! $force && defined( 'MEDIA_TRASH' ) && MEDIA_TRASH;
+
+		// wp_delete_attachment second argument is $force_delete — true when we
+		// bypass the trash. When $trashed is true we want the trash path, so
+		// pass false; when $trashed is false we want a hard delete, so pass true.
+		$deleted = wp_delete_attachment( $id, ! $trashed );
 		if ( ! $deleted ) {
 			return Media_Formatter::error_from(
 				false,
@@ -117,10 +143,13 @@ class Delete_Media extends Ability_Definition {
 
 		return array(
 			'success' => true,
-			'deleted' => true,
+			'deleted' => $trashed ? 'trashed' : 'deleted',
 			'media'   => $snapshot,
-			/* translators: %d: attachment ID */
-			'message' => sprintf( __( 'Deleted attachment #%d.', 'acrossai-abilities-manager' ), $id ),
+			'message' => $trashed
+				/* translators: %d: attachment ID */
+				? sprintf( __( 'Trashed attachment #%d.', 'acrossai-abilities-manager' ), $id )
+				/* translators: %d: attachment ID */
+				: sprintf( __( 'Deleted attachment #%d.', 'acrossai-abilities-manager' ), $id ),
 		);
 	}
 }

--- a/includes/Abilities/Media/List_Media.php
+++ b/includes/Abilities/Media/List_Media.php
@@ -29,7 +29,7 @@ class List_Media extends Ability_Definition {
 			'name' => 'acrossai/list-media',
 			'args' => array(
 				'label'               => __( 'List Media', 'acrossai-abilities-manager' ),
-				'description'         => __( 'List media items via GET /wp/v2/media. Supports search, pagination, and a mime_type filter.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List media items via GET /wp/v2/media. Supports search (across title, caption, description, and alt-text), pagination, and a mime_type filter.', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-media',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {
@@ -106,14 +106,62 @@ class List_Media extends Ability_Definition {
 			'orderby'        => 'date',
 			'order'          => 'DESC',
 		);
-		if ( ! empty( $input['search'] ) ) {
-			$args['s'] = sanitize_text_field( (string) $input['search'] );
-		}
 		if ( ! empty( $input['mime_type'] ) ) {
 			$args['post_mime_type'] = sanitize_mime_type( (string) $input['mime_type'] );
 		}
 		if ( isset( $input['parent'] ) ) {
 			$args['post_parent'] = (int) $input['parent'];
+		}
+
+		// Widened search: union the WP_Query `s` match (title/caption/description)
+		// with a meta_query id-only lookup against _wp_attachment_image_alt so
+		// alt-text-only matches are included.
+		if ( ! empty( $input['search'] ) ) {
+			$search = sanitize_text_field( (string) $input['search'] );
+
+			$base_filters = array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'no_found_rows'  => true,
+			);
+			if ( ! empty( $args['post_mime_type'] ) ) {
+				$base_filters['post_mime_type'] = $args['post_mime_type'];
+			}
+			if ( isset( $args['post_parent'] ) ) {
+				$base_filters['post_parent'] = $args['post_parent'];
+			}
+
+			$args_text_ids       = $base_filters;
+			$args_text_ids['s']  = $search;
+			$args_alt_ids        = $base_filters;
+			$args_alt_ids['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				array(
+					'key'     => '_wp_attachment_image_alt',
+					'value'   => $search,
+					'compare' => 'LIKE',
+				),
+			);
+
+			$text_ids = get_posts( $args_text_ids );
+			$alt_ids  = get_posts( $args_alt_ids );
+
+			$ids = array_values(
+				array_unique(
+					array_map( 'absint', array_merge( (array) $text_ids, (array) $alt_ids ) )
+				)
+			);
+
+			if ( empty( $ids ) ) {
+				return array(
+					'success' => true,
+					'media'   => array(),
+					'total'   => 0,
+				);
+			}
+
+			$args['post__in'] = $ids;
 		}
 
 		$query = new \WP_Query( $args );

--- a/includes/Abilities/Media/Update_Media.php
+++ b/includes/Abilities/Media/Update_Media.php
@@ -55,6 +55,10 @@ class Update_Media extends Ability_Definition {
 					'properties'           => array(
 						'success' => array( 'type' => 'boolean' ),
 						'media'   => array( 'type' => 'object' ),
+						'updated' => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
 						'message' => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
@@ -105,17 +109,21 @@ class Update_Media extends Ability_Definition {
 		}
 
 		$post_data  = array( 'ID' => $id );
+		$updated    = array();
 		$has_change = false;
 		if ( isset( $input['title'] ) ) {
 			$post_data['post_title'] = (string) $input['title'];
+			$updated[]               = 'title';
 			$has_change              = true;
 		}
 		if ( isset( $input['caption'] ) ) {
 			$post_data['post_excerpt'] = (string) $input['caption'];
+			$updated[]                 = 'caption';
 			$has_change                = true;
 		}
 		if ( isset( $input['description'] ) ) {
 			$post_data['post_content'] = (string) $input['description'];
+			$updated[]                 = 'description';
 			$has_change                = true;
 		}
 
@@ -132,12 +140,14 @@ class Update_Media extends Ability_Definition {
 
 		if ( isset( $input['alt_text'] ) ) {
 			update_post_meta( $id, '_wp_attachment_image_alt', wp_slash( (string) $input['alt_text'] ) );
+			$updated[] = 'alt_text';
 		}
 
-		$updated = get_post( $id );
+		$refreshed = get_post( $id );
 		return array(
 			'success' => true,
-			'media'   => $updated instanceof \WP_Post ? Media_Formatter::to_array( $updated ) : array(),
+			'media'   => $refreshed instanceof \WP_Post ? Media_Formatter::to_array( $refreshed ) : array(),
+			'updated' => $updated,
 			/* translators: %d: attachment ID */
 			'message' => sprintf( __( 'Updated attachment #%d.', 'acrossai-abilities-manager' ), $id ),
 		);

--- a/includes/Abilities/Plugins/Deactivate_Plugin.php
+++ b/includes/Abilities/Plugins/Deactivate_Plugin.php
@@ -21,6 +21,20 @@ defined( 'ABSPATH' ) || exit;
 class Deactivate_Plugin extends Ability_Definition {
 
 	/**
+	 * Hardcoded list of plugin file paths that must never be deactivated
+	 * by this ability. Deactivating any of them would either cut the AI's
+	 * connection to the site (mcp-manager) or disable the entire ability
+	 * surface (abilities-manager, acrossai-pro).
+	 *
+	 * @var array<int,string>
+	 */
+	private const PROTECTED_PLUGINS = array(
+		'acrossai-mcp-manager/acrossai-mcp-manager.php',
+		'acrossai-abilities-manager/acrossai-abilities-manager.php',
+		'acrossai-pro/acrossai-pro.php',
+	);
+
+	/**
 	 * Full ability spec for wp_register_ability().
 	 *
 	 * @return array
@@ -61,6 +75,8 @@ class Deactivate_Plugin extends Ability_Definition {
 						'message'        => array( 'type' => 'string' ),
 						'matched_plugin' => array( 'type' => 'string' ),
 						'certainty'      => array( 'type' => 'number' ),
+						'blocked_reason' => array( 'type' => 'string' ),
+						'plugin'         => array( 'type' => 'string' ),
 					),
 				),
 				'meta'                => array(
@@ -100,6 +116,74 @@ class Deactivate_Plugin extends Ability_Definition {
 			);
 		}
 
-		return Plugin_Helpers::deactivate_plugin_by_slug( $raw_plugin );
+		$identifier = sanitize_text_field( (string) $raw_plugin );
+		$resolved   = Plugin_Helpers::resolve_plugin( $identifier );
+
+		if ( null === $resolved['plugin_file'] ) {
+			return array(
+				'success'   => false,
+				/* translators: %s: plugin identifier */
+				'message'   => sprintf( __( 'No plugin found matching "%s".', 'acrossai-abilities-manager' ), $identifier ),
+				'certainty' => 0.0,
+			);
+		}
+
+		if ( $resolved['certainty'] < 8.0 ) {
+			return Plugin_Helpers::build_candidate_response(
+				$resolved,
+				$identifier,
+				'acrossai/deactivate-plugin',
+				__( 'Deactivate', 'acrossai-abilities-manager' )
+			);
+		}
+
+		$plugin_file = $resolved['plugin_file'];
+		$plugin_name = $resolved['plugin_name'];
+		$certainty   = $resolved['certainty'];
+
+		// Protected-plugin guard: refuse to deactivate any AcrossAI-family plugin.
+		// Check runs against the resolved file path so it cannot be bypassed by
+		// passing a partial/fuzzy identifier that resolves to a protected plugin.
+		if ( in_array( $plugin_file, self::PROTECTED_PLUGINS, true ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'protected_plugin',
+				/* translators: %s: plugin name */
+				'message'        => sprintf( __( 'Plugin "%s" is protected and cannot be deactivated by this ability.', 'acrossai-abilities-manager' ), $plugin_name ),
+				'matched_plugin' => $plugin_name,
+				'plugin'         => $plugin_file,
+				'certainty'      => $certainty,
+			);
+		}
+
+		if ( ! is_plugin_active( $plugin_file ) ) {
+			return array(
+				'success'        => true,
+				/* translators: %s: plugin name */
+				'message'        => sprintf( __( 'Plugin "%s" is already inactive.', 'acrossai-abilities-manager' ), $plugin_name ),
+				'matched_plugin' => $plugin_name,
+				'certainty'      => $certainty,
+			);
+		}
+
+		deactivate_plugins( $plugin_file );
+
+		if ( is_plugin_active( $plugin_file ) ) {
+			return array(
+				'success'        => false,
+				/* translators: %s: plugin name */
+				'message'        => sprintf( __( 'Failed to deactivate plugin "%s".', 'acrossai-abilities-manager' ), $plugin_name ),
+				'matched_plugin' => $plugin_name,
+				'certainty'      => $certainty,
+			);
+		}
+
+		return array(
+			'success'        => true,
+			/* translators: %s: plugin name */
+			'message'        => sprintf( __( 'Plugin "%s" has been deactivated.', 'acrossai-abilities-manager' ), $plugin_name ),
+			'matched_plugin' => $plugin_name,
+			'certainty'      => $certainty,
+		);
 	}
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -90,6 +90,9 @@
 			<file>tests/phpunit/abilities/Test_Verify_Core_Checksums.php</file>
 			<file>tests/phpunit/abilities/Test_Feature_064_Bootstrap_Wiring.php</file>
 		</testsuite>
+		<testsuite name="feature-065-unit">
+			<file>tests/phpunit/abilities/Test_Feature_065_Safety_And_Payload.php</file>
+		</testsuite>
 	</testsuites>
 	<source>
 		<include>

--- a/specs/065-safety-and-payload-improvements/checklists/requirements.md
+++ b/specs/065-safety-and-payload-improvements/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Safety envelope + payload enrichment
+
+**Purpose**: Validate specification completeness and quality before implementation
+**Created**: 2026-08-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details in the spec body (only in plan/tasks)
+- [x] Focused on user (operator/agent) value
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers
+- [x] Every requirement is testable
+- [x] Success criteria are measurable
+- [x] All acceptance scenarios defined
+- [x] Edge cases identified
+- [x] Scope bounded (9 files touched, no new abilities)
+- [x] Assumptions documented (including breaking-change flag)
+
+## Feature Readiness
+
+- [x] Every FR has clear acceptance criteria
+- [x] User stories cover primary flows
+- [x] Success criteria are technology-agnostic (SC-XXX phrased around outcomes, not implementations)
+- [x] Implementation details live in plan.md + tasks.md + contracts/abilities.md, not spec.md
+
+## Notes
+
+- Breaking changes intentionally shipped: `delete-media` and `delete-file` now require `confirm: true`; `read-file` output `content` field is omitted when the file is binary or oversized (in favour of `binary: true` + `blocked_reason: 'file_too_large'`). Documented in Assumptions.
+- Extensibility of the protected-plugin list via a filter is deferred — hardcoded in this feature.
+- Rename / redesign of `acrossai/edit-file` is deferred — deserves its own spec.

--- a/specs/065-safety-and-payload-improvements/contracts/abilities.md
+++ b/specs/065-safety-and-payload-improvements/contracts/abilities.md
@@ -1,0 +1,170 @@
+# Ability Contracts — modified abilities
+
+Every ability listed below **retains** its existing name, category, and `permission_callback`. Only the input/output schemas and `execute()` behaviour change.
+
+---
+
+## `acrossai/deactivate-plugin`
+
+**Input schema (unchanged)** — takes `plugin: string`.
+
+**Output schema (additive)** — new field `blocked_reason: string` when refused. Values: `"protected_plugin"` (new), plus any existing refusal values.
+
+## `acrossai/delete-media`
+
+**Input schema (breaking)**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "id":      { "type": "integer", "minimum": 1 },
+    "confirm": { "type": "boolean", "description": "Must be true to proceed" },
+    "force":   { "type": "boolean", "default": false, "description": "Skip trash even when MEDIA_TRASH is defined" }
+  },
+  "required": ["id", "confirm"],
+  "additionalProperties": false
+}
+```
+
+**Output schema (breaking on `deleted` type)**:
+```json
+{
+  "success": { "type": "boolean" },
+  "deleted": { "type": "string", "enum": ["deleted", "trashed"] },
+  "media":   { "type": "object" },
+  "message": { "type": "string" },
+  "blocked_reason": { "type": "string" }
+}
+```
+
+`blocked_reason` values on refusal: `"confirmation_required"`, existing not-found reasons.
+
+## `acrossai/update-media`
+
+**Input schema (unchanged)**.
+
+**Output schema (additive)**:
+```json
+{
+  "success": bool,
+  "updated": { "type": "array", "items": { "type": "string" } },
+  "media":   object,
+  "message": string
+}
+```
+
+`updated` values are field names from `["title", "caption", "description", "alt_text"]` in the order processed. Empty array when no update field was passed.
+
+## `acrossai/list-media`
+
+**Input schema (unchanged)**.
+
+**Output schema (unchanged)**. Behaviour change: `search` now also matches `_wp_attachment_image_alt` postmeta.
+
+## `acrossai/get-post`
+
+**Input schema (unchanged)**.
+
+**Output schema (additive)**:
+```json
+{
+  "success":  bool,
+  "post":     object,  // unchanged — raw get_post(ARRAY_A)
+  "terms":    { "type": "object", "additionalProperties": { "type": "array" } },
+  "meta":     { "type": "object" },
+  "featured_image": { "type": ["object", "null"] },
+  "permalink": string,
+  "edit_link": string,
+  "author":   { "type": "object", "properties": { "id": integer, "name": string } },
+  "message":  string
+}
+```
+
+`meta` skips protected keys (`_`-prefix or `is_protected_meta`) unless allow-listed by the `acrossai_allowed_protected_meta` filter.
+
+## `acrossai/update-post`
+
+**Input schema (unchanged)**.
+
+**Output schema (additive)**:
+```json
+{
+  "success": bool,
+  "id":      integer,
+  "post":    object,
+  "dropped_meta_keys": { "type": "array", "items": { "type": "string" } },
+  "blocked_reason":    string,
+  "message": string
+}
+```
+
+`blocked_reason` values on refusal: `"non_writable_post_type"`, `"publish_cap_required"`, `"edit_others_posts_required"`, existing not-found value.
+
+## `acrossai/delete-post`
+
+**Input schema (unchanged)**.
+
+**Output schema (additive)**:
+```json
+{
+  "success": bool,
+  "id":      integer,
+  "force":   bool,
+  "suggested_redirect": {
+    "type": "object",
+    "properties": {
+      "from": string,
+      "to":   string
+    }
+  },
+  "message": string
+}
+```
+
+`suggested_redirect` present only when the deleted post was `publish` AND `force: true`.
+
+## `acrossai/read-file`
+
+**Input schema (unchanged)**.
+
+**Output schema (additive/breaking)**:
+```json
+{
+  "success":  bool,
+  "content":  string,   // OMITTED when binary or file too large
+  "path":     string,
+  "size":     integer,
+  "binary":   bool,     // NEW — true when non-UTF-8 detected
+  "blocked_reason": string,
+  "message":  string
+}
+```
+
+`blocked_reason` values on refusal: `"protected_read"`, `"file_too_large"`, existing not-found / invalid-path.
+
+## `acrossai/delete-file`
+
+**Input schema (breaking)**:
+```json
+{
+  "type": "object",
+  "properties": {
+    "path":    { "type": "string" },
+    "confirm": { "type": "boolean" }
+  },
+  "required": ["path", "confirm"],
+  "additionalProperties": false
+}
+```
+
+**Output schema (additive)**:
+```json
+{
+  "success":  bool,
+  "backup":   { "type": ["string", "null"] },
+  "message":  string,
+  "blocked_reason": string
+}
+```
+
+`blocked_reason` values on refusal: `"confirmation_required"`, `"protected_write"`, existing not-found / invalid-path.

--- a/specs/065-safety-and-payload-improvements/plan.md
+++ b/specs/065-safety-and-payload-improvements/plan.md
@@ -1,0 +1,121 @@
+# Implementation Plan: Safety envelope + payload enrichment across 9 existing abilities
+
+**Branch**: `065-safety-and-payload-improvements` | **Date**: 2026-08-12 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Modify **9 existing ability classes** to add safety guardrails, payload enrichment, and one protected-plugin guard. No new abilities. No new categories. No new modules. No bootstrap changes. No version bump.
+
+- **`Plugins/Deactivate_Plugin.php`** — hardcoded protected-plugin list (3 entries).
+- **`Media/Delete_Media.php`** — `confirm: true` required + `MEDIA_TRASH` respect + `deleted: "deleted"|"trashed"` in response.
+- **`Media/Update_Media.php`** — `updated[]` field in response.
+- **`Media/List_Media.php`** — expand `s` search to include alt-text via union id-lookup.
+- **`Content/Get_Post.php`** — enrich response with terms/meta/featured_image/permalink/edit_link/author.
+- **`Content/Update_Post.php`** — writable-post-type gate + protected-meta filter + `publish_posts` cap on status change + `edit_others_posts` on author change.
+- **`Content/Delete_Post.php`** — `suggested_redirect` field on published-post force delete.
+- **`FileManager/Read_File.php`** — 5 MB size cap + binary detection + read-protection list.
+- **`FileManager/Delete_File.php`** — `confirm: true` required + backup + protected-file list + OPcache invalidation.
+
+## Technical Context
+
+**Language/Version**: PHP 8.1+ (unchanged).
+**Primary Dependencies**: WordPress 6.9+. No new Composer or npm packages.
+**Storage**: None new. All operations continue against existing WordPress-managed tables and the filesystem.
+**Testing**: PHPUnit 10.5. Follow the plugin's established source-inspection test pattern (`Test_Feature_<NNN>_*.php` under `tests/phpunit/abilities/`).
+**Target Platform**: WordPress 6.9+ on PHP 8.1–8.5 (existing CI matrix).
+**Project Type**: WordPress plugin — single project.
+**Performance Goals**: No regression on golden-path invocations. Safety-refusal paths return in <10 ms (no I/O).
+**Constraints**: Every ability continues to use the LITERAL `permission_callback` verbatim; NO changes to permission callbacks. Every modification is additive to `execute()` — no removal of existing behaviour on the accept path.
+**Scale/Scope**: 9 files modified in `includes/Abilities/`. 1 new tests file (`Test_Feature_065_Safety_And_Payload.php`) covering every new guardrail and every new payload field. Zero bootstrap changes.
+
+## Constitution Check
+
+*GATE: Must pass before implementation.*
+
+### I. Modular Architecture — PASS
+
+Each ability is a self-contained class. No cross-module dependencies added. Any hardcoded lists (protected-plugin, protected-file, MAX_READ_BYTES) are per-class `const` fields, not extracted to shared utilities — matches the plugin's stated "three similar lines is better than a premature abstraction" preference.
+
+### II. WordPress Standards Compliance — PASS
+
+- PHPCS: no new files, only additive edits to existing WPCS-compliant files.
+- PHPStan level 8: every WP core function used is stubbed (`get_plugins`, `is_plugin_active`, `is_protected_meta`, `wp_get_attachment_metadata`, `get_object_taxonomies`, `get_the_terms`, `get_permalink`, `get_edit_post_link`, `get_userdata`, `wp_delete_attachment`, `opcache_invalidate`, `wp_check_filetype`, etc.).
+- Plugin Check: no `eval`/`extract`/shell exec. `opcache_invalidate` is a PHP core function, `function_exists()`-guarded.
+- Multisite: reads/writes target the currently-active site (unchanged behaviour).
+
+### III. User-Centric Design — PASS (N/A, no admin UI)
+
+No admin UI changes. Every improvement is at the ability execute-callback layer.
+
+### IV. Security First — PASS
+
+- Sanitization: all new string inputs (`confirm`, `force`, etc.) processed via `(bool)` / `absint()` cast or `sanitize_text_field()` where string.
+- Capability: `manage_options` remains the gate. NEW: `update-post` adds per-post-type `publish_posts` and `edit_others_posts` checks; both are `current_user_can()` calls — never a `WP_REST_Response`.
+- Prepared queries: `list-media` alt-text union query uses `$wpdb->prepare()` with `%s` for the search token.
+- Blocked lists: protected-plugin, protected-file (`wp-config.php`, `.htaccess`), protected-meta filter all hardcoded per FRs.
+
+### V. Extensibility Without Core Modification — PASS
+
+Modifications are inside the existing ability classes. The `acrossai_allowed_protected_meta` filter is added as the extensibility surface for protected-meta writing. No changes to any other class.
+
+### VI. Reusability & DRY Principle — PASS
+
+Reuses:
+- `Media_Formatter::to_array()` for the enriched `get-post` featured_image lookup.
+- `Plugin_Helpers::resolve_plugin()` for the protected-plugin guard.
+- `File_Mods_Guard::blocked_response()` for the existing filesystem gate (unchanged).
+- `wp_get_attachment_image_src()` for featured-image URL resolution.
+
+The protected-file list is duplicated across `Read_File` and `Delete_File` as a `const` on each class rather than extracted to a shared utility — same three-line-preference reasoning as elsewhere.
+
+### VII. Definition of Done — PLANNED
+
+Every gate: PHPCS zero, PHPStan level 8 zero, PHPUnit passes. ESLint N/A (no JS).
+
+**Overall gate: PASS. No complexity-tracking entries required.**
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/065-safety-and-payload-improvements/
+├── plan.md              # This file
+├── spec.md              # Written by /speckit-specify equivalent
+├── tasks.md             # Below
+├── contracts/
+│   └── abilities.md     # Contracts for the modified abilities (below)
+└── checklists/
+    └── requirements.md  # Below
+```
+
+### Source Code (modified files)
+
+```text
+includes/Abilities/
+├── Plugins/
+│   └── Deactivate_Plugin.php         # MODIFIED — protected-plugin list
+├── Media/
+│   ├── Delete_Media.php              # MODIFIED — confirm + MEDIA_TRASH
+│   ├── Update_Media.php              # MODIFIED — updated[] field
+│   └── List_Media.php                # MODIFIED — alt-text search
+├── Content/
+│   ├── Get_Post.php                  # MODIFIED — enriched payload
+│   ├── Update_Post.php               # MODIFIED — writable-type + meta filter + caps
+│   └── Delete_Post.php               # MODIFIED — suggested_redirect
+├── FileManager/
+│   ├── Read_File.php                 # MODIFIED — size cap + binary + protection list
+│   └── Delete_File.php               # MODIFIED — confirm + backup + protection + OPcache
+
+tests/phpunit/abilities/
+└── Test_Feature_065_Safety_And_Payload.php    # NEW — one test class per FR
+
+specs/065-safety-and-payload-improvements/
+└── (docs above)
+```
+
+**Structure Decision**: Purely additive edits to 9 existing files. No new directories, no new abilities, no bootstrap changes.
+
+## Complexity Tracking
+
+*No entries — Constitution Check passes with no justifications required.*

--- a/specs/065-safety-and-payload-improvements/spec.md
+++ b/specs/065-safety-and-payload-improvements/spec.md
@@ -1,0 +1,226 @@
+# Feature Specification: Safety envelope + payload enrichment across 9 existing abilities
+
+**Feature Branch**: `065-safety-and-payload-improvements`
+**Created**: 2026-08-12
+**Status**: Draft
+**Input**: User description: "Update the code of the 9 abilities where a side-by-side quality review flagged us as weaker on safety guardrails and/or payload completeness, plus add a protected-plugin guard on `acrossai/deactivate-plugin` so it refuses to deactivate the AcrossAI plugin family (mcp-manager, abilities-manager, acrossai-pro)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Prevent accidental deactivation of the AcrossAI plugin family (Priority: P1)
+
+An operator (or AI agent operating on their behalf with `manage_options`) cannot use `acrossai/deactivate-plugin` to deactivate a plugin that belongs to the AcrossAI plugin family — specifically `acrossai-mcp-manager`, `acrossai-abilities-manager` (this plugin), and `acrossai-pro`. Deactivating any of the three would either cut off the ability surface entirely (`acrossai-abilities-manager`) or break the very connection the AI is using to reach the site (`acrossai-mcp-manager`). The `acrossai-pro` family is protected for the same reason (it hosts the pro connectors the pro tools rely on).
+
+**Why this priority**: A single accidental call to `acrossai/deactivate-plugin` targeting one of these three plugins is a foot-gun that will break the AI's connection to the site, or worse, silently disable every ability the AI is trying to use. Every other issue in this spec is a paper cut compared to "the AI accidentally cuts its own connection."
+
+**Independent Test**: An operator with `manage_options` invokes `acrossai/deactivate-plugin` with any of the three protected slugs and observes the ability refuse without mutating any state.
+
+**Acceptance Scenarios**:
+
+1. **Given** `acrossai-mcp-manager` is currently active, **When** the operator calls `acrossai/deactivate-plugin` with input `plugin: "acrossai-mcp-manager"`, **Then** the ability refuses without mutating state and returns a message naming the protected plugin.
+2. **Given** `acrossai-abilities-manager` is currently active, **When** the operator calls `acrossai/deactivate-plugin` with input `plugin: "acrossai-abilities-manager"`, **Then** the ability refuses without mutating state.
+3. **Given** `acrossai-pro` is currently active, **When** the operator calls `acrossai/deactivate-plugin` with input `plugin: "acrossai-pro"`, **Then** the ability refuses without mutating state.
+4. **Given** the operator passes the plugin's file path (e.g. `acrossai-mcp-manager/acrossai-mcp-manager.php`) rather than the slug, **When** the ability resolves the input to the same plugin family, **Then** the ability refuses (the guard works against every resolvable form the fuzzy resolver accepts).
+5. **Given** any non-protected plugin, **When** the operator calls `acrossai/deactivate-plugin`, **Then** the ability behaves exactly as it does today (no regression on the unprotected path).
+
+---
+
+### User Story 2 - Require explicit confirmation before permanently deleting media or a file (Priority: P1)
+
+Destructive filesystem and media operations require the operator to pass `confirm: true` explicitly. Passing the operation without `confirm` returns a soft refusal that names the required flag, so a misfired call from an AI agent cannot silently destroy content.
+
+**Why this priority**: Both `acrossai/delete-media` (hard-deletes the attachment + files on disk) and `acrossai/delete-file` (removes a file inside the WordPress installation) are permanently destructive. Today neither requires acknowledgment. A single misfired call has no undo.
+
+**Independent Test**: The operator invokes either ability without `confirm`, observes a soft refusal, then invokes it with `confirm: true` and observes the destructive operation execute.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing attachment, **When** the operator calls `acrossai/delete-media` with only `id`, **Then** the ability refuses with a `confirmation_required` message.
+2. **Given** the same attachment, **When** the operator calls `acrossai/delete-media` with `id` and `confirm: true`, **Then** the ability deletes the attachment.
+3. **Given** a site with `MEDIA_TRASH` defined truthy, **When** the operator calls `acrossai/delete-media` with `id` + `confirm: true` and no `force`, **Then** the attachment is trashed (not permanently deleted).
+4. **Given** the same site, **When** the operator additionally passes `force: true`, **Then** the attachment is permanently deleted regardless of `MEDIA_TRASH`.
+5. **Given** any file inside the WordPress installation, **When** the operator calls `acrossai/delete-file` without `confirm`, **Then** the ability refuses without touching the file.
+6. **Given** `acrossai/delete-file` is invoked with `confirm: true` on any file, **Then** a `.bak.<timestamp>` copy is written next to the original before the delete proceeds, and the operator's response includes the backup path.
+
+---
+
+### User Story 3 - Refuse to read or delete the site's secrets file (Priority: P1)
+
+`acrossai/read-file` and `acrossai/delete-file` refuse to touch a hardcoded list of secret-holding files at the WordPress root — specifically `wp-config.php` and `.htaccess` — regardless of the caller's `manage_options` capability. This blocks the single most damaging accidental-read path (agent slurps `wp-config.php` and echoes the database password + auth salts back to the client).
+
+**Why this priority**: `wp-config.php` contains the database password and eight authentication constants (`AUTH_KEY`, `SECURE_AUTH_KEY`, `LOGGED_IN_KEY`, `NONCE_KEY`, `AUTH_SALT`, `SECURE_AUTH_SALT`, `LOGGED_IN_SALT`, `NONCE_SALT`). A single misfired `read-file` call today discloses all nine. `manage_options` is not sufficient defense because a compromised admin session or a malicious AI client already has the capability.
+
+**Independent Test**: The operator invokes `acrossai/read-file` with `path: "wp-config.php"`, observes a `protected_read` refusal, and does the same for `.htaccess`. Then invokes `acrossai/delete-file` on `wp-config.php` and observes a `protected_write` refusal.
+
+**Acceptance Scenarios**:
+
+1. **Given** any WordPress install, **When** the operator calls `acrossai/read-file` with `path: "wp-config.php"`, **Then** the ability refuses with `blocked_reason: "protected_read"` and does not return the file contents.
+2. **Given** the same install, **When** the operator calls `acrossai/read-file` with `path: ".htaccess"`, **Then** the ability refuses with `blocked_reason: "protected_read"`.
+3. **Given** the same install, **When** the operator calls `acrossai/delete-file` with any of the protected paths, **Then** the ability refuses with `blocked_reason: "protected_write"` without modifying the file.
+
+---
+
+### User Story 4 - Cap `acrossai/read-file` at a safe upload size (Priority: P2)
+
+`acrossai/read-file` refuses to return the contents of a file that exceeds a fixed maximum byte size (default: 5 MB). Callers that legitimately need to inspect large files must issue a targeted read via an alternative surface (offset/limit — future work) rather than loading the whole file into memory.
+
+**Why this priority**: The current implementation calls `file_get_contents()` on an arbitrary path. A 500 MB `debug.log` will exhaust PHP's memory limit, fatal the request, and reveal an OOM error to the caller. A hard cap prevents the class of failure entirely.
+
+**Independent Test**: The operator invokes `acrossai/read-file` on a file that exceeds the cap, observes a soft refusal naming the limit and the file's actual size.
+
+**Acceptance Scenarios**:
+
+1. **Given** a text file smaller than the cap, **When** the operator calls `acrossai/read-file`, **Then** the ability returns the full contents as today.
+2. **Given** a file larger than the cap, **When** the operator calls `acrossai/read-file`, **Then** the ability refuses with a message naming the size limit and the actual file size, without loading the file into memory.
+3. **Given** a file that appears to contain binary content (non-UTF-8 bytes), **When** the operator calls `acrossai/read-file`, **Then** the ability returns a shape carrying `binary: true` + `size` + a human-readable message, but does NOT return the raw bytes as `content`.
+
+---
+
+### User Story 5 - Enrich `get-post` payload with derived fields (Priority: P2)
+
+`acrossai/get-post` returns not just the raw post row but also derived fields the caller usually needs next: attached terms grouped by taxonomy, non-protected post meta, the featured image (id + URL + alt), the public permalink, the admin edit link, and a shallow author `{id, name}` shape.
+
+**Why this priority**: Today `get-post` returns `get_post( $id, ARRAY_A )` — the raw WordPress row. Every downstream client that wants to render or reason about the post immediately makes 4–5 follow-up calls to hydrate terms / meta / featured image / permalink. This is wasted round-trips and wasted tokens. All the derived fields are trivially derivable in one server-side pass.
+
+**Independent Test**: The operator invokes `acrossai/get-post` on any post; the response payload includes the derived fields alongside the raw row.
+
+**Acceptance Scenarios**:
+
+1. **Given** a post assigned to categories and tags, **When** the operator calls `acrossai/get-post`, **Then** the response includes a `terms` object keyed by taxonomy with per-term `{term_id, name, slug}` triples.
+2. **Given** a post with non-protected meta, **When** the operator calls `acrossai/get-post`, **Then** the response includes a `meta` object of non-protected keys (keys starting with `_` or reported by `is_protected_meta()` are omitted unless allow-listed by a filter).
+3. **Given** a post with a featured image, **When** the operator calls `acrossai/get-post`, **Then** the response includes `featured_image: { id, url, alt }`.
+4. **Given** any post, **When** the operator calls `acrossai/get-post`, **Then** the response includes `permalink`, `edit_link`, and `author: { id, name }`.
+
+---
+
+### User Story 6 - Widen `list-media` search to include alt-text (Priority: P2)
+
+`acrossai/list-media` matches the caller's `search` string against title, caption, description, AND alt-text (the postmeta field `_wp_attachment_image_alt`) — not just the three fields WP_Query's `s` param covers by default.
+
+**Why this priority**: Alt-text is where accessibility-conscious sites store the most descriptive text about each image. Today a caller searching for "logo" against a media library where the alt-text says "Company logo, blue variant" but title/caption/description are empty will miss the match. Fixing this closes a real search-relevance gap.
+
+**Independent Test**: The operator uploads an image with a distinctive alt-text-only string, invokes `acrossai/list-media` with that string as `search`, and observes the attachment in the results.
+
+**Acceptance Scenarios**:
+
+1. **Given** an attachment whose title/caption/description are empty but whose alt-text contains "brand-hero-2026", **When** the operator calls `acrossai/list-media` with `search: "brand-hero-2026"`, **Then** the attachment appears in the results.
+2. **Given** an attachment whose title contains "brand-hero-2026" (and alt-text is empty), **When** the operator calls `acrossai/list-media` with the same search, **Then** the attachment still appears (current behaviour preserved).
+3. **Given** two attachments — one matching only via title, one matching only via alt-text — **When** the operator calls with the shared search string, **Then** both appear in a de-duplicated result set.
+
+---
+
+### User Story 7 - Report which fields `update-media` actually changed (Priority: P2)
+
+`acrossai/update-media` returns an `updated` array listing the names of the fields that were actually changed by the invocation (subset of `title`, `caption`, `description`, `alt_text`). Callers no longer need to diff before-and-after payloads to figure out what happened.
+
+**Why this priority**: The current response returns the full media object but doesn't call out which specific fields were mutated. A caller that passes all four fields and hits a validation error on one of them cannot tell from the response which three landed successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** an attachment, **When** the operator calls `acrossai/update-media` with only `alt_text`, **Then** the response includes `updated: ["alt_text"]`.
+2. **Given** the same attachment, **When** the operator calls with `title` + `caption` + `alt_text`, **Then** the response includes `updated: ["title", "caption", "alt_text"]` in the order the fields were processed.
+3. **Given** an invocation with `id` but no update fields, **When** the operator calls the ability, **Then** the response returns `updated: []` and reports success.
+
+---
+
+### User Story 8 - Add correctness gates on `update-post` (Priority: P2)
+
+`acrossai/update-post` enforces four additional gates before mutating a post:
+
+1. The post's `post_type` must be writable (registered with `public: true` OR `show_in_rest: true` — mirrors the WP-REST behaviour). Refuses on internal-only post types like `nav_menu_item` and `revision`.
+2. The `meta` object cannot include any protected meta key (a key starting with `_` or one that `is_protected_meta( $key, 'post' )` returns true for) unless allow-listed via a filter.
+3. If the caller passes `status: "publish"` (or a status change into a public state), the caller must hold `publish_posts` for that post type — not just `manage_options`.
+4. If the caller passes `author: <different_user_id>`, the caller must hold `edit_others_posts` for that post type.
+
+**Why this priority**: Today `manage_options` is the only gate; the ability blindly passes every input through `wp_update_post`. That means a caller with `manage_options` but restricted lower-tier caps (unusual but possible on custom role setups) can bypass WordPress-core's own permission model. It also means a caller can silently write protected meta that WordPress core would normally block via the REST API.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `nav_menu_item` post (internal), **When** the operator calls `acrossai/update-post` on it, **Then** the ability refuses with a message naming the non-writable post type.
+2. **Given** a caller passing `meta: { "_edit_lock": "...", "custom_field": "..." }`, **When** the ability executes, **Then** `_edit_lock` is stripped from the meta_input and the response reports which meta keys were dropped; `custom_field` is written as usual.
+3. **Given** a caller passing `status: "publish"` on a post type where the caller lacks `publish_posts`, **When** the ability executes, **Then** it refuses with a permission-denied message.
+4. **Given** a caller passing `author: <someone_else>` on a post where the caller lacks `edit_others_posts`, **When** the ability executes, **Then** it refuses with a permission-denied message.
+
+---
+
+### User Story 9 - Suggest a redirect target when `delete-post` removes a public URL (Priority: P3)
+
+`acrossai/delete-post`'s response includes a `suggested_redirect` field naming the permalink that just went dead + a suggested replacement URL (either the parent, the archive, or the site root — computed heuristically). The caller can use this to feed a redirect-manager plugin or a redirect ability without having to reconstruct the URL after the delete.
+
+**Why this priority**: Deleting a published post kills a URL that may have inbound links. Surfacing the dead URL in the response is a low-cost quality-of-life improvement. Not urgent because deletion works today; the caller can compute the URL themselves — this just saves a step.
+
+**Acceptance Scenarios**:
+
+1. **Given** a published post, **When** the operator calls `acrossai/delete-post` with `id` and `force: true`, **Then** the response includes `suggested_redirect: { from: <permalink>, to: <parent_or_archive_or_root_url> }`.
+2. **Given** a draft post, **When** the operator deletes it, **Then** no `suggested_redirect` is included (drafts have no public URL that needs redirecting).
+3. **Given** a trashed post (soft delete), **When** the ability trashes it, **Then** no `suggested_redirect` is included (URL might come back if the post is restored).
+
+---
+
+### Edge Cases
+
+- **Protected-plugin guard on `deactivate-plugin`.** The fuzzy resolver accepts multiple forms of input for the same plugin (slug, file, partial). The guard MUST match against the resolved plugin file path, not the raw input, so `deactivate-plugin` can't be tricked by passing a partial name that fuzzy-resolves to a protected plugin.
+- **`delete-media` with `MEDIA_TRASH` defined but `force: true`.** `force` takes precedence; the ability permanently deletes and reports `deleted: "deleted"` rather than `deleted: "trashed"`.
+- **`read-file` on a file exactly at the size cap.** Returns success (cap is `>`, not `>=`).
+- **`get-post` on a post with a broken featured-image reference** (attachment deleted, meta lingers). `featured_image` is present in the response as `null`, not omitted.
+- **`update-post` protected-meta filter with a filter callback that removes every default protected key.** Behaves as if the caller had specified every key — no defensive guard against a totally-open filter, since that's an intentional site-owner choice.
+- **`update-media` idempotent invocation.** Calling twice with the same fields returns `updated: [...]` both times — the ability does not compare against the current stored value; it re-writes and reports what was written.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `acrossai/deactivate-plugin` MUST maintain a hardcoded protected-plugin list containing at minimum: `acrossai-mcp-manager/acrossai-mcp-manager.php`, `acrossai-abilities-manager/acrossai-abilities-manager.php`, and `acrossai-pro/acrossai-pro.php`. Match is against the resolved plugin file path so the guard cannot be bypassed via fuzzy input.
+- **FR-002**: `acrossai/deactivate-plugin` MUST return `success: false` with `blocked_reason: "protected_plugin"` when the resolved target matches an entry in the protected list, without invoking `deactivate_plugins()`.
+- **FR-003**: `acrossai/delete-media` MUST require an explicit `confirm: true` input; refuse with `blocked_reason: "confirmation_required"` when the input is absent or falsy.
+- **FR-004**: `acrossai/delete-media` MUST honour the `MEDIA_TRASH` PHP constant — when defined truthy AND the caller omits `force: true`, the attachment is trashed (`wp_delete_attachment( $id, false )`); otherwise the delete is permanent.
+- **FR-005**: `acrossai/delete-media` response MUST include a `deleted` field with values `"deleted"` or `"trashed"` reflecting the observed outcome.
+- **FR-006**: `acrossai/list-media` MUST expand its `search` behaviour to match against `_wp_attachment_image_alt` postmeta in addition to the WP_Query `s` fields (title, caption, description). The union is de-duplicated by attachment ID.
+- **FR-007**: `acrossai/update-media` response MUST include an `updated` array naming each field the ability actually wrote (subset of `title`, `caption`, `description`, `alt_text`). Empty array when no update fields were passed.
+- **FR-008**: `acrossai/update-post` MUST refuse invocations on post types that are neither `public: true` NOR `show_in_rest: true` (matches the WP REST writability convention).
+- **FR-009**: `acrossai/update-post` MUST filter the caller-supplied `meta` object to remove any key that begins with `_` OR that `is_protected_meta( $key, 'post' )` returns true for, unless the filter `acrossai_allowed_protected_meta` returns an array containing that key. Stripped keys MUST be reported in the response payload as `dropped_meta_keys`.
+- **FR-010**: `acrossai/update-post` MUST refuse when the caller passes `status: "publish"` (or any status that maps to a public status) AND lacks `publish_posts` for the target post type.
+- **FR-011**: `acrossai/update-post` MUST refuse when the caller passes `author` set to a user ID other than the current user AND lacks `edit_others_posts` for the target post type.
+- **FR-012**: `acrossai/get-post` MUST decorate its response with the following derived fields: `terms` (object keyed by taxonomy of `[{ term_id, name, slug }]`), `meta` (object of non-protected meta), `featured_image` (`{ id, url, alt }` or `null`), `permalink` (string), `edit_link` (string), `author` (`{ id, name }`).
+- **FR-013**: `acrossai/get-post` `meta` field MUST use the same protected-key filter as FR-009 (respecting the `acrossai_allowed_protected_meta` filter).
+- **FR-014**: `acrossai/read-file` MUST refuse to return content for any file whose absolute path matches a hardcoded read-protection list containing at minimum: `wp-config.php` at ABSPATH root and `.htaccess` at ABSPATH root. Refusal MUST use `blocked_reason: "protected_read"`.
+- **FR-015**: `acrossai/read-file` MUST refuse to return content for any file whose byte size exceeds `MAX_READ_BYTES` (default 5 MB). Refusal MUST use `blocked_reason: "file_too_large"` and MUST report both the observed size and the cap.
+- **FR-016**: `acrossai/read-file` MUST detect non-UTF-8 (binary) content and return a distinct shape carrying `binary: true` + `size` + `path` + `message` rather than the raw bytes.
+- **FR-017**: `acrossai/delete-file` MUST require an explicit `confirm: true` input; refuse with `blocked_reason: "confirmation_required"` when absent or falsy.
+- **FR-018**: `acrossai/delete-file` MUST refuse to delete any file matching the read-protection list from FR-014 (`wp-config.php`, `.htaccess`). Refusal MUST use `blocked_reason: "protected_write"`.
+- **FR-019**: `acrossai/delete-file` MUST write a `.bak.<timestamp>` copy next to the target file before invoking the delete; the backup path MUST be returned in the response as `backup`.
+- **FR-020**: `acrossai/delete-file` MUST call `opcache_invalidate()` on the deleted path (guarded by `function_exists()` — OPcache may be absent).
+- **FR-021**: `acrossai/delete-post` response MUST include a `suggested_redirect` field of shape `{ from: string, to: string }` when the post being deleted is currently published AND `force: true`. Omitted otherwise.
+- **FR-022**: Every response payload from a refused (guardrail-triggered) invocation MUST include `success: false`, a human-readable `message`, and a machine-readable `blocked_reason` string; no state mutation MUST occur on the refusal path.
+- **FR-023**: Every ability listed above MUST continue to gate on `current_user_can( 'manage_options' )` via the identical permission callback the rest of the ability surface uses. No changes to the permission-callback shape.
+
+### Key Entities *(include if feature involves data)*
+
+- **Protected plugin list**: hardcoded array of WordPress plugin file paths (relative to `WP_PLUGIN_DIR`) that `acrossai/deactivate-plugin` refuses to deactivate. Not filterable in this feature — extensibility deferred.
+- **Read-protection list / write-protection list**: hardcoded array of absolute file paths (all at `ABSPATH` root) that filesystem abilities refuse to read or modify. Same list is used for both refusal categories in this feature.
+- **Protected-meta filter (`acrossai_allowed_protected_meta`)**: a WordPress filter returning an array of protected meta keys the ability layer should treat as writable. Default: empty. Applied at both `update-post` write time (FR-009) and `get-post` read time (FR-013).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of attempts to deactivate any of the three named AcrossAI plugins via `acrossai/deactivate-plugin` are refused without state mutation, regardless of input format (slug, file path, partial name).
+- **SC-002**: 100% of attempts to hard-delete media or a file without `confirm: true` are refused.
+- **SC-003**: 100% of attempts to read or delete `wp-config.php` and `.htaccess` are refused with the correct `blocked_reason`.
+- **SC-004**: 100% of `acrossai/read-file` invocations on files larger than 5 MB refuse without loading the file into memory (verified by comparing peak-memory before and during the call).
+- **SC-005**: 100% of `acrossai/update-post` invocations against `nav_menu_item` and `revision` post types are refused.
+- **SC-006**: 100% of `acrossai/get-post` invocations return non-empty `terms` for posts that have taxonomies assigned, non-`null` `featured_image` for posts with a featured image, and a valid `permalink` string.
+- **SC-007**: A `list-media` search that matches only alt-text returns the correct attachment on 100% of invocations against a controlled fixture.
+- **SC-008**: A `update-media` invocation with three fields returns `updated: [three_field_names]` in insertion order on 100% of invocations.
+- **SC-009**: All existing tests in the `composer run test` suite continue to pass; new tests added for every guardrail and every enrichment.
+- **SC-010**: PHPCS + PHPStan level 8 stay clean on the branch.
+
+## Assumptions
+
+- The plugin's convention that every ability's permission callback is the literal `static function (): bool { return current_user_can( 'manage_options' ); }` remains in force. No changes to any permission callback in this feature.
+- No changes to the plugin's overall admin UI. All improvements are behind-the-scenes at the ability layer.
+- The `acrossai-pro` slug refers to the paid family plugin (`acrossai-pro/acrossai-pro.php`). If the actual file name differs on a given install, the protected-list guard falls through as if the plugin were not installed (which is correct behaviour — nothing to protect).
+- `confirm: true` becoming a required input on `delete-media` and `delete-file` is a **breaking change** to any existing programmatic caller that omits the flag. Bounded blast radius (both are `manage_options`-gated); documented in the PR body and in the ability's `description` string.
+- `acrossai/update-post` protected-meta filtering is a **soft-breaking change** for any caller that was writing `_`-prefixed meta through the ability. Documented; keys are named in the response's `dropped_meta_keys` field so the caller can adapt.
+- `MAX_READ_BYTES = 5 * 1024 * 1024` (5 MB) is a reasonable default. Not configurable in this feature; a later feature could add a `acrossai_read_file_max_bytes` filter.
+- No version bump in this PR. This feature ships in whatever the next release is (0.0.24 or later) — the release cut is out of scope for this spec.

--- a/specs/065-safety-and-payload-improvements/tasks.md
+++ b/specs/065-safety-and-payload-improvements/tasks.md
@@ -1,0 +1,67 @@
+---
+description: "Implementation tasks for feature 065 — safety envelope + payload enrichment across 9 abilities"
+---
+
+# Tasks: Safety envelope + payload enrichment across 9 abilities
+
+**Input**: Design docs from `specs/065-safety-and-payload-improvements/`
+**Prerequisites**: [spec.md](./spec.md), [plan.md](./plan.md), [contracts/abilities.md](./contracts/abilities.md)
+**Tests**: Included per constitution §VII.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no ordering dependency).
+- **[Story]**: `US1..US9` per spec.md, or `QA`.
+
+## Phase 1: Protected-plugin guard (US1, P1)
+
+- [ ] **T010** [US1] Edit `includes/Abilities/Plugins/Deactivate_Plugin.php`. Add `private const PROTECTED_PLUGINS = ['acrossai-mcp-manager/acrossai-mcp-manager.php', 'acrossai-abilities-manager/acrossai-abilities-manager.php', 'acrossai-pro/acrossai-pro.php']`. In `execute()`, after `Plugin_Helpers::resolve_plugin()` returns the resolved file path, check `in_array($plugin_file, self::PROTECTED_PLUGINS, true)` and refuse with `blocked_reason: 'protected_plugin'` + message naming the plugin. Order: resolve first, then check protection, then check active state.
+
+## Phase 2: Filesystem safety (US2 + US3 + US4)
+
+- [ ] **T020** [US3] Edit `includes/Abilities/FileManager/Read_File.php`. Add `private const PROTECTED_FILES = ['wp-config.php', '.htaccess']` (paths relative to ABSPATH). Add `private const MAX_READ_BYTES = 5 * 1024 * 1024`. In `execute()`, after realpath resolution: (a) if the resolved path matches ABSPATH + protected filename, refuse with `blocked_reason: 'protected_read'`; (b) `filesize()` check against MAX_READ_BYTES, refuse with `blocked_reason: 'file_too_large'` + reported size/cap in message; (c) check `mb_check_encoding( $content, 'UTF-8' )` — if false, return `{ success: true, path, size, binary: true, message: '...' }` without `content`.
+- [ ] **T021** [US2 + US3] Edit `includes/Abilities/FileManager/Delete_File.php`. Add same `PROTECTED_FILES` constant. In `execute()`, after realpath resolution but before delete: (a) require `confirm: true` in input, refuse with `blocked_reason: 'confirmation_required'` if absent/falsy; (b) if resolved path matches protected file, refuse with `blocked_reason: 'protected_write'`; (c) copy source to `$abs_path . '.bak.' . time()` before deleting — capture the backup path for the response; (d) after successful delete, call `opcache_invalidate($abs_path, true)` guarded by `function_exists('opcache_invalidate')`. Response includes `backup: <path>` field.
+
+## Phase 3: Media enhancements (US2 + US6 + US7)
+
+- [ ] **T030** [US2] Edit `includes/Abilities/Media/Delete_Media.php`. Input schema: add `confirm: boolean` (required) and `force: boolean` (optional, default false). Refuse without `confirm: true` (`blocked_reason: 'confirmation_required'`). In `execute()`: compute `$trashed = ! $force && defined('MEDIA_TRASH') && MEDIA_TRASH`; call `wp_delete_attachment($id, ! $trashed)`. Response `deleted` field: `"trashed"` or `"deleted"` string (change output_schema type from boolean to string).
+- [ ] **T031** [US7] Edit `includes/Abilities/Media/Update_Media.php`. In `execute()`, track `$updated = []` as each field is written. Append `'title'`, `'caption'`, `'description'`, `'alt_text'` to `$updated` as they are processed. Include `updated: array<string>` in the response payload. Also add `updated` to `output_schema.properties`.
+- [ ] **T032** [US6] Edit `includes/Abilities/Media/List_Media.php`. When `search` is non-empty: run TWO id-only queries — the current `s`-based query (title/caption/description) AND a `meta_query` id-only lookup against `_wp_attachment_image_alt` using `LIKE`. Union and de-duplicate the IDs. If both are empty, return the current no-results shape. Otherwise pass `post__in => $ids` into the main paginated `WP_Query` (drop the `s`). Keep the existing `mime_type`/`parent`/`page`/`per_page` args.
+
+## Phase 4: Content-side enrichments and gates (US5 + US8 + US9)
+
+- [ ] **T040** [US5] Edit `includes/Abilities/Content/Get_Post.php`. Preserve current inputs and refusal shape. In `execute()`, after fetching `$post`, build the enriched payload:
+  - `terms`: iterate `get_object_taxonomies($post->post_type)`; for each taxonomy, `get_the_terms($post, $tax)` → map to `[{term_id, name, slug}]`.
+  - `meta`: iterate `get_post_meta($id)`; skip keys starting with `_` OR where `is_protected_meta($key, 'post')` is true, UNLESS the key is in `apply_filters('acrossai_allowed_protected_meta', [])`. For each retained key, if the value array has one element unserialize it, else map `maybe_unserialize` over the array.
+  - `featured_image`: `$thumb_id = get_post_thumbnail_id($post)`; if `>0`, `{id, url: wp_get_attachment_image_url($thumb_id, 'full'), alt: get_post_meta($thumb_id, '_wp_attachment_image_alt', true)}`; else `null`.
+  - `permalink`: `get_permalink($post)`.
+  - `edit_link`: `get_edit_post_link($post->ID, 'raw')`.
+  - `author`: `$author_obj = get_userdata((int) $post->post_author)`; if valid, `{id, name: display_name}`; else `{id: 0, name: ""}`.
+  Response payload adds these six fields alongside `post` (the raw `get_post(ARRAY_A)` — keep for backward compatibility). Update `output_schema` accordingly.
+- [ ] **T041** [US8] Edit `includes/Abilities/Content/Update_Post.php`. In `execute()`, after resolving `$post`:
+  - **Writable-post-type check.** `$pt_obj = get_post_type_object($post->post_type)`; refuse if `null` OR `! ($pt_obj->public || $pt_obj->show_in_rest)` with `blocked_reason: 'non_writable_post_type'`.
+  - **Protected-meta filter.** If `$input['meta']` is a non-empty array, build `$allowed = (array) apply_filters('acrossai_allowed_protected_meta', [])`. For each key, if `str_starts_with($key, '_') || is_protected_meta($key, 'post')` AND NOT `in_array($key, $allowed, true)`, drop it. Track dropped keys as `$dropped_meta_keys` array for the response. Pass the filtered meta into `$args['meta_input']`.
+  - **`publish_posts` cap check on status change.** If `$input['status']` is `publish` OR a status that `get_post_status_object($input['status'])?->public` is true, AND `! current_user_can($pt_obj->cap->publish_posts)`, refuse with `blocked_reason: 'publish_cap_required'`.
+  - **`edit_others_posts` cap on author change.** If `$input['author']` is set AND `(int) $input['author'] !== (int) get_current_user_id()` AND `! current_user_can($pt_obj->cap->edit_others_posts)`, refuse with `blocked_reason: 'edit_others_posts_required'`.
+  Response payload adds `dropped_meta_keys: array<string>` when non-empty; add to `output_schema`.
+- [ ] **T042** [US9] Edit `includes/Abilities/Content/Delete_Post.php`. When the invocation succeeds AND `$force === true` AND the post's status before delete was `publish` (probe via snapshot before delete): compute `$permalink = get_permalink($post)`; compute a suggested target — if `$post->post_parent > 0` and the parent is published, use its permalink; else if the post type has an archive, `get_post_type_archive_link($post->post_type)`; else `home_url('/')`. Include `suggested_redirect: { from: $permalink, to: $target }` in the response. Add to `output_schema`.
+
+## Phase 5: Tests
+
+- [ ] **T050** [P] [QA] Create `tests/phpunit/abilities/Test_Feature_065_Safety_And_Payload.php` extending `WP_UnitTestCase`. Follow the plugin's established source-inspection pattern (matches `Test_Feature_042/043/057/059/062/063/064`). One test method per FR (23 methods). Each test asserts (a) the source contains the expected constant / method call / branch (source-inspection assertion), and (b) where possible without a real WP DB, calls the ability's `execute()` and asserts the response shape.
+- [ ] **T051** [P] [QA] Add the new test file to `phpunit.xml.dist` under a new `<testsuite name="feature-065-unit">` entry.
+
+## Phase 6: QA gates
+
+- [ ] **T060** [QA] `composer run test` — every existing test still passes; every new test passes.
+- [ ] **T061** [QA] `composer run phpcs` — zero errors, zero warnings.
+- [ ] **T062** [QA] `composer run phpstan` at level 8 — zero errors.
+
+## Non-goals
+
+- No changes to `edit-file` naming/semantics — deferred to a follow-up spec (breaking change deserves its own decision).
+- No version bump.
+- No changes to admin UI.
+- No new abilities.
+- No changes to any of the other 240+ existing abilities.
+- Extensibility of the protected-plugin list (via filter) is out of scope; hardcoded in this feature.

--- a/tests/phpunit/abilities/Test_Feature_065_Safety_And_Payload.php
+++ b/tests/phpunit/abilities/Test_Feature_065_Safety_And_Payload.php
@@ -1,0 +1,536 @@
+<?php
+/**
+ * Structural tests for Feature 065 — safety envelope + payload enrichment
+ * across 9 existing abilities.
+ *
+ * Source-inspection assertions covering every FR from spec.md. Runs against
+ * the plugin's minimal unit-test bootstrap; no full WP environment needed.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.23
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Feature_065_Safety_And_Payload.
+ */
+class Test_Feature_065_Safety_And_Payload extends WP_UnitTestCase {
+
+	/**
+	 * Absolute paths to every source file exercised by these tests.
+	 *
+	 * @var array<string,string>
+	 */
+	private array $sources = array();
+
+	/**
+	 * Load every source file once per test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$plugin_root = dirname( __DIR__, 3 );
+
+		$this->sources = array(
+			'deactivate_plugin' => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Plugins/Deactivate_Plugin.php'
+			),
+			'delete_media'      => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Media/Delete_Media.php'
+			),
+			'update_media'      => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Media/Update_Media.php'
+			),
+			'list_media'        => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Media/List_Media.php'
+			),
+			'get_post'          => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Content/Get_Post.php'
+			),
+			'update_post'       => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Content/Update_Post.php'
+			),
+			'delete_post'       => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/Content/Delete_Post.php'
+			),
+			'read_file'         => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/FileManager/Read_File.php'
+			),
+			'delete_file'       => (string) file_get_contents(
+				$plugin_root . '/includes/Abilities/FileManager/Delete_File.php'
+			),
+		);
+	}
+
+	// =========================================================================
+	// FR-001, FR-002 — Deactivate_Plugin protected-plugin guard
+	// =========================================================================
+
+	/**
+	 * FR-001: PROTECTED_PLUGINS constant lists the three AcrossAI-family
+	 * plugin file paths.
+	 *
+	 * @return void
+	 */
+	public function test_fr001_deactivate_plugin_defines_protected_list(): void {
+		$src = $this->sources['deactivate_plugin'];
+		$this->assertStringContainsString(
+			'private const PROTECTED_PLUGINS',
+			$src,
+			'Deactivate_Plugin must declare PROTECTED_PLUGINS.'
+		);
+		$this->assertStringContainsString(
+			"'acrossai-mcp-manager/acrossai-mcp-manager.php'",
+			$src
+		);
+		$this->assertStringContainsString(
+			"'acrossai-abilities-manager/acrossai-abilities-manager.php'",
+			$src
+		);
+		$this->assertStringContainsString(
+			"'acrossai-pro/acrossai-pro.php'",
+			$src
+		);
+	}
+
+	/**
+	 * FR-002: guard checks the RESOLVED plugin file via in_array strict mode
+	 * and returns success:false + blocked_reason:protected_plugin without
+	 * invoking deactivate_plugins().
+	 *
+	 * @return void
+	 */
+	public function test_fr002_deactivate_plugin_refuses_with_protected_plugin_reason(): void {
+		$src = $this->sources['deactivate_plugin'];
+		$this->assertMatchesRegularExpression(
+			"/in_array\(\s*\\\$plugin_file,\s*self::PROTECTED_PLUGINS,\s*true\s*\)/",
+			$src,
+			'Guard must use in_array with strict mode against the resolved file.'
+		);
+		$this->assertStringContainsString(
+			"'blocked_reason' => 'protected_plugin'",
+			$src
+		);
+		// The guard must run BEFORE deactivate_plugins is called.
+		$pos_guard      = strpos( $src, "'protected_plugin'" );
+		$pos_deactivate = strpos( $src, 'deactivate_plugins(' );
+		$this->assertNotFalse( $pos_guard );
+		$this->assertNotFalse( $pos_deactivate );
+		$this->assertLessThan(
+			$pos_deactivate,
+			$pos_guard,
+			'The protected-plugin refusal must precede the deactivate_plugins() call in source order.'
+		);
+	}
+
+	// =========================================================================
+	// FR-003, FR-004, FR-005 — Delete_Media confirmation + MEDIA_TRASH + string outcome
+	// =========================================================================
+
+	/**
+	 * FR-003: delete-media requires confirm:true and refuses with
+	 * confirmation_required otherwise.
+	 *
+	 * @return void
+	 */
+	public function test_fr003_delete_media_requires_confirm(): void {
+		$src = $this->sources['delete_media'];
+		$this->assertMatchesRegularExpression(
+			"/'required'\s*=>\s*array\(\s*'id',\s*'confirm'\s*\)/",
+			$src,
+			'delete-media input schema must require both id and confirm.'
+		);
+		$this->assertStringContainsString(
+			"'blocked_reason' => 'confirmation_required'",
+			$src
+		);
+	}
+
+	/**
+	 * FR-004: delete-media honours MEDIA_TRASH — computes $trashed and calls
+	 * wp_delete_attachment( $id, ! $trashed ).
+	 *
+	 * @return void
+	 */
+	public function test_fr004_delete_media_honours_media_trash(): void {
+		$src = $this->sources['delete_media'];
+		$this->assertStringContainsString( "defined( 'MEDIA_TRASH' )", $src );
+		$this->assertStringContainsString( 'MEDIA_TRASH', $src );
+		$this->assertMatchesRegularExpression(
+			"/wp_delete_attachment\(\s*\\\$id,\s*!\s*\\\$trashed\s*\)/",
+			$src,
+			'delete-media must call wp_delete_attachment($id, ! $trashed).'
+		);
+	}
+
+	/**
+	 * FR-005: response `deleted` is the string "deleted" or "trashed"
+	 * (not boolean); output_schema declares the enum.
+	 *
+	 * @return void
+	 */
+	public function test_fr005_delete_media_response_uses_string_outcome(): void {
+		$src = $this->sources['delete_media'];
+		$this->assertMatchesRegularExpression(
+			"/'deleted'\s*=>\s*\\\$trashed\s*\?\s*'trashed'\s*:\s*'deleted'/",
+			$src
+		);
+		$this->assertStringContainsString( "'enum' => array( 'deleted', 'trashed' )", $src );
+	}
+
+	// =========================================================================
+	// FR-006 — List_Media alt-text search
+	// =========================================================================
+
+	/**
+	 * FR-006: list-media unions an alt-text meta_query with the text-search
+	 * results and passes the deduplicated id list into post__in.
+	 *
+	 * @return void
+	 */
+	public function test_fr006_list_media_search_includes_alt_text(): void {
+		$src = $this->sources['list_media'];
+		$this->assertStringContainsString( '_wp_attachment_image_alt', $src );
+		$this->assertStringContainsString( "'compare' => 'LIKE'", $src );
+		$this->assertStringContainsString( "'post__in'", $src );
+		$this->assertStringContainsString( 'array_unique', $src );
+	}
+
+	// =========================================================================
+	// FR-007 — Update_Media updated[] field
+	// =========================================================================
+
+	/**
+	 * FR-007: update-media response includes an `updated` array naming
+	 * every field written; output_schema declares it as array<string>.
+	 *
+	 * @return void
+	 */
+	public function test_fr007_update_media_returns_updated_array(): void {
+		$src = $this->sources['update_media'];
+		$this->assertStringContainsString( '$updated    = array();', $src );
+		$this->assertStringContainsString( "\$updated[]               = 'title';", $src );
+		$this->assertStringContainsString( "\$updated[]                 = 'caption';", $src );
+		$this->assertStringContainsString( "\$updated[]                 = 'description';", $src );
+		$this->assertStringContainsString( "\$updated[] = 'alt_text';", $src );
+		$this->assertStringContainsString( "'updated' => \$updated,", $src );
+		$this->assertMatchesRegularExpression(
+			"/'updated'\s*=>\s*array\(\s*\n?\s*'type'\s*=>\s*'array',\s*\n?\s*'items'\s*=>\s*array\(\s*'type'\s*=>\s*'string'\s*\)/",
+			$src,
+			'update-media output_schema must declare updated as array<string>.'
+		);
+	}
+
+	// =========================================================================
+	// FR-008, FR-009, FR-010, FR-011 — Update_Post gates
+	// =========================================================================
+
+	/**
+	 * FR-008: update-post refuses non-writable post types.
+	 *
+	 * @return void
+	 */
+	public function test_fr008_update_post_refuses_non_writable_post_types(): void {
+		$src = $this->sources['update_post'];
+		$this->assertStringContainsString( 'get_post_type_object(', $src );
+		$this->assertStringContainsString( "'blocked_reason' => 'non_writable_post_type'", $src );
+		$this->assertStringContainsString( '$pt_obj->public', $src );
+		$this->assertStringContainsString( '$pt_obj->show_in_rest', $src );
+	}
+
+	/**
+	 * FR-009: update-post filters protected meta keys via the
+	 * acrossai_allowed_protected_meta filter and reports dropped_meta_keys.
+	 *
+	 * @return void
+	 */
+	public function test_fr009_update_post_filters_protected_meta(): void {
+		$src = $this->sources['update_post'];
+		$this->assertStringContainsString( "apply_filters( 'acrossai_allowed_protected_meta', array() )", $src );
+		$this->assertStringContainsString( 'is_protected_meta(', $src );
+		$this->assertStringContainsString( "str_starts_with( \$key_str, '_' )", $src );
+		$this->assertMatchesRegularExpression(
+			"/in_array\(\s*\\\$key_str,\s*\\\$allowed,\s*true\s*\)/",
+			$src,
+			'Meta allow-list check must use in_array strict mode.'
+		);
+		$this->assertStringContainsString( "'dropped_meta_keys'", $src );
+	}
+
+	/**
+	 * FR-010: update-post gates status changes into a public status on
+	 * publish_posts.
+	 *
+	 * @return void
+	 */
+	public function test_fr010_update_post_gates_publish_status_on_publish_posts(): void {
+		$src = $this->sources['update_post'];
+		$this->assertStringContainsString( 'get_post_status_object(', $src );
+		$this->assertStringContainsString( '$pt_obj->cap->publish_posts', $src );
+		$this->assertStringContainsString( "'blocked_reason' => 'publish_cap_required'", $src );
+	}
+
+	/**
+	 * FR-011: update-post gates cross-user author changes on
+	 * edit_others_posts.
+	 *
+	 * @return void
+	 */
+	public function test_fr011_update_post_gates_author_change_on_edit_others_posts(): void {
+		$src = $this->sources['update_post'];
+		$this->assertStringContainsString( '$pt_obj->cap->edit_others_posts', $src );
+		$this->assertStringContainsString( 'get_current_user_id()', $src );
+		$this->assertStringContainsString( "'blocked_reason' => 'edit_others_posts_required'", $src );
+	}
+
+	// =========================================================================
+	// FR-012, FR-013 — Get_Post enrichment
+	// =========================================================================
+
+	/**
+	 * FR-012: get-post decorates its response with terms, meta,
+	 * featured_image, permalink, edit_link, and author.
+	 *
+	 * @return void
+	 */
+	public function test_fr012_get_post_enriches_response_with_derived_fields(): void {
+		$src = $this->sources['get_post'];
+		$this->assertStringContainsString( 'get_object_taxonomies(', $src );
+		$this->assertStringContainsString( 'get_the_terms(', $src );
+		$this->assertStringContainsString( 'get_post_thumbnail_id(', $src );
+		$this->assertStringContainsString( "wp_get_attachment_image_url( \$thumb_id, 'full' )", $src );
+		$this->assertStringContainsString( 'get_permalink(', $src );
+		$this->assertStringContainsString( "get_edit_post_link( \$id, 'raw' )", $src );
+		$this->assertStringContainsString( 'get_userdata(', $src );
+		// output_schema declares the new fields.
+		$this->assertStringContainsString( "'terms'          => array( 'type' => 'object' )", $src );
+		$this->assertStringContainsString( "'featured_image'", $src );
+		$this->assertStringContainsString( "'permalink'      => array( 'type' => 'string' )", $src );
+		$this->assertStringContainsString( "'edit_link'      => array( 'type' => 'string' )", $src );
+		$this->assertStringContainsString( "'author'         => array( 'type' => 'object' )", $src );
+	}
+
+	/**
+	 * FR-013: get-post's meta lookup honours the same
+	 * acrossai_allowed_protected_meta filter used by update-post.
+	 *
+	 * @return void
+	 */
+	public function test_fr013_get_post_meta_respects_protected_meta_filter(): void {
+		$src = $this->sources['get_post'];
+		$this->assertStringContainsString( "apply_filters( 'acrossai_allowed_protected_meta', array() )", $src );
+		$this->assertStringContainsString( 'is_protected_meta(', $src );
+		$this->assertStringContainsString( "str_starts_with( \$key_str, '_' )", $src );
+		$this->assertMatchesRegularExpression(
+			"/in_array\(\s*\\\$key_str,\s*\\\$allowed,\s*true\s*\)/",
+			$src
+		);
+	}
+
+	// =========================================================================
+	// FR-014, FR-015, FR-016 — Read_File guards
+	// =========================================================================
+
+	/**
+	 * FR-014: read-file refuses wp-config.php and .htaccess at ABSPATH root
+	 * with blocked_reason:protected_read.
+	 *
+	 * @return void
+	 */
+	public function test_fr014_read_file_refuses_protected_read_targets(): void {
+		$src = $this->sources['read_file'];
+		$this->assertStringContainsString( 'private const PROTECTED_FILES', $src );
+		$this->assertStringContainsString( "'wp-config.php'", $src );
+		$this->assertStringContainsString( "'.htaccess'", $src );
+		$this->assertStringContainsString( "'blocked_reason' => 'protected_read'", $src );
+		$this->assertMatchesRegularExpression(
+			"/in_array\(\s*basename\(\s*\\\$real_for_check\s*\),\s*self::PROTECTED_FILES,\s*true\s*\)/",
+			$src
+		);
+	}
+
+	/**
+	 * FR-015: read-file refuses when filesize exceeds MAX_READ_BYTES,
+	 * before loading the file into memory.
+	 *
+	 * @return void
+	 */
+	public function test_fr015_read_file_caps_size_before_reading(): void {
+		$src = $this->sources['read_file'];
+		$this->assertStringContainsString( 'private const MAX_READ_BYTES', $src );
+		$this->assertStringContainsString( '5242880', $src );
+		$this->assertStringContainsString( "'blocked_reason' => 'file_too_large'", $src );
+		// The filesize check must precede the file_get_contents call.
+		$pos_check   = strpos( $src, 'MAX_READ_BYTES' );
+		$pos_read    = strpos( $src, 'file_get_contents(' );
+		$this->assertNotFalse( $pos_check );
+		$this->assertNotFalse( $pos_read );
+		$this->assertLessThan(
+			$pos_read,
+			$pos_check,
+			'Size cap must be checked before file_get_contents runs.'
+		);
+	}
+
+	/**
+	 * FR-016: read-file returns a distinct binary shape without raw bytes
+	 * when mb_check_encoding UTF-8 fails.
+	 *
+	 * @return void
+	 */
+	public function test_fr016_read_file_detects_binary_content(): void {
+		$src = $this->sources['read_file'];
+		$this->assertStringContainsString( "mb_check_encoding( \$content, 'UTF-8' )", $src );
+		$this->assertStringContainsString( "'binary'  => true", $src );
+		$this->assertStringContainsString( "'message' => __( 'Binary file", $src );
+	}
+
+	// =========================================================================
+	// FR-017, FR-018, FR-019, FR-020 — Delete_File guards + backup + opcache
+	// =========================================================================
+
+	/**
+	 * FR-017: delete-file requires confirm:true and refuses with
+	 * confirmation_required otherwise.
+	 *
+	 * @return void
+	 */
+	public function test_fr017_delete_file_requires_confirm(): void {
+		$src = $this->sources['delete_file'];
+		$this->assertMatchesRegularExpression(
+			"/'required'\s*=>\s*array\(\s*'path',\s*'confirm'\s*\)/",
+			$src
+		);
+		$this->assertStringContainsString( "'blocked_reason' => 'confirmation_required'", $src );
+	}
+
+	/**
+	 * FR-018: delete-file refuses the protected files with
+	 * blocked_reason:protected_write.
+	 *
+	 * @return void
+	 */
+	public function test_fr018_delete_file_refuses_protected_write_targets(): void {
+		$src = $this->sources['delete_file'];
+		$this->assertStringContainsString( 'private const PROTECTED_FILES', $src );
+		$this->assertStringContainsString( "'wp-config.php'", $src );
+		$this->assertStringContainsString( "'.htaccess'", $src );
+		$this->assertStringContainsString( "'blocked_reason' => 'protected_write'", $src );
+		$this->assertMatchesRegularExpression(
+			"/in_array\(\s*basename\(\s*\\\$real\s*\),\s*self::PROTECTED_FILES,\s*true\s*\)/",
+			$src
+		);
+	}
+
+	/**
+	 * FR-019: delete-file writes a .bak.<timestamp> copy before deleting
+	 * and returns the backup path in the response.
+	 *
+	 * @return void
+	 */
+	public function test_fr019_delete_file_writes_timestamped_backup(): void {
+		$src = $this->sources['delete_file'];
+		$this->assertStringContainsString( "\$real . '.bak.' . time()", $src );
+		$this->assertStringContainsString( 'copy( $real, $backup )', $src );
+		$this->assertStringContainsString( "'backup'  => \$backup,", $src );
+	}
+
+	/**
+	 * FR-020: delete-file invalidates OPcache when the extension is loaded,
+	 * guarded by function_exists.
+	 *
+	 * @return void
+	 */
+	public function test_fr020_delete_file_invalidates_opcache_when_available(): void {
+		$src = $this->sources['delete_file'];
+		$this->assertMatchesRegularExpression(
+			"/function_exists\(\s*'opcache_invalidate'\s*\)/",
+			$src
+		);
+		$this->assertStringContainsString( 'opcache_invalidate( $real, true )', $src );
+	}
+
+	// =========================================================================
+	// FR-021 — Delete_Post suggested_redirect
+	// =========================================================================
+
+	/**
+	 * FR-021: delete-post includes suggested_redirect{from,to} only when the
+	 * deleted post was publish and force:true was passed.
+	 *
+	 * @return void
+	 */
+	public function test_fr021_delete_post_suggests_redirect_on_published_force_delete(): void {
+		$src = $this->sources['delete_post'];
+		$this->assertStringContainsString( "\$was_publish = ( 'publish' === (string) \$post->post_status )", $src );
+		$this->assertStringContainsString( '$permalink   = (string) get_permalink( $post )', $src );
+		$this->assertStringContainsString( 'if ( $force && $was_publish )', $src );
+		$this->assertStringContainsString( 'get_post_type_archive_link(', $src );
+		$this->assertStringContainsString( "home_url( '/' )", $src );
+		$this->assertStringContainsString( "'suggested_redirect'", $src );
+		$this->assertMatchesRegularExpression(
+			"/'from'\s*=>\s*\\\$permalink,\s*\n?\s*'to'\s*=>\s*\\\$target/",
+			$src
+		);
+	}
+
+	// =========================================================================
+	// FR-022 — Refusal envelope contract
+	// =========================================================================
+
+	/**
+	 * FR-022: every refusal path returns success:false + blocked_reason +
+	 * message and never mutates state before returning. Verified structurally
+	 * by asserting each blocked_reason literal appears alongside 'success' =>
+	 * false in the same source file.
+	 *
+	 * @return void
+	 */
+	public function test_fr022_refusal_shape_is_uniform(): void {
+		$expectations = array(
+			'deactivate_plugin' => array( 'protected_plugin' ),
+			'delete_media'      => array( 'confirmation_required' ),
+			'update_post'       => array( 'non_writable_post_type', 'publish_cap_required', 'edit_others_posts_required' ),
+			'read_file'         => array( 'protected_read', 'file_too_large' ),
+			'delete_file'       => array( 'confirmation_required', 'protected_write' ),
+		);
+		foreach ( $expectations as $key => $reasons ) {
+			$src = $this->sources[ $key ];
+			$this->assertStringContainsString( "'success'        => false", $src, "{$key} must return success=>false on refusal." );
+			foreach ( $reasons as $reason ) {
+				$this->assertStringContainsString(
+					"'{$reason}'",
+					$src,
+					"{$key} must include blocked_reason '{$reason}'."
+				);
+			}
+		}
+	}
+
+	// =========================================================================
+	// FR-023 — Permission callback unchanged
+	// =========================================================================
+
+	/**
+	 * FR-023: every modified ability continues to gate on
+	 * current_user_can('manage_options') via the identical permission
+	 * callback closure.
+	 *
+	 * @return void
+	 */
+	public function test_fr023_permission_callback_unchanged_on_every_ability(): void {
+		$literal = "'permission_callback' => static function (): bool {\n\t\t\t\t\treturn current_user_can( 'manage_options' );\n\t\t\t\t},";
+		foreach ( $this->sources as $key => $src ) {
+			$this->assertStringContainsString(
+				$literal,
+				$src,
+				"{$key} permission_callback must remain the literal manage_options closure."
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Modifies **9 existing ability classes** to add safety guardrails, protect the AcrossAI plugin family from accidental self-deactivation, and enrich a few payloads that clients previously had to hydrate with follow-up calls.

**No new abilities, no new categories, no bootstrap changes, no version bump.**

## Scope

**Safety envelope:**
- **`acrossai/deactivate-plugin`** — hardcoded protected-plugin list: `acrossai-mcp-manager`, `acrossai-abilities-manager` (this plugin), `acrossai-pro`. Refuses with `blocked_reason: 'protected_plugin'` before invoking `deactivate_plugins()`. Guards against every input form the fuzzy resolver accepts (slug/file/partial).
- **`acrossai/delete-media`** — requires `confirm: true` (**BREAKING** — required input). Honours `MEDIA_TRASH`; `deleted` field is now `"deleted"` or `"trashed"` (string, was boolean).
- **`acrossai/delete-file`** — requires `confirm: true` (**BREAKING**). Refuses on `wp-config.php` / `.htaccess`. Writes a `.bak.<timestamp>` backup before deleting. Calls `opcache_invalidate()` on success (guarded).
- **`acrossai/read-file`** — refuses on `wp-config.php` / `.htaccess` (`blocked_reason: 'protected_read'`). Refuses files larger than 5 MB (`blocked_reason: 'file_too_large'` + reports `size` and `max_bytes`). Detects binary content via `mb_check_encoding` — returns `{ binary: true, size, path, message }` without raw content.
- **`acrossai/update-post`** — writable-post-type gate (refuses `nav_menu_item`, `revision`, etc.), protected-meta filter (`_`-prefix keys stripped unless allow-listed via new `acrossai_allowed_protected_meta` filter), `publish_posts` cap check when status changes to a public status, `edit_others_posts` cap check when changing author. Response includes `dropped_meta_keys`.

**Payload enrichment:**
- **`acrossai/get-post`** — response now includes `terms` (grouped by taxonomy), `meta` (non-protected only), `featured_image` (`{id, url, alt}` or `null`), `permalink`, `edit_link`, and `author` (`{id, name}`). The raw `post` field remains for backward compatibility.
- **`acrossai/update-media`** — response now includes `updated: array<string>` naming which fields the ability actually wrote.
- **`acrossai/list-media`** — search now matches `_wp_attachment_image_alt` postmeta in addition to title/caption/description (via de-duplicated id-lookup union).
- **`acrossai/delete-post`** — response includes `suggested_redirect: {from, to}` when force-deleting a published post (heuristic target: parent → archive → home).

## Design docs

- Spec: `specs/065-safety-and-payload-improvements/spec.md` (23 FRs, 9 user stories, 10 measurable success criteria)
- Plan: `specs/065-safety-and-payload-improvements/plan.md`
- Tasks: `specs/065-safety-and-payload-improvements/tasks.md`
- Contracts: `specs/065-safety-and-payload-improvements/contracts/abilities.md`

## Breaking changes (intentional)

Both `acrossai-abilities-manager`-family plugins gate on `manage_options`, so blast radius is bounded to admin-level scripts, but callers should update to pass:

- `acrossai/delete-media` — now requires `confirm: true`.
- `acrossai/delete-file` — now requires `confirm: true`.
- `acrossai/read-file` — returns `binary: true` (no `content`) on non-UTF-8 files; refuses on files > 5 MB.
- `acrossai/update-post` — `_`-prefixed / protected meta keys are dropped from `meta` input; use the `acrossai_allowed_protected_meta` filter to allow-list specific keys.

## Deferred to a follow-up spec

- **`acrossai/edit-file` rename.** The current op is a full-file overwrite; the slug `edit-file` implies anchored replacement. Bundling this with a safety patch risks confusing two changes. Will open a separate issue with rename options (`edit-file` → `overwrite-file` + a new anchored `edit-file`).

## Test plan

- [x] `composer run test` — 518 tests / 1330 assertions / 0 failures on the local run (23 new test methods added).
- [x] `composer run phpcs` — 0 errors, 0 warnings.
- [x] `composer run phpstan` level 8 — 0 errors.
- [ ] CI 8-check matrix on this PR.
- [ ] Manual smoke: attempt to deactivate each of the 3 protected plugins via the ability — should refuse.
- [ ] Manual smoke: `read-file` against `wp-config.php` — should refuse.
- [ ] Manual smoke: `delete-media` without `confirm` — should refuse; with `confirm: true` on a site with `MEDIA_TRASH` — should trash rather than hard-delete.

## Notes

- No version bump in this PR (per instruction) — release cut is a separate operation.
- No CLAUDE.md changes.
- Purely additive edits to 9 existing files + 1 new test file + 1 new `<testsuite name="feature-065-unit">` in `phpunit.xml.dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)