### PR TITLE
feat(066): block tree mutation & nested editing

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/064-transients-nested-options-and-integrity"
+  "feature_directory": "specs/066-block-tree-mutation-and-nested-editing"
 }

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.23
+Stable tag: 0.0.24
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -136,6 +136,21 @@ Several admin-only actions can cause external services to receive data — all a
 No data is sent to any external server without an explicit administrator action.
 
 == Changelog ==
+
+= 0.0.24 =
+* **New — 6 abilities and 1 enhancement for full Gutenberg block-tree control (feature 066).** Closes the gap between the plugin's existing block-registry surface and per-post block-tree manipulation. All abilities live under the existing `acrossai-abilities-manager-content` category.
+
+**Feature 066 — Block tree mutation & nested editing (6 new abilities + 1 modified).**
+  * `acrossai/get-post-blocks` — return a post's parsed Gutenberg block tree with each block annotated with its canonical integer-array path (e.g. `[0, 2, 1]` = 2nd grandchild of the 3rd child of the 1st top-level block). Read-only, idempotent.
+  * `acrossai/add-block` — insert a new block into a post at `parent_path` + `index`. Appends when the requested index exceeds the current sibling count.
+  * `acrossai/remove-block` — remove the block at a canonical path; returns the removed payload so callers can undo/log.
+  * `acrossai/duplicate-block` — deep-clone the block at a path (including all inner blocks) and insert the clone as the next sibling.
+  * `acrossai/move-block` — atomically move a block from `from_path` to `to_parent_path` + `to_index`. Refuses moves into the source's own subtree (would create a cycle).
+  * `acrossai/insert-pattern` — resolve a saved block pattern by slug across database / active theme / installed plugins, then insert its constituent blocks at `parent_path` + `index`. Ambiguous slugs return `multiple_locations` so callers can disambiguate via `source` / `theme_type` / `plugin_slug`.
+  * `acrossai/update-post-block` (modified) — now accepts an optional `path` input for nested editing at any depth. Existing consumers using `block_index` or `block_name` + `occurrence` see **zero behaviour change** — the path branch is a strict addition.
+  * All write abilities share the same guards as the existing `update-post-block`: `manage_options` + `edit_posts` globally, `edit_post` per-post, post-type whitelist against internal CPTs (revision / nav_menu_item / custom_css / customize_changeset / oembed_cache / user_request), block-name regex validation, and soft-fail attribute-schema validation against the registered block type.
+  * Shared `Block_Tree` utility (`includes/Abilities/Utilities/Block_Tree.php`) centralises tree-path primitives — walk, get-at-path, insert / remove / replace / move, block-name and attribute-schema validation. Extracts what was previously private inline logic in `Update_Post_Block::execute`.
+  * Test coverage: 82 new PHPUnit assertions across 8 test files.
 
 = 0.0.23 =
 * **New — 30 abilities across three feature spec drops (062, 063, 064).** Bulk expansion of the plugin's ability surface. No breaking changes.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.23
+ * Version:           0.0.24
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -351,6 +351,13 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Menus\Get_Navigation_Context();
 		new Menus\List_Navigation_Locations();
 		new Content\Update_Post_Block();
+		// Feature 066 — Block tree mutation & nested editing.
+		new Content\Get_Post_Blocks();
+		new Content\Add_Block();
+		new Content\Remove_Block();
+		new Content\Duplicate_Block();
+		new Content\Move_Block();
+		new Content\Insert_Pattern();
 		new Content\Inspect_Post_Autosaves();
 		new Block\Get_Site_Editor_Context();
 		new Block\Refresh_Site_Editor_Context();

--- a/includes/Abilities/Content/Add_Block.php
+++ b/includes/Abilities/Content/Add_Block.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Feature 066 — insert a new block into a post at a canonical path.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Content
+ * @since      0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Block_Tree;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Insert a block into a post's tree at parent_path + index. Appends when the
+ * requested index is at or past the current sibling count.
+ */
+class Add_Block extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/add-block',
+			'args' => array(
+				'label'               => __( 'Add Block', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Insert a new Gutenberg block into a post at the given parent_path and sibling index. If index >= current sibling count, the block is appended.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'     => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'parent_path' => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'    => 'integer',
+								'minimum' => 0,
+							),
+						),
+						'index'       => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'block'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'name'        => array( 'type' => 'string' ),
+								'attrs'       => array( 'type' => 'object' ),
+								'innerHTML'   => array( 'type' => 'string' ),
+								'innerBlocks' => array( 'type' => 'array' ),
+							),
+							'required'   => array( 'name' ),
+						),
+					),
+					'required'             => array( 'post_id', 'parent_path', 'index', 'block' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'post_id' => array( 'type' => 'integer' ),
+						'block'   => array( 'type' => 'object' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'posts',
+						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id      = absint( $input['post_id'] ?? 0 );
+		$parent_path  = self::sanitize_path( $input['parent_path'] ?? array() );
+		$index        = (int) ( $input['index'] ?? 0 );
+		$block_input  = is_array( $input['block'] ?? null ) ? $input['block'] : array();
+		$block_name   = isset( $block_input['name'] ) ? (string) $block_input['name'] : '';
+
+		if ( ! Block_Tree::validate_block_name( $block_name ) ) {
+			return self::fail( $post_id, 'invalid_block_name', __( 'A valid block name (e.g. "core/paragraph") is required.', 'acrossai-abilities-manager' ) );
+		}
+
+		$attrs = isset( $block_input['attrs'] ) && is_array( $block_input['attrs'] ) ? $block_input['attrs'] : array();
+		$attr_check = Block_Tree::validate_attributes_against_schema( $block_name, $attrs );
+		if ( is_wp_error( $attr_check ) ) {
+			return self::fail( $post_id, (string) $attr_check->get_error_code(), (string) $attr_check->get_error_message() );
+		}
+
+		$blocks = Block_Tree::parse_post_blocks( $post_id, 'edit' );
+		if ( is_wp_error( $blocks ) ) {
+			return self::fail( $post_id, (string) $blocks->get_error_code(), (string) $blocks->get_error_message() );
+		}
+
+		$new_block = array(
+			'blockName'   => $block_name,
+			'attrs'       => $attrs,
+			'innerHTML'   => isset( $block_input['innerHTML'] ) ? (string) $block_input['innerHTML'] : '',
+			'innerBlocks' => isset( $block_input['innerBlocks'] ) && is_array( $block_input['innerBlocks'] ) ? $block_input['innerBlocks'] : array(),
+		);
+
+		if ( ! Block_Tree::insert_at_path( $blocks, $parent_path, $index, $new_block ) ) {
+			return self::fail( $post_id, 'invalid_path', __( 'Parent path does not resolve.', 'acrossai-abilities-manager' ) );
+		}
+
+		$saved = self::persist( $post_id, $blocks );
+		if ( is_wp_error( $saved ) ) {
+			return self::fail( $post_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		// Compute the new block's actual path after insertion (index may have
+		// been clamped to the append position).
+		$parent_children_count = self::children_count_at( $blocks, $parent_path );
+		$actual_index          = min( $index, max( 0, $parent_children_count - 1 ) );
+		$new_path              = array_merge( $parent_path, array( $actual_index ) );
+		$inserted              = Block_Tree::get_at_path( $blocks, $new_path );
+		if ( is_array( $inserted ) ) {
+			$inserted['path'] = $new_path;
+		}
+
+		return array(
+			'success' => true,
+			'post_id' => $post_id,
+			'block'   => $inserted,
+			/* translators: 1: block name, 2: post ID */
+			'message' => sprintf( __( 'Inserted %1$s into post #%2$d.', 'acrossai-abilities-manager' ), $block_name, $post_id ),
+		);
+	}
+
+	/**
+	 * Coerce the parent_path input to an int[].
+	 *
+	 * @param mixed $raw
+	 * @return int[]
+	 */
+	private static function sanitize_path( $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+		$out = array();
+		foreach ( $raw as $item ) {
+			if ( is_int( $item ) && $item >= 0 ) {
+				$out[] = $item;
+			} elseif ( is_string( $item ) && ctype_digit( $item ) ) {
+				$out[] = (int) $item;
+			} else {
+				return array();
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Save the mutated tree via wp_update_post().
+	 *
+	 * @param int                              $post_id
+	 * @param array<int, array<string, mixed>> $blocks
+	 * @return int|\WP_Error
+	 */
+	private static function persist( int $post_id, array $blocks ) {
+		return wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => serialize_blocks( $blocks ),
+			),
+			true
+		);
+	}
+
+	/**
+	 * Count children under the block at $parent_path (root when empty).
+	 *
+	 * @param array<int, array<string, mixed>> $blocks
+	 * @param int[]                            $parent_path
+	 * @return int
+	 */
+	private static function children_count_at( array $blocks, array $parent_path ): int {
+		if ( array() === $parent_path ) {
+			return count( $blocks );
+		}
+		$parent = Block_Tree::get_at_path( $blocks, $parent_path );
+		if ( ! is_array( $parent ) || ! isset( $parent['innerBlocks'] ) || ! is_array( $parent['innerBlocks'] ) ) {
+			return 0;
+		}
+		return count( $parent['innerBlocks'] );
+	}
+
+	/**
+	 * Build a failure envelope.
+	 *
+	 * @param int    $post_id
+	 * @param string $code
+	 * @param string $message
+	 * @return array<string, mixed>
+	 */
+	private static function fail( int $post_id, string $code, string $message ): array {
+		return array(
+			'success'    => false,
+			'post_id'    => $post_id,
+			'message'    => $message,
+			'error_code' => $code,
+		);
+	}
+}

--- a/includes/Abilities/Content/Duplicate_Block.php
+++ b/includes/Abilities/Content/Duplicate_Block.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Feature 066 — deep-clone a block at a canonical path.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Content
+ * @since      0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Block_Tree;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Deep-clone the block at the given path (PHP arrays copy by value, so the
+ * clone is fully independent) and insert it as the next sibling.
+ */
+class Duplicate_Block extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/duplicate-block',
+			'args' => array(
+				'label'               => __( 'Duplicate Block', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Create a deep clone of the Gutenberg block at the given path and insert it as the next sibling.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'path'    => array(
+							'type'     => 'array',
+							'minItems' => 1,
+							'items'    => array(
+								'type'    => 'integer',
+								'minimum' => 0,
+							),
+						),
+					),
+					'required'             => array( 'post_id', 'path' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'post_id' => array( 'type' => 'integer' ),
+						'block'   => array( 'type' => 'object' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'posts',
+						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id = absint( $input['post_id'] ?? 0 );
+		$path    = self::sanitize_path( $input['path'] ?? array() );
+		if ( array() === $path ) {
+			return self::fail( $post_id, 'invalid_path', __( 'A non-empty path is required.', 'acrossai-abilities-manager' ) );
+		}
+
+		$blocks = Block_Tree::parse_post_blocks( $post_id, 'edit' );
+		if ( is_wp_error( $blocks ) ) {
+			return self::fail( $post_id, (string) $blocks->get_error_code(), (string) $blocks->get_error_message() );
+		}
+
+		$source = Block_Tree::get_at_path( $blocks, $path );
+		if ( null === $source ) {
+			return self::fail( $post_id, 'invalid_path', __( 'Path does not resolve.', 'acrossai-abilities-manager' ) );
+		}
+
+		// PHP arrays are value types — this assignment produces a deep copy.
+		$clone = $source;
+		unset( $clone['path'] );
+
+		$parent_path  = $path;
+		$source_index = (int) array_pop( $parent_path );
+		$insert_index = $source_index + 1;
+
+		if ( ! Block_Tree::insert_at_path( $blocks, $parent_path, $insert_index, $clone ) ) {
+			return self::fail( $post_id, 'invalid_path', __( 'Failed to insert clone.', 'acrossai-abilities-manager' ) );
+		}
+
+		$saved = wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => serialize_blocks( $blocks ),
+			),
+			true
+		);
+		if ( is_wp_error( $saved ) ) {
+			return self::fail( $post_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		$new_path      = array_merge( $parent_path, array( $insert_index ) );
+		$cloned_block  = Block_Tree::get_at_path( $blocks, $new_path );
+		if ( is_array( $cloned_block ) ) {
+			$cloned_block['path'] = $new_path;
+		}
+
+		return array(
+			'success' => true,
+			'post_id' => $post_id,
+			'block'   => $cloned_block,
+			/* translators: %d: post ID */
+			'message' => sprintf( __( 'Duplicated block on post #%d.', 'acrossai-abilities-manager' ), $post_id ),
+		);
+	}
+
+	/**
+	 * Coerce a raw path input to int[].
+	 *
+	 * @param mixed $raw
+	 * @return int[]
+	 */
+	private static function sanitize_path( $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+		$out = array();
+		foreach ( $raw as $item ) {
+			if ( is_int( $item ) && $item >= 0 ) {
+				$out[] = $item;
+			} elseif ( is_string( $item ) && ctype_digit( $item ) ) {
+				$out[] = (int) $item;
+			} else {
+				return array();
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Build a failure envelope.
+	 *
+	 * @param int    $post_id
+	 * @param string $code
+	 * @param string $message
+	 * @return array<string, mixed>
+	 */
+	private static function fail( int $post_id, string $code, string $message ): array {
+		return array(
+			'success'    => false,
+			'post_id'    => $post_id,
+			'message'    => $message,
+			'error_code' => $code,
+		);
+	}
+}

--- a/includes/Abilities/Content/Get_Post_Blocks.php
+++ b/includes/Abilities/Content/Get_Post_Blocks.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Feature 066 — return a post's parsed block tree with canonical paths.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Content
+ * @since      0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Block_Tree;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Read a post's block tree via parse_blocks() and annotate every node with a
+ * canonical integer-array `path`. Read-only, idempotent, does not touch the
+ * database beyond a single get_post() lookup.
+ */
+class Get_Post_Blocks extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/get-post-blocks',
+			'args' => array(
+				'label'               => __( 'Get Post Blocks', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return the parsed Gutenberg block tree of a post with each block annotated with its canonical integer-array path (e.g. [0, 2, 1] = 2nd grandchild of the 3rd child of the 1st top-level block).', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+					),
+					'required'             => array( 'post_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'post_id' => array( 'type' => 'integer' ),
+						'blocks'  => array( 'type' => 'array' ),
+						'total'   => array( 'type' => 'integer' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'posts',
+						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id = absint( $input['post_id'] ?? 0 );
+		$blocks  = Block_Tree::parse_post_blocks( $post_id, 'read' );
+		if ( is_wp_error( $blocks ) ) {
+			return array(
+				'success'    => false,
+				'post_id'    => $post_id,
+				'message'    => $blocks->get_error_message(),
+				'error_code' => $blocks->get_error_code(),
+			);
+		}
+
+		$annotated = Block_Tree::annotate_with_paths( $blocks );
+		$total     = 0;
+		Block_Tree::walk_tree(
+			$blocks,
+			static function () use ( &$total ): void {
+				++$total;
+			}
+		);
+
+		return array(
+			'success' => true,
+			'post_id' => $post_id,
+			'blocks'  => $annotated,
+			'total'   => $total,
+			/* translators: 1: total block count, 2: post ID */
+			'message' => sprintf( __( 'Returned %1$d blocks for post #%2$d.', 'acrossai-abilities-manager' ), $total, $post_id ),
+		);
+	}
+}

--- a/includes/Abilities/Content/Insert_Pattern.php
+++ b/includes/Abilities/Content/Insert_Pattern.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Feature 066 — expand a saved block pattern at a canonical path.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Content
+ * @since      0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Block_Tree;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Pattern\Pattern_Detector;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Pattern\Pattern_Helper;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve a block pattern by slug (across db / theme / plugin), parse its
+ * content, and insert its constituent blocks at the given parent_path +
+ * index. Delegates resolution to the shared Pattern_Detector — no source
+ * scanning is duplicated here.
+ */
+class Insert_Pattern extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/insert-pattern',
+			'args' => array(
+				'label'               => __( 'Insert Pattern', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Resolve a block pattern by slug (across database, active theme, and installed plugins) and insert its constituent blocks at the given parent_path and sibling index. Refuses ambiguous slugs unless a "source" (and optionally "theme_type" or "plugin_slug") is provided.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'     => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'parent_path' => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'    => 'integer',
+								'minimum' => 0,
+							),
+						),
+						'index'       => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+						'slug'        => array(
+							'type'      => 'string',
+							'minLength' => 1,
+						),
+						'source'      => array(
+							'type' => 'string',
+							'enum' => array( 'db', 'theme', 'plugin' ),
+						),
+						'theme_type'  => array(
+							'type' => 'string',
+							'enum' => array( 'parent', 'child' ),
+						),
+						'plugin_slug' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'post_id', 'parent_path', 'index', 'slug' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'post_id'        => array( 'type' => 'integer' ),
+						'inserted_paths' => array( 'type' => 'array' ),
+						'count'          => array( 'type' => 'integer' ),
+						'message'        => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'posts',
+						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id     = absint( $input['post_id'] ?? 0 );
+		$parent_path = self::sanitize_path( $input['parent_path'] ?? array() );
+		$index       = (int) ( $input['index'] ?? 0 );
+		$slug        = sanitize_title( (string) ( $input['slug'] ?? '' ) );
+		$source      = isset( $input['source'] ) ? (string) $input['source'] : '';
+		$theme_type  = isset( $input['theme_type'] ) ? (string) $input['theme_type'] : '';
+		$plugin_slug = isset( $input['plugin_slug'] ) ? (string) $input['plugin_slug'] : '';
+
+		if ( '' === $slug ) {
+			return self::fail( $post_id, 'invalid_slug', __( 'A non-empty pattern slug is required.', 'acrossai-abilities-manager' ) );
+		}
+
+		$locations = Pattern_Detector::locate( $slug );
+		$selected  = Pattern_Detector::select( $locations, $source, $theme_type, $plugin_slug );
+		if ( is_wp_error( $selected ) ) {
+			return self::fail( $post_id, (string) $selected->get_error_code(), (string) $selected->get_error_message() );
+		}
+
+		$pattern_content = self::load_pattern_content( $selected );
+		if ( '' === $pattern_content ) {
+			return self::fail( $post_id, 'pattern_empty', __( 'The resolved pattern has no content to insert.', 'acrossai-abilities-manager' ) );
+		}
+
+		$pattern_blocks = parse_blocks( $pattern_content );
+		if ( ! is_array( $pattern_blocks ) || array() === $pattern_blocks ) {
+			return self::fail( $post_id, 'pattern_empty', __( 'The resolved pattern contains no parseable blocks.', 'acrossai-abilities-manager' ) );
+		}
+
+		$blocks = Block_Tree::parse_post_blocks( $post_id, 'edit' );
+		if ( is_wp_error( $blocks ) ) {
+			return self::fail( $post_id, (string) $blocks->get_error_code(), (string) $blocks->get_error_message() );
+		}
+
+		$inserted_paths = array();
+		$cursor         = $index;
+		foreach ( $pattern_blocks as $pattern_block ) {
+			if ( ! is_array( $pattern_block ) ) {
+				continue;
+			}
+			if ( ! Block_Tree::insert_at_path( $blocks, $parent_path, $cursor, $pattern_block ) ) {
+				return self::fail( $post_id, 'invalid_path', __( 'Parent path does not resolve.', 'acrossai-abilities-manager' ) );
+			}
+			$inserted_paths[] = array_merge( $parent_path, array( $cursor ) );
+			++$cursor;
+		}
+
+		$saved = wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => serialize_blocks( $blocks ),
+			),
+			true
+		);
+		if ( is_wp_error( $saved ) ) {
+			return self::fail( $post_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		return array(
+			'success'        => true,
+			'post_id'        => $post_id,
+			'inserted_paths' => $inserted_paths,
+			'count'          => count( $inserted_paths ),
+			/* translators: 1: count, 2: slug, 3: post ID */
+			'message'        => sprintf( __( 'Inserted %1$d blocks from pattern "%2$s" into post #%3$d.', 'acrossai-abilities-manager' ), count( $inserted_paths ), $slug, $post_id ),
+		);
+	}
+
+	/**
+	 * Load raw block-markup content from a Pattern_Detector location.
+	 *
+	 * @param array<string, mixed> $location
+	 * @return string
+	 */
+	private static function load_pattern_content( array $location ): string {
+		$source = (string) ( $location['source'] ?? '' );
+		if ( 'db' === $source ) {
+			$post_id = (int) ( $location['post_id'] ?? 0 );
+			$post    = $post_id > 0 ? get_post( $post_id ) : null;
+			return $post instanceof \WP_Post ? (string) $post->post_content : '';
+		}
+
+		$path = (string) ( $location['path'] ?? '' );
+		if ( '' === $path || ! is_file( $path ) ) {
+			return '';
+		}
+		$contents = (string) @file_get_contents( $path );
+		if ( '' === $contents ) {
+			return '';
+		}
+		$parsed = Pattern_Helper::parse_file( $contents );
+		return isset( $parsed['body'] ) ? (string) $parsed['body'] : '';
+	}
+
+	/**
+	 * Coerce a raw path input to int[].
+	 *
+	 * @param mixed $raw
+	 * @return int[]
+	 */
+	private static function sanitize_path( $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+		$out = array();
+		foreach ( $raw as $item ) {
+			if ( is_int( $item ) && $item >= 0 ) {
+				$out[] = $item;
+			} elseif ( is_string( $item ) && ctype_digit( $item ) ) {
+				$out[] = (int) $item;
+			} else {
+				return array();
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Build a failure envelope.
+	 *
+	 * @param int    $post_id
+	 * @param string $code
+	 * @param string $message
+	 * @return array<string, mixed>
+	 */
+	private static function fail( int $post_id, string $code, string $message ): array {
+		return array(
+			'success'    => false,
+			'post_id'    => $post_id,
+			'message'    => $message,
+			'error_code' => $code,
+		);
+	}
+}

--- a/includes/Abilities/Content/Move_Block.php
+++ b/includes/Abilities/Content/Move_Block.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Feature 066 — atomically move a block within a post.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Content
+ * @since      0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Block_Tree;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Move a block from a source path to a destination (to_parent_path + index).
+ * Refuses to move a block into its own subtree.
+ */
+class Move_Block extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/move-block',
+			'args' => array(
+				'label'               => __( 'Move Block', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Atomically move a Gutenberg block from a source path to a destination (to_parent_path + to_index). Refuses to move a block into its own subtree.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'        => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'from_path'      => array(
+							'type'     => 'array',
+							'minItems' => 1,
+							'items'    => array(
+								'type'    => 'integer',
+								'minimum' => 0,
+							),
+						),
+						'to_parent_path' => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'    => 'integer',
+								'minimum' => 0,
+							),
+						),
+						'to_index'       => array(
+							'type'    => 'integer',
+							'minimum' => 0,
+						),
+					),
+					'required'             => array( 'post_id', 'from_path', 'to_parent_path', 'to_index' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'post_id'       => array( 'type' => 'integer' ),
+						'block'         => array( 'type' => 'object' ),
+						'previous_path' => array( 'type' => 'array' ),
+						'message'       => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'posts',
+						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id   = absint( $input['post_id'] ?? 0 );
+		$from_path = self::sanitize_path( $input['from_path'] ?? array() );
+		$to_parent = self::sanitize_path( $input['to_parent_path'] ?? array(), true );
+		$to_index  = (int) ( $input['to_index'] ?? 0 );
+
+		if ( array() === $from_path ) {
+			return self::fail( $post_id, 'invalid_path', __( 'A non-empty from_path is required.', 'acrossai-abilities-manager' ) );
+		}
+
+		$blocks = Block_Tree::parse_post_blocks( $post_id, 'edit' );
+		if ( is_wp_error( $blocks ) ) {
+			return self::fail( $post_id, (string) $blocks->get_error_code(), (string) $blocks->get_error_message() );
+		}
+
+		$result = Block_Tree::move( $blocks, $from_path, $to_parent, $to_index );
+		if ( is_wp_error( $result ) ) {
+			return self::fail( $post_id, (string) $result->get_error_code(), (string) $result->get_error_message() );
+		}
+
+		$saved = wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => serialize_blocks( $blocks ),
+			),
+			true
+		);
+		if ( is_wp_error( $saved ) ) {
+			return self::fail( $post_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		// Compute the new path for the moved block. Move() adjusted to_index
+		// automatically for same-parent moves; the caller-facing "actual"
+		// position may match to_index or the appended position.
+		$children_count = self::children_count_at( $blocks, $to_parent );
+		$actual_index   = min( $to_index, max( 0, $children_count - 1 ) );
+		$new_path       = array_merge( $to_parent, array( $actual_index ) );
+		$moved_block    = Block_Tree::get_at_path( $blocks, $new_path );
+		if ( is_array( $moved_block ) ) {
+			$moved_block['path'] = $new_path;
+		}
+
+		return array(
+			'success'       => true,
+			'post_id'       => $post_id,
+			'block'         => $moved_block,
+			'previous_path' => $from_path,
+			/* translators: %d: post ID */
+			'message'       => sprintf( __( 'Moved block on post #%d.', 'acrossai-abilities-manager' ), $post_id ),
+		);
+	}
+
+	/**
+	 * Coerce a raw path input to int[]. When $allow_empty is true, an empty
+	 * array is a valid return value (root).
+	 *
+	 * @param mixed $raw
+	 * @param bool  $allow_empty
+	 * @return int[]
+	 */
+	private static function sanitize_path( $raw, bool $allow_empty = false ): array {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+		$out = array();
+		foreach ( $raw as $item ) {
+			if ( is_int( $item ) && $item >= 0 ) {
+				$out[] = $item;
+			} elseif ( is_string( $item ) && ctype_digit( $item ) ) {
+				$out[] = (int) $item;
+			} else {
+				return $allow_empty ? array() : array();
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Children count under $parent_path (root when empty).
+	 *
+	 * @param array<int, array<string, mixed>> $blocks
+	 * @param int[]                            $parent_path
+	 * @return int
+	 */
+	private static function children_count_at( array $blocks, array $parent_path ): int {
+		if ( array() === $parent_path ) {
+			return count( $blocks );
+		}
+		$parent = Block_Tree::get_at_path( $blocks, $parent_path );
+		if ( ! is_array( $parent ) || ! isset( $parent['innerBlocks'] ) || ! is_array( $parent['innerBlocks'] ) ) {
+			return 0;
+		}
+		return count( $parent['innerBlocks'] );
+	}
+
+	/**
+	 * Build a failure envelope.
+	 *
+	 * @param int    $post_id
+	 * @param string $code
+	 * @param string $message
+	 * @return array<string, mixed>
+	 */
+	private static function fail( int $post_id, string $code, string $message ): array {
+		return array(
+			'success'    => false,
+			'post_id'    => $post_id,
+			'message'    => $message,
+			'error_code' => $code,
+		);
+	}
+}

--- a/includes/Abilities/Content/Remove_Block.php
+++ b/includes/Abilities/Content/Remove_Block.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Feature 066 — remove the block at a canonical path from a post.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Content
+ * @since      0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Block_Tree;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Remove the block at a canonical path. Returns the removed block payload in
+ * the response so callers can undo/log.
+ */
+class Remove_Block extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/remove-block',
+			'args' => array(
+				'label'               => __( 'Remove Block', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Remove the Gutenberg block at the given canonical path from a post.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-content',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+						),
+						'path'    => array(
+							'type'     => 'array',
+							'minItems' => 1,
+							'items'    => array(
+								'type'    => 'integer',
+								'minimum' => 0,
+							),
+						),
+					),
+					'required'             => array( 'post_id', 'path' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success' => array( 'type' => 'boolean' ),
+						'post_id' => array( 'type' => 'integer' ),
+						'removed' => array( 'type' => 'object' ),
+						'message' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'posts',
+						'sub_group_label' => __( 'Posts', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array<string,mixed> $input Ability input payload.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$post_id = absint( $input['post_id'] ?? 0 );
+		$path    = self::sanitize_path( $input['path'] ?? array() );
+		if ( array() === $path ) {
+			return self::fail( $post_id, 'invalid_path', __( 'A non-empty path is required.', 'acrossai-abilities-manager' ) );
+		}
+
+		$blocks = Block_Tree::parse_post_blocks( $post_id, 'edit' );
+		if ( is_wp_error( $blocks ) ) {
+			return self::fail( $post_id, (string) $blocks->get_error_code(), (string) $blocks->get_error_message() );
+		}
+
+		$removed = Block_Tree::remove_at_path( $blocks, $path );
+		if ( null === $removed ) {
+			return self::fail( $post_id, 'invalid_path', __( 'Path does not resolve.', 'acrossai-abilities-manager' ) );
+		}
+
+		$saved = wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => serialize_blocks( $blocks ),
+			),
+			true
+		);
+		if ( is_wp_error( $saved ) ) {
+			return self::fail( $post_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		return array(
+			'success' => true,
+			'post_id' => $post_id,
+			'removed' => $removed,
+			/* translators: %d: post ID */
+			'message' => sprintf( __( 'Removed block from post #%d.', 'acrossai-abilities-manager' ), $post_id ),
+		);
+	}
+
+	/**
+	 * Coerce a raw path input to int[].
+	 *
+	 * @param mixed $raw
+	 * @return int[]
+	 */
+	private static function sanitize_path( $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+		$out = array();
+		foreach ( $raw as $item ) {
+			if ( is_int( $item ) && $item >= 0 ) {
+				$out[] = $item;
+			} elseif ( is_string( $item ) && ctype_digit( $item ) ) {
+				$out[] = (int) $item;
+			} else {
+				return array();
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Build a failure envelope.
+	 *
+	 * @param int    $post_id
+	 * @param string $code
+	 * @param string $message
+	 * @return array<string, mixed>
+	 */
+	private static function fail( int $post_id, string $code, string $message ): array {
+		return array(
+			'success'    => false,
+			'post_id'    => $post_id,
+			'message'    => $message,
+			'error_code' => $code,
+		);
+	}
+}

--- a/includes/Abilities/Content/Update_Post_Block.php
+++ b/includes/Abilities/Content/Update_Post_Block.php
@@ -10,18 +10,19 @@
 
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
 
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Block_Tree;
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Parse a post's block tree, find a single block by client-supplied id
- * (either the `data-block` attribute or a matching `blockName`+`index`
- * fallback), merge new `attributes`, replace `innerHTML`, and save the
- * post with the serialised block tree.
+ * Parse a post's block tree, find a single block, merge new `attributes`,
+ * replace `innerHTML`, and save the post with the serialised block tree.
  *
- * Bounded scope: matches only top-level (non-nested) blocks by index.
- * Nested block editing is deferred to a future spec.
+ * Feature 066: adds an optional `path` input (int[]) so callers can target
+ * blocks at any nesting depth. When `path` is absent the legacy addressing
+ * modes (block_index or block_name+occurrence) continue to work byte-
+ * identically to earlier releases.
  */
 class Update_Post_Block extends Ability_Definition {
 
@@ -35,7 +36,7 @@ class Update_Post_Block extends Ability_Definition {
 			'name' => 'acrossai/update-post-block',
 			'args' => array(
 				'label'               => __( 'Update Block', 'acrossai-abilities-manager' ),
-				'description'         => __( 'Parse a post\'s block tree, find one top-level block by 0-based index (block_index) or by (block_name, occurrence), merge the supplied attributes, replace innerHTML, and save the post. Only top-level blocks are matched; nested-block editing is not supported by this ability.', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Parse a post\'s block tree, find one block, merge the supplied attributes, replace innerHTML, and save the post. Targeting priority: (1) path — a canonical integer-array path targeting a block at any nesting depth; (2) block_index — 0-based top-level index; (3) block_name (+ optional occurrence).', 'acrossai-abilities-manager' ),
 				'category'            => 'acrossai-abilities-manager-content',
 				'execute_callback'    => array( $this, 'execute' ),
 				'permission_callback' => static function (): bool {
@@ -47,6 +48,13 @@ class Update_Post_Block extends Ability_Definition {
 						'post_id'     => array(
 							'type'    => 'integer',
 							'minimum' => 1,
+						),
+						'path'        => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'    => 'integer',
+								'minimum' => 0,
+							),
 						),
 						'block_index' => array(
 							'type'    => 'integer',
@@ -142,6 +150,56 @@ class Update_Post_Block extends Ability_Definition {
 			);
 		}
 
+		// Feature 066 — nested-path branch runs first. When `path` is present
+		// and non-empty, target the block at that path anywhere in the tree.
+		// When absent, fall through to the legacy top-level branches below,
+		// preserving byte-identical behaviour for existing consumers.
+		$path = self::sanitize_path_input( $input['path'] ?? null );
+		if ( array() !== $path ) {
+			$target = Block_Tree::get_at_path( $blocks, $path );
+			if ( ! is_array( $target ) ) {
+				return array(
+					'success' => false,
+					'message' => __( 'Path does not resolve to a block.', 'acrossai-abilities-manager' ),
+				);
+			}
+			if ( isset( $input['attributes'] ) && is_array( $input['attributes'] ) ) {
+				$target['attrs'] = array_merge( (array) ( $target['attrs'] ?? array() ), $input['attributes'] );
+			}
+			if ( isset( $input['inner_html'] ) ) {
+				$target['innerHTML']    = (string) $input['inner_html'];
+				$target['innerContent'] = array( (string) $input['inner_html'] );
+			}
+			if ( ! Block_Tree::replace_at_path( $blocks, $path, $target ) ) {
+				return array(
+					'success' => false,
+					'message' => __( 'Failed to update block at path.', 'acrossai-abilities-manager' ),
+				);
+			}
+			$new_content = serialize_blocks( $blocks );
+			$updated     = wp_update_post(
+				array(
+					'ID'           => $post_id,
+					'post_content' => $new_content,
+				),
+				true
+			);
+			if ( is_wp_error( $updated ) ) {
+				return array(
+					'success' => false,
+					'message' => $updated->get_error_message(),
+				);
+			}
+			$target['path'] = $path;
+			return array(
+				'success' => true,
+				'post_id' => $post_id,
+				'block'   => $target,
+				/* translators: 1: path string, 2: post ID */
+				'message' => sprintf( __( 'Updated block at path [%1$s] on post #%2$d.', 'acrossai-abilities-manager' ), implode( ',', $path ), $post_id ),
+			);
+		}
+
 		$target_index = null;
 		if ( isset( $input['block_index'] ) ) {
 			$target_index = (int) $input['block_index'];
@@ -212,5 +270,31 @@ class Update_Post_Block extends Ability_Definition {
 			/* translators: 1: index, 2: post ID */
 			'message' => sprintf( __( 'Updated block #%1$d on post #%2$d.', 'acrossai-abilities-manager' ), $target_index, $post_id ),
 		);
+	}
+
+	/**
+	 * Feature 066 — coerce a raw `path` input to int[] and return an empty
+	 * array (which means "path input absent, use legacy branches") for any
+	 * malformed or missing value. A valid non-empty path is one or more
+	 * non-negative integers.
+	 *
+	 * @param mixed $raw
+	 * @return int[]
+	 */
+	private static function sanitize_path_input( $raw ): array {
+		if ( ! is_array( $raw ) || array() === $raw ) {
+			return array();
+		}
+		$out = array();
+		foreach ( $raw as $item ) {
+			if ( is_int( $item ) && $item >= 0 ) {
+				$out[] = $item;
+			} elseif ( is_string( $item ) && ctype_digit( $item ) ) {
+				$out[] = (int) $item;
+			} else {
+				return array();
+			}
+		}
+		return $out;
 	}
 }

--- a/includes/Abilities/Utilities/Block_Tree.php
+++ b/includes/Abilities/Utilities/Block_Tree.php
@@ -1,0 +1,608 @@
+<?php
+/**
+ * Feature 066 — shared block-tree utility used by every content ability that
+ * reads or mutates a post's Gutenberg block tree.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Utilities
+ * @since      0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Utilities;
+
+use WP_Error;
+use WP_Post;
+use WP_Post_Type;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Pure tree-addressing primitives operating on the array shape returned by
+ * WordPress core parse_blocks(). Every method that mutates does so on a
+ * caller-provided reference; there is no persistence at this layer.
+ *
+ * Canonical path scheme: an ordered array of zero-based non-negative integers.
+ * [] denotes the root list. [i] the i-th top-level block. [i, j] the j-th
+ * child of that block. And so on recursively.
+ *
+ * IO-adjacent helpers (parse_post_blocks, assert_post_type_editable) exist so
+ * every ability that mutates a post can share one identical guard sequence.
+ */
+final class Block_Tree {
+
+	/**
+	 * Post types that internal WordPress subsystems reserve and where the
+	 * block-editor round-trip does not apply. Extracted from the legacy
+	 * inline whitelist in Update_Post_Block.
+	 *
+	 * @var string[]
+	 */
+	private const FORBIDDEN_POST_TYPES = array(
+		'revision',
+		'nav_menu_item',
+		'custom_css',
+		'customize_changeset',
+		'oembed_cache',
+		'user_request',
+	);
+
+	/**
+	 * Namespace/name pattern for a Gutenberg block. Both segments accept
+	 * alphanumerics, underscore, and hyphen. Extracted from Update_Post_Block.
+	 */
+	private const BLOCK_NAME_PATTERN = '/^[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+$/';
+
+	/**
+	 * Validate a Gutenberg block name.
+	 *
+	 * @param string $name Candidate block name (e.g. "core/paragraph").
+	 * @return bool
+	 */
+	public static function validate_block_name( string $name ): bool {
+		return '' !== $name && 1 === preg_match( self::BLOCK_NAME_PATTERN, $name );
+	}
+
+	/**
+	 * Verify a post can be edited via the block-tree abilities.
+	 *
+	 * Rejects internal CPTs and post types that do not participate in the
+	 * WordPress editor surface (no public exposure, no UI, no REST).
+	 *
+	 * @param int $post_id Post ID.
+	 * @return true|WP_Error True on success; WP_Error on any failure.
+	 */
+	public static function assert_post_type_editable( int $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return new WP_Error(
+				'post_not_found',
+				__( 'Post not found.', 'acrossai-abilities-manager' )
+			);
+		}
+		$post_type_obj = get_post_type_object( (string) $post->post_type );
+		if ( ! $post_type_obj instanceof WP_Post_Type
+			|| in_array( $post_type_obj->name, self::FORBIDDEN_POST_TYPES, true )
+			|| ! ( (bool) $post_type_obj->public || (bool) $post_type_obj->show_ui || (bool) $post_type_obj->show_in_rest ) ) {
+			return new WP_Error(
+				'post_type_forbidden',
+				__( 'This post type is not editable through this ability.', 'acrossai-abilities-manager' )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Parse a post's block tree with post-existence and capability guards.
+	 *
+	 * Callers that intend to mutate should pass 'edit' as $cap; reads pass
+	 * 'read'. The caller receives the raw parse_blocks() output; annotation
+	 * with paths is a separate step.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $cap     Either 'edit' or 'read'.
+	 * @return array<int, array<string, mixed>>|WP_Error Parsed blocks or error.
+	 */
+	public static function parse_post_blocks( int $post_id, string $cap = 'edit' ) {
+		if ( $post_id <= 0 ) {
+			return new WP_Error(
+				'invalid_post_id',
+				__( 'A valid post_id is required.', 'acrossai-abilities-manager' )
+			);
+		}
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return new WP_Error(
+				'post_not_found',
+				__( 'Post not found.', 'acrossai-abilities-manager' )
+			);
+		}
+		$editable = self::assert_post_type_editable( $post_id );
+		if ( is_wp_error( $editable ) ) {
+			return $editable;
+		}
+		$required = 'read' === $cap ? 'read_post' : 'edit_post';
+		if ( ! current_user_can( $required, $post_id ) ) {
+			return new WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to access this post.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		$blocks = parse_blocks( (string) $post->post_content );
+		return is_array( $blocks ) ? $blocks : array();
+	}
+
+	/**
+	 * Depth-first walk over a block tree, invoking $visitor for every node
+	 * with its computed path. $visitor receives ( array $block, int[] $path ).
+	 *
+	 * @param array<int, array<string, mixed>> $blocks  Parsed block tree.
+	 * @param callable                         $visitor fn(array $block, array $path): void
+	 * @param int[]                            $prefix  Internal recursion parameter.
+	 * @return void
+	 */
+	public static function walk_tree( array $blocks, callable $visitor, array $prefix = array() ): void {
+		foreach ( $blocks as $index => $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+			$path = array_merge( $prefix, array( (int) $index ) );
+			$visitor( $block, $path );
+			$inner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : array();
+			if ( ! empty( $inner ) ) {
+				self::walk_tree( array_values( $inner ), $visitor, $path );
+			}
+		}
+	}
+
+	/**
+	 * Return a deep copy of the tree with each node's `path` key populated.
+	 * Non-mutating.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks  Parsed block tree.
+	 * @param int[]                            $prefix  Internal recursion parameter.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function annotate_with_paths( array $blocks, array $prefix = array() ): array {
+		$out = array();
+		foreach ( $blocks as $index => $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+			$path          = array_merge( $prefix, array( (int) $index ) );
+			$block['path'] = $path;
+			$inner         = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : array();
+			if ( ! empty( $inner ) ) {
+				$block['innerBlocks'] = self::annotate_with_paths( array_values( $inner ), $path );
+			}
+			$out[] = $block;
+		}
+		return $out;
+	}
+
+	/**
+	 * Return the block at $path or null if the path does not resolve.
+	 * $path may not be empty (the root itself is not a block).
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Parsed block tree.
+	 * @param int[]                            $path   Canonical block path.
+	 * @return array<string, mixed>|null
+	 */
+	public static function get_at_path( array $blocks, array $path ): ?array {
+		if ( array() === $path ) {
+			return null;
+		}
+		$cursor = $blocks;
+		$last   = count( $path ) - 1;
+		foreach ( $path as $depth => $index ) {
+			if ( ! is_int( $index ) || $index < 0 || ! isset( $cursor[ $index ] ) || ! is_array( $cursor[ $index ] ) ) {
+				return null;
+			}
+			if ( $depth === $last ) {
+				return $cursor[ $index ];
+			}
+			$cursor = isset( $cursor[ $index ]['innerBlocks'] ) && is_array( $cursor[ $index ]['innerBlocks'] )
+				? array_values( $cursor[ $index ]['innerBlocks'] )
+				: array();
+		}
+		return null;
+	}
+
+	/**
+	 * Insert $new_block into the children of the block at $parent_path at
+	 * $index. If $index >= sibling count, append at the end. $parent_path may
+	 * be empty to insert into the root list.
+	 *
+	 * Mutates $blocks by reference.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks       Root block tree.
+	 * @param int[]                            $parent_path  Path of the parent (empty = root).
+	 * @param int                              $index        Zero-based insert position.
+	 * @param array<string, mixed>             $new_block    Block payload to insert.
+	 * @return bool True on success.
+	 */
+	public static function insert_at_path( array &$blocks, array $parent_path, int $index, array $new_block ): bool {
+		if ( $index < 0 ) {
+			return false;
+		}
+		$new_block = self::normalize_block_shape( $new_block );
+
+		if ( array() === $parent_path ) {
+			$count = count( $blocks );
+			$pos   = min( $index, $count );
+			array_splice( $blocks, $pos, 0, array( $new_block ) );
+			$blocks = array_values( $blocks );
+			return true;
+		}
+
+		$parent = &self::locate_parent_ref( $blocks, $parent_path );
+		if ( null === $parent ) {
+			return false;
+		}
+		if ( ! isset( $parent['innerBlocks'] ) || ! is_array( $parent['innerBlocks'] ) ) {
+			$parent['innerBlocks'] = array();
+		}
+		$children = array_values( $parent['innerBlocks'] );
+		$count    = count( $children );
+		$pos      = min( $index, $count );
+		array_splice( $children, $pos, 0, array( $new_block ) );
+		$parent['innerBlocks'] = array_values( $children );
+
+		// Keep innerContent placeholders consistent — WordPress core expects
+		// one null entry per child block when there is HTML surrounding them.
+		// If innerContent is currently a simple wrapper (only nulls or empty),
+		// grow the null-array to match the new child count. Otherwise leave
+		// it alone and let serialize_blocks resolve the layout on the next
+		// parse round-trip.
+		if ( isset( $parent['innerContent'] ) && is_array( $parent['innerContent'] ) && self::is_null_only( $parent['innerContent'] ) ) {
+			$parent['innerContent'] = array_fill( 0, count( $parent['innerBlocks'] ), null );
+		}
+		return true;
+	}
+
+	/**
+	 * Remove the block at $path and return it, or null if the path does not
+	 * resolve. $path may not be empty.
+	 *
+	 * Mutates $blocks by reference.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Root block tree.
+	 * @param int[]                            $path   Canonical block path.
+	 * @return array<string, mixed>|null Removed block or null.
+	 */
+	public static function remove_at_path( array &$blocks, array $path ): ?array {
+		if ( array() === $path ) {
+			return null;
+		}
+		$parent_path = $path;
+		$leaf        = (int) array_pop( $parent_path );
+
+		if ( array() === $parent_path ) {
+			if ( ! isset( $blocks[ $leaf ] ) || ! is_array( $blocks[ $leaf ] ) ) {
+				return null;
+			}
+			$removed = $blocks[ $leaf ];
+			array_splice( $blocks, $leaf, 1 );
+			$blocks = array_values( $blocks );
+			return $removed;
+		}
+
+		$parent = &self::locate_parent_ref( $blocks, $parent_path );
+		if ( null === $parent || ! isset( $parent['innerBlocks'] ) || ! is_array( $parent['innerBlocks'] ) ) {
+			return null;
+		}
+		$children = array_values( $parent['innerBlocks'] );
+		if ( ! isset( $children[ $leaf ] ) ) {
+			return null;
+		}
+		$removed = $children[ $leaf ];
+		array_splice( $children, $leaf, 1 );
+		$parent['innerBlocks'] = array_values( $children );
+
+		if ( isset( $parent['innerContent'] ) && is_array( $parent['innerContent'] ) && self::is_null_only( $parent['innerContent'] ) ) {
+			$parent['innerContent'] = array_fill( 0, count( $parent['innerBlocks'] ), null );
+		}
+		return $removed;
+	}
+
+	/**
+	 * Replace the block at $path with $new_block. Returns false when the path
+	 * does not resolve.
+	 *
+	 * Mutates $blocks by reference.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks     Root block tree.
+	 * @param int[]                            $path       Canonical block path.
+	 * @param array<string, mixed>             $new_block  Replacement block.
+	 * @return bool
+	 */
+	public static function replace_at_path( array &$blocks, array $path, array $new_block ): bool {
+		if ( array() === $path ) {
+			return false;
+		}
+		$parent_path = $path;
+		$leaf        = (int) array_pop( $parent_path );
+		$new_block   = self::normalize_block_shape( $new_block );
+
+		if ( array() === $parent_path ) {
+			if ( ! isset( $blocks[ $leaf ] ) || ! is_array( $blocks[ $leaf ] ) ) {
+				return false;
+			}
+			$blocks[ $leaf ] = $new_block;
+			return true;
+		}
+
+		$parent = &self::locate_parent_ref( $blocks, $parent_path );
+		if ( null === $parent || ! isset( $parent['innerBlocks'] ) || ! is_array( $parent['innerBlocks'] ) ) {
+			return false;
+		}
+		$children = array_values( $parent['innerBlocks'] );
+		if ( ! isset( $children[ $leaf ] ) ) {
+			return false;
+		}
+		$children[ $leaf ]     = $new_block;
+		$parent['innerBlocks'] = array_values( $children );
+		return true;
+	}
+
+	/**
+	 * Atomically move the block at $from to child position $to_index of the
+	 * parent at $to_parent. Refuses moves whose destination lies inside the
+	 * source's own subtree (would create a cycle).
+	 *
+	 * Mutates $blocks by reference.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks    Root block tree.
+	 * @param int[]                            $from      Source block path.
+	 * @param int[]                            $to_parent Destination parent path.
+	 * @param int                              $to_index  Zero-based destination sibling index.
+	 * @return true|WP_Error
+	 */
+	public static function move( array &$blocks, array $from, array $to_parent, int $to_index ) {
+		if ( array() === $from ) {
+			return new WP_Error(
+				'invalid_path',
+				__( 'Source path must not be empty.', 'acrossai-abilities-manager' )
+			);
+		}
+		if ( $to_index < 0 ) {
+			return new WP_Error(
+				'invalid_destination',
+				__( 'Destination index must be zero or greater.', 'acrossai-abilities-manager' )
+			);
+		}
+		if ( self::path_starts_with( $to_parent, $from ) ) {
+			return new WP_Error(
+				'descendant_destination',
+				__( 'Destination lies within the source subtree.', 'acrossai-abilities-manager' )
+			);
+		}
+		if ( null === self::get_at_path( $blocks, $from ) ) {
+			return new WP_Error(
+				'invalid_path',
+				__( 'Source path does not resolve to a block.', 'acrossai-abilities-manager' )
+			);
+		}
+		if ( array() !== $to_parent && null === self::get_at_path( $blocks, $to_parent ) ) {
+			return new WP_Error(
+				'invalid_destination',
+				__( 'Destination parent path does not resolve to a block.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		$moved = self::remove_at_path( $blocks, $from );
+		if ( null === $moved ) {
+			return new WP_Error(
+				'invalid_path',
+				__( 'Source path does not resolve to a block.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		// Adjust destination index if the removal shifted siblings in the
+		// same parent. Only relevant when to_parent == parent(from) and the
+		// source sat at a lower index than the destination.
+		$from_parent = $from;
+		array_pop( $from_parent );
+		if ( $from_parent === $to_parent ) {
+			$source_index = (int) end( $from );
+			if ( $source_index < $to_index ) {
+				--$to_index;
+			}
+		}
+
+		if ( ! self::insert_at_path( $blocks, $to_parent, $to_index, $moved ) ) {
+			// Restore in case insert failed unexpectedly.
+			self::insert_at_path( $blocks, $from_parent, (int) end( $from ), $moved );
+			return new WP_Error(
+				'invalid_destination',
+				__( 'Failed to insert at destination.', 'acrossai-abilities-manager' )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * Validate a block's attributes against its registered block type's
+	 * schema. Soft-fails (returns true) when the block type is not
+	 * registered — the abilities layer must remain usable for custom or
+	 * plugin-supplied blocks not present on this site.
+	 *
+	 * @param string               $block_name Block name (namespace/name).
+	 * @param array<string, mixed> $attrs      Candidate attributes.
+	 * @return true|WP_Error
+	 */
+	public static function validate_attributes_against_schema( string $block_name, array $attrs ) {
+		if ( ! Block_Info::registry_available() ) {
+			return true;
+		}
+		$block_type = Block_Info::get_block( $block_name );
+		if ( null === $block_type ) {
+			return true;
+		}
+		$schema = $block_type->attributes;
+		if ( ! is_array( $schema ) || array() === $schema ) {
+			return true;
+		}
+		foreach ( $attrs as $key => $value ) {
+			if ( ! isset( $schema[ $key ] ) || ! is_array( $schema[ $key ] ) ) {
+				continue;
+			}
+			$declared = isset( $schema[ $key ]['type'] ) ? (array) $schema[ $key ]['type'] : array();
+			if ( array() === $declared ) {
+				continue;
+			}
+			if ( ! self::value_matches_type( $value, $declared ) ) {
+				return new WP_Error(
+					'invalid_attributes',
+					sprintf(
+						/* translators: 1: attribute name, 2: block name */
+						__( 'Attribute "%1$s" does not match the schema declared by block type "%2$s".', 'acrossai-abilities-manager' ),
+						(string) $key,
+						$block_name
+					)
+				);
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Locate a reference to the block at $path so callers can mutate it in
+	 * place. Returns null if the path does not resolve.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Root block tree.
+	 * @param int[]                            $path   Non-empty path.
+	 * @return array<string, mixed>|null
+	 */
+	private static function &locate_parent_ref( array &$blocks, array $path ): ?array {
+		$null   = null;
+		$cursor = &$blocks;
+		$last   = count( $path ) - 1;
+		foreach ( $path as $depth => $index ) {
+			if ( ! is_int( $index ) || $index < 0 || ! isset( $cursor[ $index ] ) || ! is_array( $cursor[ $index ] ) ) {
+				return $null;
+			}
+			if ( $depth === $last ) {
+				$ref = &$cursor[ $index ];
+				return $ref;
+			}
+			if ( ! isset( $cursor[ $index ]['innerBlocks'] ) || ! is_array( $cursor[ $index ]['innerBlocks'] ) ) {
+				return $null;
+			}
+			$cursor = &$cursor[ $index ]['innerBlocks'];
+		}
+		return $null;
+	}
+
+	/**
+	 * True when $candidate begins with every element of $prefix.
+	 *
+	 * @param int[] $candidate
+	 * @param int[] $prefix
+	 * @return bool
+	 */
+	private static function path_starts_with( array $candidate, array $prefix ): bool {
+		if ( count( $prefix ) > count( $candidate ) ) {
+			return false;
+		}
+		return array_slice( $candidate, 0, count( $prefix ) ) === $prefix;
+	}
+
+	/**
+	 * True when every element of the array is null.
+	 *
+	 * @param array<int, mixed> $arr
+	 * @return bool
+	 */
+	private static function is_null_only( array $arr ): bool {
+		foreach ( $arr as $item ) {
+			if ( null !== $item ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Bring a caller-supplied block payload up to the shape parse_blocks()
+	 * would have produced — fill in missing structural keys.
+	 *
+	 * @param array<string, mixed> $block
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_block_shape( array $block ): array {
+		if ( isset( $block['name'] ) && ! isset( $block['blockName'] ) ) {
+			$block['blockName'] = (string) $block['name'];
+			unset( $block['name'] );
+		}
+		if ( ! isset( $block['attrs'] ) || ! is_array( $block['attrs'] ) ) {
+			$block['attrs'] = array();
+		}
+		if ( ! isset( $block['innerBlocks'] ) || ! is_array( $block['innerBlocks'] ) ) {
+			$block['innerBlocks'] = array();
+		}
+		if ( ! isset( $block['innerHTML'] ) ) {
+			$block['innerHTML'] = '';
+		}
+		if ( ! isset( $block['innerContent'] ) || ! is_array( $block['innerContent'] ) ) {
+			$block['innerContent'] = '' === $block['innerHTML'] && array() === $block['innerBlocks']
+				? array()
+				: array( (string) $block['innerHTML'] );
+		}
+		return $block;
+	}
+
+	/**
+	 * Naive JSON-schema type match — good enough for the "obvious wrong type"
+	 * guard we want. Registered block-type attributes typically declare one
+	 * of: string, number, integer, boolean, array, object, null.
+	 *
+	 * @param mixed         $value
+	 * @param array<string> $types
+	 * @return bool
+	 */
+	private static function value_matches_type( $value, array $types ): bool {
+		foreach ( $types as $type ) {
+			$type = strtolower( (string) $type );
+			switch ( $type ) {
+				case 'string':
+					if ( is_string( $value ) ) {
+						return true;
+					}
+					break;
+				case 'number':
+					if ( is_int( $value ) || is_float( $value ) ) {
+						return true;
+					}
+					break;
+				case 'integer':
+					if ( is_int( $value ) ) {
+						return true;
+					}
+					break;
+				case 'boolean':
+					if ( is_bool( $value ) ) {
+						return true;
+					}
+					break;
+				case 'array':
+					if ( is_array( $value ) && array_is_list( $value ) ) {
+						return true;
+					}
+					break;
+				case 'object':
+					if ( is_array( $value ) || is_object( $value ) ) {
+						return true;
+					}
+					break;
+				case 'null':
+					if ( null === $value ) {
+						return true;
+					}
+					break;
+			}
+		}
+		return false;
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -89,6 +89,14 @@
 			<file>tests/phpunit/abilities/Test_Verify_Plugin_Checksums.php</file>
 			<file>tests/phpunit/abilities/Test_Verify_Core_Checksums.php</file>
 			<file>tests/phpunit/abilities/Test_Feature_064_Bootstrap_Wiring.php</file>
+			<file>tests/phpunit/abilities/Test_Block_Tree.php</file>
+			<file>tests/phpunit/abilities/Test_Get_Post_Blocks.php</file>
+			<file>tests/phpunit/abilities/Test_Add_Block.php</file>
+			<file>tests/phpunit/abilities/Test_Remove_Block.php</file>
+			<file>tests/phpunit/abilities/Test_Update_Post_Block_Nested.php</file>
+			<file>tests/phpunit/abilities/Test_Move_Block.php</file>
+			<file>tests/phpunit/abilities/Test_Duplicate_Block.php</file>
+			<file>tests/phpunit/abilities/Test_Insert_Pattern.php</file>
 		</testsuite>
 	</testsuites>
 	<source>

--- a/specs/066-block-tree-mutation-and-nested-editing/checklists/requirements.md
+++ b/specs/066-block-tree-mutation-and-nested-editing/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Block Tree Mutation & Nested Editing
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- Validation performed 2026-08-12; all 15 items pass on first iteration.
+- Spec references WordPress-neutral concepts (Post, Block, Block path, Block pattern, Block type) rather than PHP function names, class names, or file paths — implementation surface is deferred to plan.md.
+- Backward-compat requirement (FR-012, SC-003) is stated in behavioral terms without naming the underlying ability class.
+- Ambiguity on pattern insert (US7 / FR-017) has an explicit disambiguation path — no NEEDS CLARIFICATION needed.

--- a/specs/066-block-tree-mutation-and-nested-editing/contracts/abilities.md
+++ b/specs/066-block-tree-mutation-and-nested-editing/contracts/abilities.md
@@ -1,0 +1,391 @@
+# Ability Contracts
+
+**Feature**: 066-block-tree-mutation-and-nested-editing
+**Date**: 2026-08-12
+
+Every ability in this feature registers via `wp_register_ability( 'acrossai/<slug>', [...] )` and lives under the existing `acrossai-abilities-manager-content` category. All abilities share the response envelope defined in [data-model.md](../data-model.md#entity-response-envelope).
+
+**Shared cross-cutting behaviour** (documented once here, applied by every ability):
+
+- **Capability model**: every write ability requires `manage_options` AND `edit_posts` globally, plus `edit_post($post_id)` per-post. `Get_Post_Blocks` swaps `edit_post` for `read_post`.
+- **Post-type gate**: writes refuse on `revision`, `nav_menu_item`, `custom_css`, `customize_changeset`, `oembed_cache`, `user_request`; also refuse any post type whose registration excludes editor UI, REST exposure, AND public access.
+- **Round-trip**: writes flow through `parse_blocks( get_post()->post_content )` → mutate in memory → `serialize_blocks()` → `wp_update_post( [ 'ID' => $post_id, 'post_content' => $new_content ] )`.
+- **Attribute validation**: soft — validates against the registered block type when known; permits unknown types.
+- **On error**: returns `{ success: false, post_id, message, error_code }` with no payload keys.
+
+---
+
+## 1. `acrossai/get-post-blocks`
+
+**Purpose**: Return the parsed block tree of a post with each block annotated with its canonical path.
+
+**Type**: read · idempotent · non-destructive
+
+### Input schema
+
+```json
+{
+  "type": "object",
+  "required": ["post_id"],
+  "properties": {
+    "post_id": { "type": "integer", "minimum": 1 }
+  }
+}
+```
+
+### Output schema (success)
+
+```json
+{
+  "type": "object",
+  "required": ["success", "post_id", "blocks", "message"],
+  "properties": {
+    "success":  { "type": "boolean", "const": true },
+    "post_id":  { "type": "integer" },
+    "blocks":   { "type": "array", "items": { "$ref": "#/definitions/Block" } },
+    "total":    { "type": "integer", "description": "Total blocks across all nesting levels" },
+    "message":  { "type": "string" }
+  },
+  "definitions": {
+    "Block": {
+      "type": "object",
+      "required": ["name", "attrs", "innerBlocks", "innerHTML", "path"],
+      "properties": {
+        "name":         { "type": "string", "pattern": "^[A-Za-z0-9_-]+/[A-Za-z0-9_-]+$" },
+        "attrs":        { "type": "object" },
+        "innerBlocks":  { "type": "array", "items": { "$ref": "#/definitions/Block" } },
+        "innerHTML":    { "type": "string" },
+        "innerContent": { "type": "array" },
+        "path":         { "type": "array", "items": { "type": "integer", "minimum": 0 } }
+      }
+    }
+  }
+}
+```
+
+### Error cases
+
+| `error_code` | Cause |
+|---|---|
+| `post_not_found` | `post_id` does not resolve |
+| `post_type_forbidden` | Post type is internal or non-editor-compatible |
+| `insufficient_capability` | Caller lacks `manage_options` / `edit_posts` / `read_post($post_id)` |
+
+---
+
+## 2. `acrossai/add-block`
+
+**Purpose**: Insert a new block at a parent path + sibling index (append if index ≥ current sibling count).
+
+**Type**: write · non-idempotent · destructive
+
+### Input schema
+
+```json
+{
+  "type": "object",
+  "required": ["post_id", "parent_path", "index", "block"],
+  "properties": {
+    "post_id":     { "type": "integer", "minimum": 1 },
+    "parent_path": { "type": "array", "items": { "type": "integer", "minimum": 0 } },
+    "index":       { "type": "integer", "minimum": 0 },
+    "block": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name":         { "type": "string", "pattern": "^[A-Za-z0-9_-]+/[A-Za-z0-9_-]+$" },
+        "attrs":        { "type": "object" },
+        "innerHTML":    { "type": "string" },
+        "innerBlocks":  { "type": "array" }
+      }
+    }
+  }
+}
+```
+
+### Output schema (success)
+
+```json
+{
+  "type": "object",
+  "required": ["success", "post_id", "block", "message"],
+  "properties": {
+    "success": { "const": true },
+    "post_id": { "type": "integer" },
+    "block":   { "type": "object", "description": "The inserted block with its new path" },
+    "message": { "type": "string" }
+  }
+}
+```
+
+### Error cases
+
+| `error_code` | Cause |
+|---|---|
+| `post_not_found` / `post_type_forbidden` / `insufficient_capability` | Standard |
+| `invalid_block_name` | `name` fails the regex |
+| `invalid_path` | `parent_path` does not resolve to an existing block (or root) |
+| `invalid_attributes` | `attrs` fail the registered block type's schema |
+
+---
+
+## 3. `acrossai/remove-block`
+
+**Purpose**: Remove the block at a specified path.
+
+**Type**: write · non-idempotent · destructive
+
+### Input schema
+
+```json
+{
+  "type": "object",
+  "required": ["post_id", "path"],
+  "properties": {
+    "post_id": { "type": "integer", "minimum": 1 },
+    "path":    { "type": "array", "items": { "type": "integer", "minimum": 0 }, "minItems": 1 }
+  }
+}
+```
+
+### Output schema (success)
+
+```json
+{
+  "type": "object",
+  "required": ["success", "post_id", "removed", "message"],
+  "properties": {
+    "success": { "const": true },
+    "post_id": { "type": "integer" },
+    "removed": { "type": "object", "description": "The removed block (for undo/logging)" },
+    "message": { "type": "string" }
+  }
+}
+```
+
+### Error cases
+
+| `error_code` | Cause |
+|---|---|
+| `post_not_found` / `post_type_forbidden` / `insufficient_capability` | Standard |
+| `invalid_path` | `path` empty or does not resolve |
+
+---
+
+## 4. `acrossai/update-post-block` (MODIFIED — extends existing ability)
+
+**Purpose**: Update block attributes and/or inner HTML at any nesting depth. Backward compatible with existing input shapes.
+
+**Type**: write · idempotent · destructive
+
+### Input schema (additions in **bold**)
+
+```json
+{
+  "type": "object",
+  "required": ["post_id"],
+  "properties": {
+    "post_id":     { "type": "integer", "minimum": 1 },
+
+    "path":        { "type": "array", "items": { "type": "integer", "minimum": 0 } },
+
+    "block_index": { "type": "integer", "minimum": 0 },
+    "block_name":  { "type": "string" },
+    "occurrence":  { "type": "integer", "minimum": 0 },
+
+    "attributes":  { "type": "object" },
+    "inner_html":  { "type": "string" }
+  }
+}
+```
+
+### Target resolution priority
+
+1. `path` present and non-empty → use `Block_Tree::replace_at_path`.
+2. `block_index` present → existing top-level index logic (unchanged behaviour).
+3. `block_name` (+ optional `occurrence`) → existing name-occurrence logic (unchanged).
+4. None of the above → `invalid_input` error.
+
+### Output schema (unchanged from existing)
+
+```json
+{
+  "type": "object",
+  "required": ["success", "post_id", "block", "message"],
+  "properties": {
+    "success": { "type": "boolean" },
+    "post_id": { "type": "integer" },
+    "block":   { "type": "object" },
+    "message": { "type": "string" }
+  }
+}
+```
+
+### Error cases (additions)
+
+| `error_code` | Cause |
+|---|---|
+| Existing codes | Unchanged |
+| `invalid_path` | `path` does not resolve (new) |
+| `invalid_attributes` | Attributes fail registered schema |
+
+### Backward-compatibility guarantee
+
+Any request that omits `path` behaves identically to the pre-066 version of this ability. No behaviour change for existing consumers.
+
+---
+
+## 5. `acrossai/move-block`
+
+**Purpose**: Atomically move a block from a source path to a destination (parent path + sibling index). Refuses moves into the source's own subtree.
+
+**Type**: write · non-idempotent · destructive
+
+### Input schema
+
+```json
+{
+  "type": "object",
+  "required": ["post_id", "from_path", "to_parent_path", "to_index"],
+  "properties": {
+    "post_id":        { "type": "integer", "minimum": 1 },
+    "from_path":      { "type": "array", "items": { "type": "integer", "minimum": 0 }, "minItems": 1 },
+    "to_parent_path": { "type": "array", "items": { "type": "integer", "minimum": 0 } },
+    "to_index":       { "type": "integer", "minimum": 0 }
+  }
+}
+```
+
+### Output schema (success)
+
+```json
+{
+  "type": "object",
+  "required": ["success", "post_id", "block", "previous_path", "message"],
+  "properties": {
+    "success":       { "const": true },
+    "post_id":       { "type": "integer" },
+    "block":         { "type": "object", "description": "The moved block at its new path" },
+    "previous_path": { "type": "array", "items": { "type": "integer" } },
+    "message":       { "type": "string" }
+  }
+}
+```
+
+### Error cases
+
+| `error_code` | Cause |
+|---|---|
+| `post_not_found` / `post_type_forbidden` / `insufficient_capability` | Standard |
+| `invalid_path` | `from_path` empty or does not resolve |
+| `invalid_destination` | `to_parent_path` does not resolve |
+| `descendant_destination` | `to_parent_path` starts with `from_path` (would create a cycle) |
+
+---
+
+## 6. `acrossai/duplicate-block`
+
+**Purpose**: Deep-clone the block at a specified path (including all inner blocks) and insert the clone as the next sibling.
+
+**Type**: write · non-idempotent · destructive
+
+### Input schema
+
+```json
+{
+  "type": "object",
+  "required": ["post_id", "path"],
+  "properties": {
+    "post_id": { "type": "integer", "minimum": 1 },
+    "path":    { "type": "array", "items": { "type": "integer", "minimum": 0 }, "minItems": 1 }
+  }
+}
+```
+
+### Output schema (success)
+
+```json
+{
+  "type": "object",
+  "required": ["success", "post_id", "block", "message"],
+  "properties": {
+    "success": { "const": true },
+    "post_id": { "type": "integer" },
+    "block":   { "type": "object", "description": "The cloned block with its new path" },
+    "message": { "type": "string" }
+  }
+}
+```
+
+### Error cases
+
+Standard set + `invalid_path`.
+
+---
+
+## 7. `acrossai/insert-pattern`
+
+**Purpose**: Resolve a saved pattern by slug (across db / theme / plugin sources) and insert its constituent blocks at a specified parent path and sibling index.
+
+**Type**: write · non-idempotent · destructive
+
+### Input schema
+
+```json
+{
+  "type": "object",
+  "required": ["post_id", "parent_path", "index", "slug"],
+  "properties": {
+    "post_id":     { "type": "integer", "minimum": 1 },
+    "parent_path": { "type": "array", "items": { "type": "integer", "minimum": 0 } },
+    "index":       { "type": "integer", "minimum": 0 },
+    "slug":        { "type": "string", "minLength": 1 },
+    "source":      { "type": "string", "enum": ["db", "theme", "plugin"], "description": "Optional disambiguation when slug resolves in multiple sources" },
+    "theme_type":  { "type": "string", "enum": ["parent", "child"], "description": "Optional — only relevant when source=theme" },
+    "plugin_slug": { "type": "string", "description": "Optional — only relevant when source=plugin" }
+  }
+}
+```
+
+### Output schema (success)
+
+```json
+{
+  "type": "object",
+  "required": ["success", "post_id", "inserted_paths", "message"],
+  "properties": {
+    "success":        { "const": true },
+    "post_id":        { "type": "integer" },
+    "inserted_paths": {
+      "type": "array",
+      "items": { "type": "array", "items": { "type": "integer", "minimum": 0 } },
+      "description": "Paths of every inserted block, in insertion order"
+    },
+    "count":          { "type": "integer", "description": "Number of blocks inserted" },
+    "message":        { "type": "string" }
+  }
+}
+```
+
+### Error cases
+
+| `error_code` | Cause |
+|---|---|
+| Standard set | — |
+| `pattern_not_found` | Slug does not resolve in any source |
+| `multiple_locations` | Slug resolves in more than one source and no `source` was specified |
+| `invalid_path` | `parent_path` does not resolve |
+
+---
+
+## Contract summary
+
+| Ability | Read/Write | Input requires | Output payload |
+|---|---|---|---|
+| `get-post-blocks` | R | `post_id` | `blocks` (annotated tree), `total` |
+| `add-block` | W | `post_id`, `parent_path`, `index`, `block` | `block` (with new path) |
+| `remove-block` | W | `post_id`, `path` | `removed` |
+| `update-post-block` | W | `post_id` + one of {`path`, `block_index`, `block_name`} | `block` |
+| `move-block` | W | `post_id`, `from_path`, `to_parent_path`, `to_index` | `block`, `previous_path` |
+| `duplicate-block` | W | `post_id`, `path` | `block` |
+| `insert-pattern` | W | `post_id`, `parent_path`, `index`, `slug` | `inserted_paths`, `count` |

--- a/specs/066-block-tree-mutation-and-nested-editing/data-model.md
+++ b/specs/066-block-tree-mutation-and-nested-editing/data-model.md
@@ -1,0 +1,149 @@
+# Data Model: Block Tree Mutation & Nested Editing
+
+**Feature**: 066-block-tree-mutation-and-nested-editing
+**Date**: 2026-08-12
+
+This feature introduces **no new persistent storage**. All data lives in existing WordPress storage (`wp_posts.post_content`) and is manipulated in-memory as parsed block trees. This document describes the **logical entities** that appear in ability inputs and outputs.
+
+---
+
+## Entity: `Post`
+
+The WordPress post whose content is being read or mutated.
+
+| Field | Type | Notes |
+|---|---|---|
+| `post_id` | `int` (≥ 1) | Primary identifier — matches `wp_posts.ID` |
+| `post_content` | `string` | The raw block-comment-annotated HTML stored in the database (read/write side effect only — never returned to callers directly) |
+| `post_type` | `string` | Used for the editability whitelist (`Block_Tree::assert_post_type_editable`) |
+
+**Source of truth**: `get_post( $post_id )` (WordPress core).
+
+**Validation**:
+- `$post_id` must resolve to an existing post via `get_post()`.
+- `$post_type` must NOT be one of the internal types: `revision`, `nav_menu_item`, `custom_css`, `customize_changeset`, `oembed_cache`, `user_request`.
+- `$post_type` must have `show_in_rest = true` OR `show_ui = true` OR `public = true` (matches existing `Update_Post_Block:127-135`).
+
+---
+
+## Entity: `Block`
+
+A single node in a Post's parsed block tree. Corresponds exactly to one element in the array returned by `parse_blocks()`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `string` | Block namespace/name — e.g. `core/paragraph`. Must match `^[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+$` (extracted regex from `Update_Post_Block:160`) |
+| `attrs` | `array<string, mixed>` | Block attributes — validated against the registered block type's `attributes` schema when the type is registered (soft-fail if not) |
+| `innerBlocks` | `Block[]` | Ordered list of child blocks — recursive |
+| `innerHTML` | `string` | Rendered HTML between the opening and closing block comment |
+| `innerContent` | `array<string\|null>` | Interleaved HTML fragments and inner-block placeholders (`null` marks a child-block position). Matches core `parse_blocks` shape. |
+
+**Additional field appended by `Get_Post_Blocks` output** (not part of stored data):
+
+| Field | Type | Notes |
+|---|---|---|
+| `path` | `int[]` | Canonical path of this block within its Post's tree — pre-computed by `Block_Tree::annotate_with_paths()` |
+
+**Validation**:
+- On input to write abilities: `name` must pass the regex; `attrs` must satisfy the registered schema when known.
+- `innerContent` is preserved verbatim on writes that only modify `attrs` (matches `Update_Post_Block:186` behaviour).
+
+**State transitions**:
+- Created by `Add_Block` / `Insert_Pattern`.
+- Modified in place by `Update_Post_Block` (with `path`).
+- Moved by `Move_Block`.
+- Deep-cloned by `Duplicate_Block`.
+- Destroyed by `Remove_Block`.
+
+---
+
+## Entity: `Block path`
+
+A canonical, unambiguous address for one `Block` within a `Post`'s tree.
+
+| Property | Value |
+|---|---|
+| **Type** | `int[]` (ordered list of non-negative integers) |
+| **Root** | `[]` — refers to the top-level list; not a block itself |
+| **Semantics** | `[i]` = i-th top-level block. `[i, j]` = j-th child of the i-th top-level block. Depth is `count($path)`. |
+| **Validation** | Every element `>= 0`; every element must resolve to an existing index at that level (except where an "insert-at-one-past-the-end" append is explicitly allowed) |
+
+**Operations** (all pure, from `Block_Tree`):
+- `get_at_path( array $blocks, array $path ): ?array` — return the Block at path or `null`.
+- `insert_at_path( array &$blocks, array $parent_path, int $index, array $new_block ): bool` — insert as child of `parent_path` at `$index`; append if `$index >= count(children)`.
+- `remove_at_path( array &$blocks, array $path ): ?array` — remove and return the removed Block or `null`.
+- `replace_at_path( array &$blocks, array $path, array $new_block ): bool` — swap in place.
+- `move( array &$blocks, array $from, array $to_parent, int $to_index ): true|WP_Error` — atomic move; returns error if `$to_parent` starts with `$from` (descendant guard).
+- `annotate_with_paths( array $blocks, array $prefix = [] ): array` — recursive; returns a copy with `path` added to every node.
+
+**Edge cases**:
+- Path `[]` cannot be passed to `get_at_path` — it identifies the root array itself, not a Block.
+- `insert_at_path` accepts `[]` as `parent_path` — insert into the top-level list.
+- `remove_at_path([])` is undefined behaviour and MUST be rejected.
+
+---
+
+## Entity: `Block pattern`
+
+A named collection of blocks resolvable by slug from one of three sources.
+
+| Field | Type | Notes |
+|---|---|---|
+| `slug` | `string` | Pattern identifier |
+| `source` | `string` (`db` \| `theme` \| `plugin`) | Which registry to resolve against |
+| `theme_type` | `string?` | If `source=theme`, distinguishes parent/child theme |
+| `plugin_slug` | `string?` | If `source=plugin`, identifies which plugin owns the pattern |
+| `blocks` | `Block[]` | The parsed pattern content — inserted as children of the target parent path when the pattern is applied |
+
+**Resolution**:
+- If `slug` is unambiguous across sources → auto-resolve.
+- If `slug` resolves in multiple sources without an explicit `source` → return error with `error_code=multiple_locations` (matches existing `Read_Block_Pattern` behaviour per feature spec assumption 4).
+- If `slug` resolves nowhere → return error with a "unknown pattern slug" message.
+
+---
+
+## Entity: `Block type` (external / read-only)
+
+The runtime registration for a given `Block.name` in the site's `WP_Block_Type_Registry`. Used for attribute-schema validation only.
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `string` | Namespace/name |
+| `attributes` | `array` | Schema keyed by attribute name; each has `type`, optional `default`, optional `source` |
+
+**Access**: `Block_Info::get_block( $name )` (existing utility at `includes/Abilities/Utilities/Block_Info.php:56`).
+
+**Validation policy**: Soft — if not registered on this site, block writes proceed without attribute validation (see research R4). Never mutated by this feature.
+
+---
+
+## Entity: `Response envelope`
+
+The shape returned by every ability in this feature.
+
+| Field | Type | When present | Notes |
+|---|---|---|---|
+| `success` | `boolean` | always | `true` on completion, `false` on error |
+| `post_id` | `int` | always | Echoes the input `post_id` for correlation |
+| `message` | `string` | always | Human-readable summary |
+| `error_code` | `string?` | on `success=false` | Machine-readable code — e.g. `invalid_path`, `multiple_locations`, `insufficient_capability` |
+| `blocks` | `Block[]` | `Get_Post_Blocks` success only | Annotated tree |
+| `block` | `Block` | write abilities success only | The affected block, including its `path` after mutation |
+| `previous_path` | `int[]` | `Move_Block` success only | Where the block used to live |
+| `inserted_paths` | `int[][]` | `Insert_Pattern` success only | Paths of every inserted block, in insertion order |
+
+**Rule**: When `success=false`, none of the payload keys (`blocks`, `block`, `previous_path`, `inserted_paths`) are present.
+
+---
+
+## Relationships
+
+```
+Post 1 ── 1 tree of Blocks
+Block 1 ── 0..N innerBlocks (Blocks)  [recursive]
+Block 1 ── 1 Block path                [computed per read]
+Block 1 ── 0..1 Block type             [registry lookup for validation]
+Block pattern 1 ── N Blocks            [expanded on insert]
+```
+
+No relational storage is introduced. `Post` and `Block type` are external entities WordPress core owns. `Block`, `Block path`, `Block pattern`, and `Response envelope` are all in-memory shapes derived from or destined for `Post.post_content`.

--- a/specs/066-block-tree-mutation-and-nested-editing/plan.md
+++ b/specs/066-block-tree-mutation-and-nested-editing/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Block Tree Mutation & Nested Editing
+
+**Branch**: `066-block-tree-mutation-and-nested-editing` | **Date**: 2026-08-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/066-block-tree-mutation-and-nested-editing/spec.md`
+
+## Summary
+
+Provide complete read/write control over the Gutenberg block tree inside a WordPress post — including nested blocks — via six new abilities (`get-post-blocks`, `add-block`, `remove-block`, `duplicate-block`, `move-block`, `insert-pattern`) plus an enhancement to the existing `update-post-block` ability that accepts a canonical path input for nested addressing while preserving 100% backward compatibility with existing consumers.
+
+**Technical approach.** One shared utility class (`includes/Abilities/Utilities/Block_Tree.php`) implements the canonical block-path scheme (an ordered array of zero-based integers) and provides pure tree primitives — walk, get-at-path, insert-at-path, remove-at-path, replace-at-path, move — plus block-name validation and attribute-schema validation. Every new and modified ability consumes this utility rather than duplicating tree logic. Wire-level shape mirrors existing ability responses (`{ success, <payload>, message }`) and every ability registers via the existing `Ability_Definition` → `acrossai_abilities_api_init` → `AcrossAI_Core_Abilities_Bootstrap` pipeline used by every other content ability.
+
+## Technical Context
+
+**Language/Version**: PHP 8.1+ (per Constitution §II)
+**Primary Dependencies**: WordPress 6.9+, WordPress Abilities API (`wp_register_ability`), WordPress core block functions (`parse_blocks`, `serialize_blocks`, `WP_Block_Type_Registry`), existing plugin base class `Ability_Definition`, existing `Block_Info` utility
+**Storage**: WordPress `wp_posts.post_content` (round-tripped through core block parser); no new tables, no new options
+**Testing**: PHPUnit ^13.2 via `composer test`; existing source-inspection pattern in `tests/phpunit/abilities/`; integration tests via `WP_UnitTestCase` with `factory->post->create_and_get()` fixtures
+**Target Platform**: Server-side WordPress plugin (any hosting environment WP 6.9+ / PHP 8.1+ supports)
+**Project Type**: WordPress plugin — single-project layout under `includes/`
+**Performance Goals**: Read of a post's block tree returns in <100ms for posts up to 500 total blocks (typical realistic ceiling); write operations complete in <200ms (dominated by `wp_update_post` DB write)
+**Constraints**: Must preserve `post_content` round-trip fidelity where `parse_blocks`/`serialize_blocks` allow (95%+ per SC-004); 0 partial writes on validation failure (SC-005); no breaking change to existing `update-post-block` inputs (SC-003)
+**Scale/Scope**: 6 new ability classes + 1 utility class + 1 modified ability class + 7 new PHPUnit test files; approximately 800-1200 LOC total across ability classes; utility ~300-400 LOC
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+### I. Modular Architecture — PASS
+- Six new ability classes live alongside the existing `Update_Post_Block` under `includes/Abilities/Content/` — each is a self-contained module registering one ability. The shared `Block_Tree` utility centralises tree logic per §I ("extract to `includes/Utilities/` on second use") — this is the second use of block-tree walking (first use is inside `Update_Post_Block::execute`).
+- No cross-module coupling introduced; new abilities register via the same `acrossai_abilities_api_init` hook as every existing ability.
+
+### II. WordPress Standards Compliance — PASS (PLANNED)
+- WPCS strict + PHPStan level 8 + ESLint zero errors: enforced via existing `composer phpcs`, `composer phpstan`, and ESLint tooling.
+- Plugin Check: zero errors expected — no new SQL, no new forbidden functions, no new AJAX/REST surfaces beyond what the Abilities API auto-provides.
+- PHP 8.1+ typed properties and return types throughout.
+- All exports use the `acrossai_` prefix (namespace already `AcrossAI_Abilities_Manager\…`).
+- No new options, transients, cron, or file writes.
+
+### III. User-Centric Design (NON-NEGOTIABLE) — N/A
+- No UI surface in this feature. Abilities are consumed by clients over the Abilities API. Constitution §III (DataForm/DataViews mandate) does not apply.
+
+### IV. Security First (NON-NEGOTIABLE) — PASS (PLANNED)
+- Every write ability enforces the same capability model as the existing `Update_Post_Block::execute` — global `manage_options` + `edit_posts`, plus per-post `edit_post($post_id)` (FR-018).
+- Block-name regex validation before mutation (FR-008).
+- Attribute-schema validation against registered block type when available (FR-020).
+- Post-type whitelist blocks internal/uneditable types (FR-019).
+- All DB writes flow through `wp_update_post()` — no custom SQL, no direct `$wpdb->query()`.
+- Read ability requires post-read capability to prevent leaking private content.
+
+### V. Extensibility Without Core Modification — PASS
+- Registration is hook-only (`acrossai_abilities_api_init`). No monkey-patching of core.
+- Graceful degradation: when a block type is not registered, attribute-schema validation warns but does not hard-fail — client can still author custom blocks (FR-020).
+- Third-party block registrations work through the same interface without special-casing.
+
+### VI. Reusability & DRY Principle — PASS
+- `Block_Tree` extracts tree-walking on second use per §VI ("extract to `includes/Utilities/` on second use"). First use lives inside `Update_Post_Block::execute` (private inline logic); after this feature, both `Update_Post_Block` and the six new abilities consume the shared utility.
+- Pattern-source resolution reused from the existing `Read_Block_Pattern` helper — no duplicate source-scanning (per feature spec assumption 4).
+- Block-name regex validation moves from a private constant in `Update_Post_Block` into `Block_Tree::validate_block_name` — single source of truth.
+
+### VII. Definition of Done — PASS (PLANNED)
+- PHPCS/PHPStan/ESLint: zero errors (checked at commit).
+- PHPUnit: one test file per new ability plus one for `Block_Tree` primitives — 8 new files.
+- Security review: covered by the standard `after_plan` and `after_implement` hooks in `.specify/extensions.yml`.
+- No DRY violations (see §VI).
+- `acrossai_` prefix on every registered ability and global function (already the plugin-wide convention).
+
+**Gate result**: PASS on all principles. No violations require justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/066-block-tree-mutation-and-nested-editing/
+├── plan.md              # This file (/speckit-plan output)
+├── research.md          # Phase 0 output — path scheme, atomicity, pattern-source reuse
+├── data-model.md        # Phase 1 output — Block / Block path / response envelope entities
+├── quickstart.md        # Phase 1 output — canonical read → mutate → verify walkthrough
+├── contracts/
+│   └── abilities.md     # Ability contracts (input/output schemas per ability)
+├── checklists/
+│   └── requirements.md  # Spec-quality checklist (already generated by /speckit-specify)
+├── spec.md              # Feature spec (/speckit-specify output)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+includes/
+├── Abilities/
+│   ├── Ability_Definition.php                 # existing base class (no change)
+│   ├── AcrossAI_Core_Abilities_Bootstrap.php  # MODIFY — register 6 new ability classes
+│   ├── Content/
+│   │   ├── Update_Post_Block.php              # MODIFY — accept optional `path` input; delegate to Block_Tree
+│   │   ├── Get_Post_Blocks.php                # NEW — read ability
+│   │   ├── Add_Block.php                      # NEW — write ability
+│   │   ├── Remove_Block.php                   # NEW — write ability
+│   │   ├── Duplicate_Block.php                # NEW — write ability
+│   │   ├── Move_Block.php                     # NEW — write ability
+│   │   └── Insert_Pattern.php                 # NEW — write ability (reuses Read_Block_Pattern's source resolver)
+│   ├── Block/                                 # existing block-registry abilities (no change)
+│   └── Utilities/
+│       ├── Block_Info.php                     # existing (no change) — used for schema lookup
+│       └── Block_Tree.php                     # NEW — shared tree-path utility
+
+tests/
+└── phpunit/
+    └── abilities/
+        ├── Test_Get_Post_Blocks.php           # NEW
+        ├── Test_Add_Block.php                 # NEW
+        ├── Test_Remove_Block.php              # NEW
+        ├── Test_Duplicate_Block.php           # NEW
+        ├── Test_Move_Block.php                # NEW
+        ├── Test_Insert_Pattern.php            # NEW
+        ├── Test_Update_Post_Block_Nested.php  # NEW — nested-path branch coverage
+        └── Test_Block_Tree.php                # NEW — utility primitives
+```
+
+**Structure Decision**: WordPress plugin single-project layout — the plugin already organises abilities under `includes/Abilities/<Category>/` with utilities under `includes/Abilities/Utilities/`. New abilities and the new utility follow that established layout with no new top-level directories. Tests use the existing PHPUnit convention under `tests/phpunit/abilities/`.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+_Constitution Check passed all seven principles. No violations to justify._

--- a/specs/066-block-tree-mutation-and-nested-editing/quickstart.md
+++ b/specs/066-block-tree-mutation-and-nested-editing/quickstart.md
@@ -1,0 +1,239 @@
+# Quickstart: Block Tree Mutation & Nested Editing
+
+**Feature**: 066-block-tree-mutation-and-nested-editing
+**Date**: 2026-08-12
+
+End-to-end walkthrough for a client using the seven abilities together. This is the reference flow verification in [plan.md § Verification](./plan.md) is derived from.
+
+---
+
+## Scenario
+
+Build the following block tree inside an empty post using nothing but the new/enhanced abilities:
+
+```
+core/columns
+├─ core/column
+│  ├─ core/heading  ("Left column heading")
+│  └─ core/paragraph ("Left body copy")
+└─ core/column
+   └─ core/paragraph ("Right body copy")
+```
+
+Then verify the tree, duplicate a column, remove the duplicate, move a paragraph across columns, and read the final state.
+
+---
+
+## Setup
+
+Create the target post via WP-CLI (or the admin) — post ID `42` used below.
+
+```
+wp post create --post_type=post --post_status=draft --post_title="Block tree demo" --porcelain
+# → 42
+```
+
+At the start, `post_content` is empty, so `get-post-blocks` returns `blocks: []`.
+
+---
+
+## Step 1 — Insert the columns container at root
+
+```json
+Ability: acrossai/add-block
+Input:  { "post_id": 42, "parent_path": [], "index": 0,
+          "block": { "name": "core/columns" } }
+```
+
+**Expected**: `success: true`, inserted `block.path = [0]`.
+
+---
+
+## Step 2 — Insert the two columns as children of `[0]`
+
+```json
+Ability: acrossai/add-block
+Input:  { "post_id": 42, "parent_path": [0], "index": 0,
+          "block": { "name": "core/column" } }
+```
+→ `block.path = [0, 0]`
+
+```json
+Ability: acrossai/add-block
+Input:  { "post_id": 42, "parent_path": [0], "index": 1,
+          "block": { "name": "core/column" } }
+```
+→ `block.path = [0, 1]`
+
+---
+
+## Step 3 — Populate the left column
+
+```json
+Ability: acrossai/add-block
+Input:  { "post_id": 42, "parent_path": [0, 0], "index": 0,
+          "block": { "name": "core/heading",
+                     "attrs": { "level": 2, "content": "Left column heading" } } }
+```
+→ `block.path = [0, 0, 0]`
+
+```json
+Ability: acrossai/add-block
+Input:  { "post_id": 42, "parent_path": [0, 0], "index": 1,
+          "block": { "name": "core/paragraph",
+                     "attrs": { "content": "Left body copy" } } }
+```
+→ `block.path = [0, 0, 1]`
+
+---
+
+## Step 4 — Populate the right column
+
+```json
+Ability: acrossai/add-block
+Input:  { "post_id": 42, "parent_path": [0, 1], "index": 0,
+          "block": { "name": "core/paragraph",
+                     "attrs": { "content": "Right body copy" } } }
+```
+→ `block.path = [0, 1, 0]`
+
+---
+
+## Step 5 — Read the tree to verify
+
+```json
+Ability: acrossai/get-post-blocks
+Input:  { "post_id": 42 }
+```
+
+**Expected** (elided innerHTML for readability):
+
+```json
+{
+  "success": true,
+  "post_id": 42,
+  "total": 6,
+  "blocks": [
+    {
+      "name": "core/columns", "path": [0],
+      "innerBlocks": [
+        {
+          "name": "core/column", "path": [0, 0],
+          "innerBlocks": [
+            { "name": "core/heading",   "path": [0, 0, 0], "attrs": { "level": 2, "content": "Left column heading" } },
+            { "name": "core/paragraph", "path": [0, 0, 1], "attrs": { "content": "Left body copy" } }
+          ]
+        },
+        {
+          "name": "core/column", "path": [0, 1],
+          "innerBlocks": [
+            { "name": "core/paragraph", "path": [0, 1, 0], "attrs": { "content": "Right body copy" } }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+**SC-006 checkpoint**: two-column layout with 4 nested blocks built with 6 write calls + 1 read = 7 total. ✅
+
+---
+
+## Step 6 — Update a nested paragraph (nested `update-post-block`)
+
+```json
+Ability: acrossai/update-post-block
+Input:  { "post_id": 42, "path": [0, 0, 1],
+          "attributes": { "content": "Left body copy (revised)" } }
+```
+
+**Expected**: `success: true`, `block.path = [0, 0, 1]`, `block.attrs.content = "Left body copy (revised)"`. Every other block untouched (verify with a second `get-post-blocks`).
+
+---
+
+## Step 7 — Duplicate the left column
+
+```json
+Ability: acrossai/duplicate-block
+Input:  { "post_id": 42, "path": [0, 0] }
+```
+
+**Expected**: clone of the left column (including its heading + paragraph) appears at `[0, 1]`; the former right column shifts to `[0, 2]`.
+
+---
+
+## Step 8 — Remove the duplicate
+
+```json
+Ability: acrossai/remove-block
+Input:  { "post_id": 42, "path": [0, 1] }
+```
+
+**Expected**: the tree returns to its pre-duplicate shape — the right column is back at `[0, 1]`.
+
+---
+
+## Step 9 — Move the right column's paragraph into the left column
+
+```json
+Ability: acrossai/move-block
+Input:  { "post_id": 42,
+          "from_path": [0, 1, 0],
+          "to_parent_path": [0, 0], "to_index": 2 }
+```
+
+**Expected**: the paragraph appears at `[0, 0, 2]` (after the heading and the original left paragraph); the right column at `[0, 1]` is now empty.
+
+---
+
+## Step 10 — Insert a pattern into the (now empty) right column
+
+Assume a theme pattern with slug `my-theme/promo` exists.
+
+```json
+Ability: acrossai/insert-pattern
+Input:  { "post_id": 42,
+          "parent_path": [0, 1], "index": 0,
+          "slug": "my-theme/promo" }
+```
+
+**Expected**: `success: true`, `inserted_paths: [[0,1,0], [0,1,1], ...]` (one entry per block the pattern contains); `count` matches the pattern's block count.
+
+---
+
+## Step 11 — Backward-compat check on `update-post-block`
+
+Verify a pre-066 consumer call still works — pass ONLY `block_index`, no `path`:
+
+```json
+Ability: acrossai/update-post-block
+Input:  { "post_id": 42, "block_index": 0,
+          "attributes": { "align": "wide" } }
+```
+
+**Expected**: the top-level `core/columns` at `[0]` gets `attrs.align = "wide"`. Every other block untouched. This exact request shape worked before 066 and MUST continue to work identically (SC-003).
+
+---
+
+## Round-trip fidelity check (SC-004)
+
+For a canonical post (e.g. the one built above at step 5):
+
+1. `get-post-blocks` → capture tree.
+2. `update-post-block` with `path: [0]` and empty `attributes: {}` — this is a "no-op" write that goes through the full parse-serialize round-trip.
+3. Compare stored `post_content` before/after. Byte-identical for 95%+ of realistic content (known parser-normalisation edge cases excluded).
+
+---
+
+## Failure paths worth exercising manually
+
+| Scenario | Expected error_code |
+|---|---|
+| `get-post-blocks` with `post_id = 999999` | `post_not_found` |
+| `add-block` with invalid `name: "notaslug"` | `invalid_block_name` |
+| `remove-block` with `path: [0, 5, 3]` when only 2 top-level blocks exist | `invalid_path` |
+| `move-block` from `[0]` to inside `[0, 0]` (destination inside source) | `descendant_destination` |
+| `insert-pattern` with a slug that exists in both db and active theme | `multiple_locations` |
+| Any write ability called by a subscriber user | `insufficient_capability` |
+| `update-post-block` against a `revision` post ID | `post_type_forbidden` |

--- a/specs/066-block-tree-mutation-and-nested-editing/research.md
+++ b/specs/066-block-tree-mutation-and-nested-editing/research.md
@@ -1,0 +1,224 @@
+# Research: Block Tree Mutation & Nested Editing
+
+**Feature**: 066-block-tree-mutation-and-nested-editing
+**Date**: 2026-08-12
+
+Phase 0 resolves technical unknowns raised by the spec's Assumptions and by the "Constraints" line in Technical Context. Every decision is captured with a Decision / Rationale / Alternatives block.
+
+---
+
+## R1. Canonical block-path addressing scheme
+
+**Decision**: Ordered array of non-negative integers (`int[]`). `[]` denotes root; `[i]` denotes the i-th top-level block; `[i, j]` denotes the j-th child of the i-th top-level block; and so on recursively.
+
+**Rationale**:
+- Unambiguous — `[0, 10]` vs `[0, 1, 0]` cannot be confused with each other, unlike dot-string notation ("0.10" vs "0.1.0").
+- Trivial to validate — `is_array($path) && every(fn($x) => is_int($x) && $x >= 0)`.
+- Native to JSON — clients pass the array as-is; no parsing.
+- Native to PHP — `count($path)` gives depth; recursion by `$rest = array_slice($path, 1)` gives child-tree traversal.
+- Matches how JSON tools reason about nested trees.
+
+**Alternatives considered**:
+- **Dot-string ("0.2.1")**: user-friendlier at low sibling counts but breaks past 10 siblings (indexes are visually ambiguous).
+- **Name + occurrence + parent-path (hybrid)**: extends the existing `block_name + occurrence` scheme with a parent-path prefix. Backward compatibility gained is illusory — clients still learn a new input shape — and complexity is higher.
+
+**Impact on API**: All tree-mutation abilities accept a `path` input of type `array<int>`. `insert` / `insert-pattern` / `move` additionally split `path` into `parent_path` + `index` for clarity ("into this parent, at this index").
+
+---
+
+## R2. Atomicity of `move`
+
+**Decision**: Move is implemented as `remove-then-insert` on an in-memory tree copy. The `wp_update_post` write is a single atomic DB call, so callers never observe an intermediate state.
+
+**Rationale**:
+- WordPress `wp_update_post()` performs a single `UPDATE wp_posts SET post_content = ...` — either the whole new tree is persisted or nothing changes.
+- Doing remove-then-insert on a PHP array copy in-memory means the source and destination paths are computed against a consistent snapshot (before applying either mutation to the DB).
+- FR-013 requires atomicity of observable state, not atomicity of the internal PHP steps.
+
+**Alternatives considered**:
+- **Custom SQL transaction**: unnecessary — single-row `UPDATE` is already atomic at the row level; adding a transaction would only matter if we also updated a second table, which we do not.
+
+**Impact on API**: Client sees either the new tree or the pre-move tree; no interleaved state is observable.
+
+---
+
+## R3. Move-to-descendant refusal
+
+**Decision**: Refuse if the destination `parent_path` starts with the source `path`. Detect via `array_slice($destination_parent_path, 0, count($source_path)) === $source_path`.
+
+**Rationale**:
+- If a block at `[0, 1]` were moved into `[0, 1, 0]`, the moved block would become its own ancestor — a cycle that `serialize_blocks()` cannot represent and that would corrupt round-trip fidelity.
+- The check is O(depth), cheap.
+
+**Alternatives considered**:
+- **Allow and let serializer fail**: leaks a low-level parser error to callers; violates FR-005 ("clear failure messages").
+
+**Impact on API**: `move-block` fails with a clear "destination lies within source subtree" message before touching the DB.
+
+---
+
+## R4. Attribute-schema validation strategy
+
+**Decision**: For each mutating write, look up the block type via `WP_Block_Type_Registry::get_instance()->get_registered($name)` (through the existing `Block_Info::get_block()` helper). If registered and its `attributes` schema is available, validate the incoming attributes against that schema. If not registered, log at `wp_debug_log` level and proceed (soft-fail).
+
+**Rationale**:
+- Matches Constitution §V "graceful degradation" — custom or plugin-supplied blocks may not be registered on this specific site (e.g., pattern imports from other sites); refusing them all would break real workflows.
+- Matches the spec's FR-020 requirement ("degrade gracefully when the block type is not registered").
+- Rejecting on schema mismatch prevents storing invalid attribute payloads that the block editor cannot render.
+
+**Alternatives considered**:
+- **Hard-fail on unregistered blocks**: too restrictive; would refuse legitimate content.
+- **Validate only in `add-block` / `insert-pattern`**: creates inconsistent validation coverage between insert and update. Applying the check uniformly to every write is simpler and safer.
+
+**Impact on API**: Client sees a clear validation error for attribute schema mismatches; unregistered blocks pass through unchanged.
+
+---
+
+## R5. Pattern-source resolution reuse
+
+**Decision**: `Insert_Pattern` delegates slug-to-pattern resolution to whatever helper `includes/Abilities/Block/Read_Block_Pattern.php` uses today. If that helper is inline (not extracted), extract it into `includes/Abilities/Utilities/Pattern_Source_Resolver.php` as part of this feature (single-use extraction is fine when a second use materialises — matches Constitution §VI).
+
+**Rationale**:
+- Zero duplication of source-scanning logic (db `wp_block` CPT + theme `/patterns` + plugin `/patterns`).
+- The existing helper already handles the "multiple sources" ambiguity case that FR-017 requires; reusing avoids re-implementing the ambiguity detection.
+
+**Alternatives considered**:
+- **Reimplement source scan in `Insert_Pattern`**: violates DRY; risks divergence in "multiple locations" detection.
+
+**Impact on scope**: If extraction is needed, one additional utility class file. Detection happens during implementation, not now.
+
+---
+
+## R6. Round-trip fidelity of `post_content`
+
+**Decision**: All writes go through `parse_blocks(get_post()->post_content)` → mutate → `serialize_blocks($blocks)` → `wp_update_post([post_content])`. No custom serialization.
+
+**Rationale**:
+- SC-004 targets 95% byte-identical round-trip; core `parse_blocks`/`serialize_blocks` achieves this except for known parser-normalisation edge cases (whitespace inside HTML comments, empty inner content collapsing) — all outside our control.
+- Using core functions means we inherit their bug fixes and format changes for free.
+
+**Alternatives considered**:
+- **Custom serializer preserving exact byte layout**: overkill for the target; would fork WordPress core behaviour we don't own.
+
+**Impact on tests**: One integration test creates a post from a canonical fixture, reads via `Get_Post_Blocks`, writes back with `Update_Post_Block` supplying identical inputs, and asserts `post_content` is unchanged.
+
+---
+
+## R7. Backward compatibility of `Update_Post_Block`
+
+**Decision**: Add an optional `path` input to the ability's input schema. In `execute()`, resolve target block in this priority order:
+
+1. If `path` present and non-empty → use `Block_Tree::replace_at_path`.
+2. Else if `block_index` present → use existing top-level index logic (unchanged).
+3. Else if `block_name` + optional `occurrence` present → use existing name-occurrence logic (unchanged).
+4. Else → validation error identical to today's.
+
+**Rationale**:
+- Any existing consumer passing only `block_index` or `block_name` sees zero behaviour change (path is null → branch 2 or 3 runs).
+- The `path` input is optional, so consumers don't need to know it exists.
+- Extraction of the top-level index / name-occurrence resolution into `Block_Tree::resolve_top_level_index()` is optional — it can stay inline in `Update_Post_Block` if extraction adds no new caller.
+
+**Alternatives considered**:
+- **Deprecate `block_index` / `block_name` inputs**: would break SC-003. Rejected.
+- **New ability `update-block-at-path` instead of extending `update-post-block`**: proliferates near-duplicate abilities. Rejected.
+
+**Impact on tests**: New test file `Test_Update_Post_Block_Nested.php` covers the `path` branch; existing `Test_Update_Post_Block.php` (if present) continues to cover the legacy branches.
+
+---
+
+## R8. Post-type whitelist
+
+**Decision**: Reuse the exact whitelist logic from `Update_Post_Block::execute` lines 127-135. Extract into `Block_Tree::assert_post_type_editable(int $post_id): true|WP_Error` so all seven abilities share one implementation.
+
+**Rationale**:
+- Constitution §VI mandates extraction on second use — this is the seventh use.
+- Single source of truth for the internal-CPT reject list means adding a new internal CPT to the deny list touches one place, not seven.
+
+**Alternatives considered**:
+- **Inline the check in each ability**: 7× duplication. Rejected outright.
+
+**Impact on `Block_Tree`**: One additional method. No new dependencies.
+
+---
+
+## R9. Capability model uniformity
+
+**Decision**: Every write ability performs the same three checks in this order:
+
+1. Global: `current_user_can('manage_options')` AND `current_user_can('edit_posts')` (matches existing `Update_Post_Block::execute`).
+2. Post-type gate: `Block_Tree::assert_post_type_editable($post_id)`.
+3. Per-post: `current_user_can('edit_post', $post_id)`.
+
+The read ability (`Get_Post_Blocks`) performs 1 + 2, plus `current_user_can('read_post', $post_id)` in place of `edit_post`.
+
+**Rationale**:
+- FR-018 requires parity with existing `Update_Post_Block` for writes.
+- The read gate prevents leaking private-post content to callers who can `manage_options` at site level but shouldn't see all posts.
+
+**Alternatives considered**:
+- **Skip per-post cap and rely on global**: violates least privilege.
+
+**Impact on tests**: Each ability's test file asserts all three checks are present via source inspection (matching existing convention in `Test_Add_Post_Meta.php`).
+
+---
+
+## R10. Response envelope shape
+
+**Decision**: Every ability returns:
+
+```json
+{
+  "success": true,
+  "post_id": 123,
+  "<payload_key>": ...,
+  "message": "Human-readable summary"
+}
+```
+
+For `Get_Post_Blocks`: payload key is `blocks`, value is the annotated tree.
+For every write ability: payload keys include `block` (the affected block with its new path) and, where relevant, `previous_path` (e.g. for `move-block`).
+
+**Rationale**:
+- Matches existing convention in `List_Blocks` (`{ success, blocks, total, filters, message }`) and `Update_Post_Block` (`{ success, post_id, block, message }`).
+- `success: false` responses omit the payload keys and include `message` + an optional `error_code` field for machine-readable error routing.
+
+**Alternatives considered**:
+- **Throw exceptions on failure**: violates existing convention. Rejected.
+- **Envelope with `data` wrapper**: adds one level of nesting without new information. Rejected.
+
+**Impact on contracts**: `contracts/abilities.md` documents this envelope once and each ability's schema references it.
+
+---
+
+## R11. Deep-clone strategy for `duplicate-block`
+
+**Decision**: Use PHP's native array-copy semantics. Since PHP arrays are copy-on-write value types (not references), `$clone = $original` on a nested `parse_blocks` structure gives a deep copy without special handling. Regenerate any `clientId` fields if present (the block parser does not persist `clientId`, so typically none exist in the parsed tree).
+
+**Rationale**:
+- `parse_blocks()` returns arrays of arrays (with no object references) — PHP's assignment operator produces an independent copy.
+- No third-party deep-clone library needed.
+
+**Alternatives considered**:
+- **`json_decode(json_encode($block))`**: works but ~10× slower and loses `NAN`/`INF` if they appear. Rejected — plain assignment is fine.
+
+**Impact on `Block_Tree`**: `insert_at_path` accepts the clone by value; no reference concerns.
+
+---
+
+## Summary of resolved unknowns
+
+| # | Unknown | Resolution |
+|---|---|---|
+| R1 | Path scheme | `int[]` (ordered array of non-negative integers) |
+| R2 | Move atomicity | In-memory `remove-then-insert` + single `wp_update_post` |
+| R3 | Move-to-descendant guard | Prefix-match check on `parent_path` vs `source path` |
+| R4 | Attribute validation | Registry lookup; soft-fail on unregistered blocks |
+| R5 | Pattern source reuse | Delegate to existing `Read_Block_Pattern` helper; extract if needed |
+| R6 | Round-trip fidelity | Core `parse_blocks` + `serialize_blocks` — no custom serializer |
+| R7 | Backward compat | Optional `path` input; falls through to existing index/name logic |
+| R8 | Post-type whitelist | Extract from `Update_Post_Block:127-135` into `Block_Tree` |
+| R9 | Capability model | Global + post-type gate + per-post cap (edit or read) |
+| R10 | Response envelope | `{ success, post_id, <payload>, message }` — matches existing |
+| R11 | Deep clone | PHP native value-copy semantics on parsed arrays |
+
+**All NEEDS CLARIFICATION resolved. Ready for Phase 1 design.**

--- a/specs/066-block-tree-mutation-and-nested-editing/spec.md
+++ b/specs/066-block-tree-mutation-and-nested-editing/spec.md
@@ -1,0 +1,213 @@
+# Feature Specification: Block Tree Mutation & Nested Editing
+
+**Feature Branch**: `066-block-tree-mutation-and-nested-editing`
+**Created**: 2026-08-12
+**Status**: Draft
+**Input**: User description: "Add six new abilities and enhance one existing ability to give clients complete read/write control over the Gutenberg block tree inside a WordPress post, including nested blocks. Today the plugin can inspect the block registry and edit a single top-level block, but cannot read a post's block tree, insert/remove/move/duplicate blocks, or insert a pattern at a position — and existing update-post-block explicitly defers nested-block editing. Realistic block-editor content nests blocks inside containers, so this gap blocks most practical automation."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Read a post's full block tree with addressable paths (Priority: P1)
+
+A client (human operator or automation) needs a machine-readable view of every block inside a post — including nested blocks inside containers (columns, group, cover, query-loop) — with a canonical address for each block so subsequent operations can target any node unambiguously.
+
+**Why this priority**: Every write operation in this feature requires first reading the current tree to know what to target. Without this, no downstream automation is possible. This is the foundational read primitive.
+
+**Independent Test**: Create a post whose content contains a container block with two nested paragraph blocks. Invoke the read ability with that post's ID. Verify the response returns a hierarchical structure that includes every block, each annotated with a canonical path identifier (an array of zero-based child indices) that resolves to that block's position in the tree.
+
+**Acceptance Scenarios**:
+
+1. **Given** a post with a container block that contains two paragraphs, **When** the client requests the block tree for that post, **Then** the response contains the container at path `[0]` and its two children at paths `[0, 0]` and `[0, 1]`.
+2. **Given** a post whose content is empty, **When** the client requests the block tree, **Then** the response returns an empty tree and a success indicator (not an error).
+3. **Given** a post ID that does not exist, **When** the client requests the block tree, **Then** the response returns a failure indicator with a message identifying the missing post.
+
+---
+
+### User Story 2 — Insert a new block at any position in the tree (Priority: P1)
+
+A client needs to add a new block anywhere in a post — either as a top-level block or nested inside an existing container — by pointing at the parent and the desired sibling index.
+
+**Why this priority**: Insertion is the most-requested write operation for content authoring. Without nested insertion, clients cannot build realistic multi-column or container-based layouts.
+
+**Independent Test**: Read the tree of a post that contains a container with one child. Invoke the insert ability with a target parent path pointing at the container and a sibling index of 0, providing a new block payload. Re-read the tree and verify the new block appears at the expected path and the previously-existing child has shifted to the next sibling index.
+
+**Acceptance Scenarios**:
+
+1. **Given** a post with a container at path `[0]` containing one child, **When** the client inserts a new block at parent path `[0]` index `0`, **Then** the new block occupies path `[0, 0]` and the prior child moves to `[0, 1]`.
+2. **Given** a post with three top-level blocks, **When** the client inserts a new block at parent path `[]` (root) index `1`, **Then** the new block occupies path `[1]` and the tree grows to four top-level blocks.
+3. **Given** the client provides a block name that does not match the required namespace/name format, **When** the insert is attempted, **Then** the response returns a failure with a message identifying the invalid block name.
+
+---
+
+### User Story 3 — Remove a block from any position in the tree (Priority: P1)
+
+A client needs to delete a block anywhere in a post's tree — top-level or nested — by pointing at the block's canonical path.
+
+**Why this priority**: Deletion pairs with insertion as a foundational tree-mutation primitive. Without it, clients cannot correct their own inserts or clean up existing content.
+
+**Independent Test**: Read the tree of a post with nested blocks. Invoke the remove ability with a path targeting a nested child. Re-read the tree and verify only that block was removed and its parent + siblings remain intact.
+
+**Acceptance Scenarios**:
+
+1. **Given** a post with a container containing two children, **When** the client removes the block at path `[0, 0]`, **Then** the container retains one child and it is the former second child (now at `[0, 0]`).
+2. **Given** the client requests removal at a path whose parent does not exist, **When** the remove is attempted, **Then** the response returns a failure with a message identifying the invalid path.
+
+---
+
+### User Story 4 — Update block attributes and inner HTML at any nesting depth (Priority: P1)
+
+A client needs to update the attributes or inner content of a specific block at any nesting depth in a post — extending the existing top-level-only update capability to nested blocks.
+
+**Why this priority**: The existing update capability is limited to top-level blocks. Realistic content nests blocks inside containers, so the current limitation blocks most practical editing scenarios. Extending this without breaking existing consumers is a foundational parity requirement.
+
+**Independent Test**: Read the tree of a post with a nested paragraph inside a container. Invoke the update ability with the nested path and new attributes. Re-read the tree and verify only the targeted block changed; siblings and other subtrees are untouched.
+
+**Acceptance Scenarios**:
+
+1. **Given** a post with a container containing a paragraph at path `[0, 0]`, **When** the client updates that path with new attributes, **Then** the paragraph reflects the new attributes and no other block changes.
+2. **Given** an existing consumer that continues to call the update ability with only the top-level index (no path), **When** the update executes, **Then** it behaves identically to prior versions of the ability with no behavior change.
+3. **Given** the client provides attributes that fail validation against the registered block type's schema, **When** the update is attempted, **Then** the response returns a failure with a message identifying the invalid attribute.
+
+---
+
+### User Story 5 — Move a block from one position to another (Priority: P2)
+
+A client needs to reorder blocks or reparent them (move a top-level block into a container, or move a nested block out) by specifying a source path and a destination.
+
+**Why this priority**: Move rounds out the tree-mutation primitives beyond insert/remove/update. Useful for layout adjustments but not blocking initial parity — clients can achieve the same effect with remove-then-insert as a temporary workaround.
+
+**Independent Test**: Read a post's tree containing two top-level blocks. Invoke the move ability from path `[1]` to a nested position inside the first block. Re-read the tree and verify the block moved atomically (no intermediate state where it appears twice or is missing).
+
+**Acceptance Scenarios**:
+
+1. **Given** two top-level blocks, **When** the client moves the block at path `[1]` into path `[0]` at index `0`, **Then** the source position is gone and the block appears as the first child of the former top-level `[0]`.
+2. **Given** a container with three children, **When** the client moves the child at path `[0, 2]` to path `[0, 0]`, **Then** the child appears first and the other children shift down.
+
+---
+
+### User Story 6 — Duplicate a block in place (Priority: P2)
+
+A client needs to clone an existing block (with its full subtree of inner blocks) and insert the clone as the next sibling of the source, so recurring layout patterns can be reused without re-authoring.
+
+**Why this priority**: Duplication is a productivity primitive. Not blocking parity because clients could achieve the same via read + insert of the same payload.
+
+**Independent Test**: Read a post's tree containing a container with one child. Invoke the duplicate ability at path `[0]`. Re-read the tree and verify a deep clone of the container (including its child) now sits at path `[1]`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a container block with two nested children, **When** the client duplicates path `[0]`, **Then** a deep-cloned container with two nested children appears at `[1]` and the original is unchanged.
+2. **Given** a nested block at path `[0, 1]`, **When** the client duplicates it, **Then** a clone appears at `[0, 2]` and subsequent siblings shift accordingly.
+
+---
+
+### User Story 7 — Insert a saved pattern at any position (Priority: P3)
+
+A client needs to insert the contents of a saved block pattern (resolved by slug across database, active theme, and installed plugins) at any position in a post's tree, expanding the pattern into its component blocks in place.
+
+**Why this priority**: Convenience feature that composes existing capabilities (pattern resolution + tree insertion). Not blocking because clients can manually assemble the equivalent blocks via multiple insert calls.
+
+**Independent Test**: Given a known pattern slug that exists in the theme, invoke the insert-pattern ability at a target path. Re-read the tree and verify the pattern's constituent blocks appear at the target location in the same order as they exist in the pattern's definition.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pattern slug present in the active theme's patterns directory, **When** the client inserts that pattern at parent path `[0]` index `0`, **Then** the pattern's blocks appear as children of `[0]` starting at index `0`.
+2. **Given** a pattern slug that resolves in multiple sources (database + theme), **When** the client inserts without specifying a source, **Then** the response returns a failure identifying the ambiguity and the client can retry with an explicit source.
+3. **Given** a pattern slug that does not resolve in any source, **When** the client inserts, **Then** the response returns a failure identifying the unknown slug.
+
+---
+
+### Edge Cases
+
+- **Empty tree**: reading, and any attempt to address a non-empty path, on an empty tree — read succeeds; writes fail with a clear "path does not exist" message.
+- **Out-of-range sibling index**: an insert at index greater than the current sibling count — append at the end rather than fail.
+- **Classic / freeform content**: posts whose content includes `core/freeform` blocks (from the classic editor) — round-trip preserves the freeform content unchanged; reads expose it as a normal block node.
+- **Post types not compatible with the block editor**: internal post types (revisions, nav menu items, custom CSS, customize changesets, oembed cache, user requests) — all abilities refuse to operate on these post types.
+- **Unknown / unregistered block types**: a block whose type is not registered on the current site — reads still expose the block by name; attribute-schema validation degrades gracefully (warns but does not hard-fail) so writes remain possible for custom blocks.
+- **Concurrent edits**: two clients editing the same post's tree at the same time — last write wins; there is no built-in optimistic-lock. (Explicit non-goal for this feature.)
+- **Move to descendant**: a client attempting to move a block into its own subtree — refused with a failure message identifying the invalid destination.
+- **Path overflow when duplicating in a nested position**: duplicating a block whose parent list is at capacity — succeeds; there is no artificial cap on sibling count.
+- **Backward compatibility on update**: existing consumers of the update ability that pass only a top-level index (not a path) — behavior is unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Tree read**
+
+- **FR-001**: The system MUST provide an ability to return the parsed block tree of a specified post as a hierarchical structure.
+- **FR-002**: Each block in the returned tree MUST carry a canonical path identifier — an array of zero-based child indices — representing that block's position in the tree.
+- **FR-003**: The returned structure MUST expose, for each block: block name, attributes, inner HTML, and its list of inner (nested) blocks.
+
+**Canonical addressing**
+
+- **FR-004**: All tree-mutation abilities MUST accept and interpret block positions using the canonical path format: an ordered array of zero-based non-negative integers. `[]` denotes the root (top-level list); `[i]` denotes the i-th top-level block; `[i, j]` denotes the j-th child of the i-th top-level block; and so on.
+- **FR-005**: The system MUST reject any path that does not resolve to an existing block (except where the operation is defined to accept "one past the end" as an append position).
+
+**Insert**
+
+- **FR-006**: The system MUST provide an ability to insert a new block at a specified parent path and sibling index. If the sibling index equals or exceeds the current sibling count, the new block MUST be appended at the end.
+- **FR-007**: The insert ability MUST accept a block payload composed of block name, attributes, inner HTML, and (optionally) a list of inner blocks.
+- **FR-008**: The insert ability MUST validate the block name against the required namespace/name format before mutating the post.
+
+**Remove**
+
+- **FR-009**: The system MUST provide an ability to remove the block at a specified path.
+
+**Update**
+
+- **FR-010**: The existing update ability MUST accept an optional path input that identifies a block at any nesting depth.
+- **FR-011**: When the path input is present, the update ability MUST apply the requested attribute and/or inner-HTML changes only to the block at that path, leaving all other blocks untouched.
+- **FR-012**: When the path input is absent, the update ability MUST behave identically to its prior versions (using its existing top-level index or block-name + occurrence inputs) with no observable behavior change.
+
+**Move**
+
+- **FR-013**: The system MUST provide an ability to move a block from a source path to a destination (parent path + sibling index) atomically — the operation MUST NOT produce an intermediate state where the block appears twice or is missing.
+- **FR-014**: The move ability MUST refuse operations whose destination lies inside the source's own subtree, returning a failure with a clear message.
+
+**Duplicate**
+
+- **FR-015**: The system MUST provide an ability to create a deep clone of the block at a specified path (including all of its inner blocks) and insert the clone as the next sibling of the source.
+
+**Insert pattern**
+
+- **FR-016**: The system MUST provide an ability to resolve a saved block pattern by slug (across database, active theme, and installed plugins) and insert its constituent blocks at a specified parent path and sibling index.
+- **FR-017**: When a pattern slug is ambiguous across sources, the insert-pattern ability MUST refuse the operation and return a failure message identifying the ambiguity; the client MUST be able to disambiguate by specifying a source explicitly.
+
+**Cross-cutting**
+
+- **FR-018**: Every write ability (insert, remove, update, move, duplicate, insert-pattern) MUST require the caller to have the same per-post editing capability as the existing update ability, plus any additional global capability check the existing update ability enforces.
+- **FR-019**: Every write ability MUST refuse to operate on post types that are internal-only or that do not support the block editor (revisions, nav menu items, custom CSS, customize changesets, oembed cache, user requests, and any post type whose registration excludes editor UI/REST exposure).
+- **FR-020**: Every write ability MUST validate block attributes against the registered block type's schema when the block type is known; validation MUST degrade gracefully when the block type is not registered (log/warn but do not fail).
+- **FR-021**: All abilities MUST return a response shape consistent with existing abilities — a `success` flag, a payload, and a human-readable message.
+- **FR-022**: All write abilities MUST preserve round-trip fidelity of post content: reading, then writing back unchanged, MUST produce byte-identical stored content wherever the underlying parse-and-serialize round-trip permits.
+- **FR-023**: All new abilities MUST live under the existing content category and namespace already used by the current update ability.
+
+### Key Entities
+
+- **Post**: The WordPress post whose content is being read or mutated. Identified by post ID.
+- **Block**: A node in the post's content tree. Composed of: name (namespace/name), attributes (structured data), inner HTML (rendered markup), and inner blocks (ordered list of child Block nodes).
+- **Block path**: An ordered list of zero-based integers that identifies a Block's position in a Post's tree. Empty list denotes the root.
+- **Block pattern**: A named collection of blocks resolvable by slug from one of three sources — the database (reusable-block posts), the active theme's patterns directory, or an installed plugin's patterns directory.
+- **Block type**: The registered definition for a given block name — includes its expected attribute schema. Discovered at runtime from the site's block registry.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A client can read any post's full block tree, including all nesting levels, in a single call — 100% of blocks reachable by path.
+- **SC-002**: A client can perform any of the six tree-mutation operations (insert, remove, update, move, duplicate, insert-pattern) at any depth in the tree using a single canonical path input — no operation requires more than one call to affect one block.
+- **SC-003**: Existing consumers of the update ability continue to function unchanged — 100% of the prior input shapes produce byte-identical outcomes to prior versions.
+- **SC-004**: A round-trip of read → write-unchanged preserves post content byte-for-byte in at least 95% of realistic test posts (allowance for parser-normalization edge cases outside our control).
+- **SC-005**: Every write ability refuses invalid inputs (bad block name, bad path, incompatible post type) with a clear, actionable failure message before mutating any state — 0 partial writes.
+- **SC-006**: A client can build a two-column layout containing four total nested blocks from an empty post using no more than seven ability calls (1 read + 6 writes).
+
+## Assumptions
+
+- Clients speak to the plugin via the WordPress Abilities API — no new transport is introduced.
+- The post's `post_content` is either block-editor content or content already round-trippable via WordPress's core block parser. Purely-classic (unparsed) content is not a target scenario for tree mutation but MUST survive unchanged when read.
+- Registered block types on the target site accurately reflect the blocks used in real content. Where a block name is not registered (custom or removed plugin), attribute-schema validation is best-effort only.
+- Pattern-source resolution reuses whatever helper the existing read-block-pattern ability uses — no new pattern-source discovery is introduced by this feature.
+- Concurrent-write safety is out of scope for this feature; last-write-wins is acceptable and matches existing WordPress editing behavior.
+- No user interface changes are required for this feature — abilities are consumed by clients (Abilities API), not by admin screens.
+- Registration of new block types programmatically is explicitly out of scope; block-type authoring remains a plugin-code concern.
+- Classic (freeform) block content transformation beyond passthrough (preserving it round-trip) is explicitly out of scope.

--- a/specs/066-block-tree-mutation-and-nested-editing/tasks.md
+++ b/specs/066-block-tree-mutation-and-nested-editing/tasks.md
@@ -1,0 +1,335 @@
+---
+
+description: "Task list for Feature 066 — Block Tree Mutation & Nested Editing"
+---
+
+# Tasks: Block Tree Mutation & Nested Editing
+
+**Input**: Design documents from `/specs/066-block-tree-mutation-and-nested-editing/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/abilities.md](./contracts/abilities.md), [quickstart.md](./quickstart.md)
+
+**Tests**: Included per feature spec — plan.md § VII Definition of Done requires per-ability PHPUnit tests, and quickstart.md drives an end-to-end integration test.
+
+**Organization**: Tasks are grouped by user story (US1–US7) to enable independent implementation and testing. US1–US4 are P1 (blocking parity), US5–US6 are P2 (round-out tree ops), US7 is P3 (pattern insertion).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US7)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+WordPress plugin single-project layout (from plan.md § Project Structure):
+
+- **Source**: `includes/Abilities/` (ability classes), `includes/Abilities/Utilities/` (shared helpers), `includes/Abilities/Content/` (this feature's ability classes)
+- **Tests**: `tests/phpunit/abilities/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm feature branch, verify tooling, no code changes.
+
+- [ ] T001 Verify current branch is `066-block-tree-mutation-and-nested-editing` and working tree is clean
+- [ ] T002 Verify `composer install` succeeds and `composer phpcs`, `composer phpstan`, `composer test` all pass on `main` merged into the branch (baseline green)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the shared `Block_Tree` utility and extract shared guards from `Update_Post_Block`. Every user story depends on this.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T003 [P] Create `includes/Abilities/Utilities/Block_Tree.php` skeleton (namespace, class declaration, PHP 8.1+ typed methods stubs matching data-model.md § Block path operations)
+- [ ] T004 Implement `Block_Tree::validate_block_name(string $name): bool` in `includes/Abilities/Utilities/Block_Tree.php` — extract regex from `includes/Abilities/Content/Update_Post_Block.php:160`
+- [ ] T005 Implement `Block_Tree::assert_post_type_editable(int $post_id): true|WP_Error` in `includes/Abilities/Utilities/Block_Tree.php` — extract post-type whitelist from `includes/Abilities/Content/Update_Post_Block.php:127-135`
+- [ ] T006 Implement `Block_Tree::parse_post_blocks(int $post_id): array|WP_Error` in `includes/Abilities/Utilities/Block_Tree.php` — wraps `parse_blocks(get_post()->post_content)` with post-existence + capability guards from `Update_Post_Block::execute:112-121`
+- [ ] T007 Implement pure tree primitives in `includes/Abilities/Utilities/Block_Tree.php`: `walk_tree`, `get_at_path`, `insert_at_path`, `remove_at_path`, `replace_at_path`, `annotate_with_paths` (all pure, no IO — see data-model.md § Block path operations)
+- [ ] T008 Implement `Block_Tree::move(array &$blocks, array $from, array $to_parent, int $to_index): true|WP_Error` in `includes/Abilities/Utilities/Block_Tree.php` — atomic remove-then-insert on in-memory copy with descendant-guard from research.md R3
+- [ ] T009 Implement `Block_Tree::validate_attributes_against_schema(string $block_name, array $attrs): true|WP_Error` in `includes/Abilities/Utilities/Block_Tree.php` — uses `Block_Info::get_block()` from `includes/Abilities/Utilities/Block_Info.php:56`; soft-fail on unregistered types per research.md R4
+- [ ] T010 [P] Create PHPUnit test `tests/phpunit/abilities/Test_Block_Tree.php` covering all primitives — walk, get, insert (including append-at-end), remove, replace, move (including descendant-guard failure), annotate_with_paths, validate_block_name (positive + negative), assert_post_type_editable (all forbidden CPTs + one editable)
+- [ ] T011 Verify `composer phpstan` and `composer phpcs` pass on the new `Block_Tree.php` and `Test_Block_Tree.php`
+
+**Checkpoint**: `Block_Tree` utility ready — user story implementation can now begin in parallel.
+
+---
+
+## Phase 3: User Story 1 — Read post's block tree with paths (Priority: P1) 🎯 MVP
+
+**Goal**: Deliver `acrossai/get-post-blocks` — the foundational read primitive every write ability depends on.
+
+**Independent Test**: Create a post with `<!-- wp:columns --><!-- wp:column --><!-- wp:paragraph -->Left<!-- /wp:paragraph --><!-- wp:paragraph -->Also left<!-- /wp:paragraph --><!-- /wp:column --><!-- /wp:columns -->` in `post_content`. Invoke `acrossai/get-post-blocks` with that post's ID. Verify response contains the columns block at path `[0]`, the column at `[0, 0]`, and both paragraphs at `[0, 0, 0]` and `[0, 0, 1]`.
+
+### Tests for User Story 1
+
+- [ ] T012 [P] [US1] Create `tests/phpunit/abilities/Test_Get_Post_Blocks.php` — source-inspection tests matching `Test_Add_Post_Meta.php` pattern (registration, category `acrossai-abilities-manager-content`, schema shape per contracts/abilities.md § 1, permission structure)
+- [ ] T013 [P] [US1] Add integration test in `Test_Get_Post_Blocks.php` — creates a nested-block fixture post via `factory->post->create_and_get()` and asserts every returned block has a correct `path` integer array
+
+### Implementation for User Story 1
+
+- [ ] T014 [US1] Create `includes/Abilities/Content/Get_Post_Blocks.php` — extends `Ability_Definition`, registers `acrossai/get-post-blocks` under `acrossai-abilities-manager-content` category, input/output schema per contracts/abilities.md § 1
+- [ ] T015 [US1] Implement `Get_Post_Blocks::execute($input)` — calls `Block_Tree::parse_post_blocks` + `Block_Tree::annotate_with_paths`, uses `read_post` capability (not `edit_post` — read-only per research.md R9), returns response envelope per contracts/abilities.md
+- [ ] T016 [US1] Register `Get_Post_Blocks` in `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php` alongside existing content abilities
+- [ ] T017 [US1] Run `composer test -- --filter=Test_Get_Post_Blocks` and verify all cases pass
+
+**Checkpoint**: `get-post-blocks` fully functional — SC-001 achievable (100% blocks reachable by path).
+
+---
+
+## Phase 4: User Story 2 — Insert a new block at any position (Priority: P1)
+
+**Goal**: Deliver `acrossai/add-block` — the primary write primitive for content authoring.
+
+**Independent Test**: Given a post with a container at `[0]` containing one child, invoke `acrossai/add-block` with `parent_path=[0], index=0, block={name: "core/paragraph", attrs: {content: "test"}}`. Re-read via `get-post-blocks` and verify the new paragraph is at `[0, 0]` and the prior child moved to `[0, 1]`.
+
+### Tests for User Story 2
+
+- [ ] T018 [P] [US2] Create `tests/phpunit/abilities/Test_Add_Block.php` — source-inspection tests (registration, schema per contracts/abilities.md § 2, capability calls present)
+- [ ] T019 [P] [US2] Add integration tests in `Test_Add_Block.php`: (a) insert at root, (b) insert nested, (c) append when index >= sibling count, (d) fail on `invalid_block_name`, (e) fail on `invalid_path`, (f) fail on `invalid_attributes`
+
+### Implementation for User Story 2
+
+- [ ] T020 [US2] Create `includes/Abilities/Content/Add_Block.php` — extends `Ability_Definition`, registers `acrossai/add-block`, input/output schema per contracts/abilities.md § 2
+- [ ] T021 [US2] Implement `Add_Block::execute($input)` — parses tree via `Block_Tree`, validates block name + attributes, calls `Block_Tree::insert_at_path`, serializes and writes via `wp_update_post`, returns response with the inserted block's new `path`
+- [ ] T022 [US2] Register `Add_Block` in `AcrossAI_Core_Abilities_Bootstrap.php`
+- [ ] T023 [US2] Run `composer test -- --filter=Test_Add_Block` — all cases pass
+
+**Checkpoint**: `add-block` fully functional — combined with US1 this enables read + insert workflows.
+
+---
+
+## Phase 5: User Story 3 — Remove a block from any position (Priority: P1)
+
+**Goal**: Deliver `acrossai/remove-block` — the destroy primitive.
+
+**Independent Test**: Given a post with a container containing two children, invoke `acrossai/remove-block` with `path=[0, 0]`. Re-read and verify the container has one child (the former second child, now at `[0, 0]`).
+
+### Tests for User Story 3
+
+- [ ] T024 [P] [US3] Create `tests/phpunit/abilities/Test_Remove_Block.php` — source-inspection tests (registration, schema per contracts/abilities.md § 3, capabilities)
+- [ ] T025 [P] [US3] Integration tests: (a) remove nested child, (b) remove top-level, (c) fail on `invalid_path` (empty path or non-resolvable), (d) response includes the removed block payload
+
+### Implementation for User Story 3
+
+- [ ] T026 [US3] Create `includes/Abilities/Content/Remove_Block.php` — extends `Ability_Definition`, input/output schema per contracts/abilities.md § 3
+- [ ] T027 [US3] Implement `Remove_Block::execute($input)` — parse tree, call `Block_Tree::remove_at_path`, serialize + write, return removed block in response
+- [ ] T028 [US3] Register `Remove_Block` in `AcrossAI_Core_Abilities_Bootstrap.php`
+- [ ] T029 [US3] Run `composer test -- --filter=Test_Remove_Block` — all cases pass
+
+**Checkpoint**: US1 + US2 + US3 = read + insert + remove — clients can author basic content.
+
+---
+
+## Phase 6: User Story 4 — Update at any nesting depth (Priority: P1)
+
+**Goal**: Extend `acrossai/update-post-block` to accept the canonical `path` input, preserving full backward compatibility with existing `block_index` / `block_name`+`occurrence` inputs.
+
+**Independent Test**: Given a post with a paragraph at `[0, 0, 0]`, invoke `update-post-block` with `path=[0, 0, 0]` and new attributes. Re-read and verify only that block changed. Also verify a legacy call `{ post_id, block_index: 0, attributes }` behaves identically to the pre-066 version (no path, no behaviour change).
+
+### Tests for User Story 4
+
+- [ ] T030 [P] [US4] Create `tests/phpunit/abilities/Test_Update_Post_Block_Nested.php` — covers the new `path` branch only (existing `Test_Update_Post_Block.php` — if present — remains untouched to protect the legacy branches)
+- [ ] T031 [P] [US4] Integration tests: (a) nested update via `path` succeeds, (b) legacy `block_index` call still works byte-identical to pre-066 (SC-003), (c) legacy `block_name` + `occurrence` call still works, (d) `path` + `block_index` together — path takes priority per research.md R7, (e) `invalid_path` error, (f) `invalid_attributes` error
+
+### Implementation for User Story 4
+
+- [ ] T032 [US4] Modify `includes/Abilities/Content/Update_Post_Block.php` — add optional `path` input to input schema per contracts/abilities.md § 4
+- [ ] T033 [US4] Modify `Update_Post_Block::execute` — insert path-resolution branch per research.md R7 priority (path → block_index → block_name+occurrence), delegate to `Block_Tree::replace_at_path` when path is present, keep existing branches unchanged
+- [ ] T034 [US4] Remove the top-level-only comment at `includes/Abilities/Content/Update_Post_Block.php:23-24`
+- [ ] T035 [US4] Replace the inline block-name regex at `Update_Post_Block:160` with a call to `Block_Tree::validate_block_name`
+- [ ] T036 [US4] Replace the inline post-type whitelist at `Update_Post_Block:127-135` with a call to `Block_Tree::assert_post_type_editable`
+- [ ] T037 [US4] Run `composer test -- --filter='Test_Update_Post_Block'` — nested + legacy suites both pass
+
+**Checkpoint**: All P1 user stories (US1–US4) complete — feature reaches parity for read + insert + remove + nested update. This is the recommended MVP scope for a first PR increment if scope needs to be split.
+
+---
+
+## Phase 7: User Story 5 — Move a block (Priority: P2)
+
+**Goal**: Deliver `acrossai/move-block` — reorder or reparent atomically.
+
+**Independent Test**: Given two top-level blocks, invoke `move-block` from `[1]` into `[0]` at index `0`. Verify source is gone and the block is now first child of former `[0]`.
+
+### Tests for User Story 5
+
+- [ ] T038 [P] [US5] Create `tests/phpunit/abilities/Test_Move_Block.php` — source-inspection tests (registration, schema per contracts/abilities.md § 5)
+- [ ] T039 [P] [US5] Integration tests: (a) reparent top-level → nested, (b) reorder within same parent, (c) fail on `descendant_destination` (move into own subtree), (d) fail on `invalid_path` / `invalid_destination`, (e) atomicity — after failed move the tree is unchanged
+
+### Implementation for User Story 5
+
+- [ ] T040 [US5] Create `includes/Abilities/Content/Move_Block.php` — extends `Ability_Definition`, input/output schema per contracts/abilities.md § 5
+- [ ] T041 [US5] Implement `Move_Block::execute($input)` — parse tree, call `Block_Tree::move` (which handles descendant-guard + atomic remove-then-insert), serialize + write, return response with new `block.path` and `previous_path`
+- [ ] T042 [US5] Register `Move_Block` in `AcrossAI_Core_Abilities_Bootstrap.php`
+- [ ] T043 [US5] Run `composer test -- --filter=Test_Move_Block` — all cases pass
+
+**Checkpoint**: US1–US5 complete.
+
+---
+
+## Phase 8: User Story 6 — Duplicate a block (Priority: P2)
+
+**Goal**: Deliver `acrossai/duplicate-block` — deep-clone in place.
+
+**Independent Test**: Given a container with 2 nested children, invoke `duplicate-block` at `[0]`. Verify a deep clone appears at `[1]` with 2 nested children of its own, and the original is unchanged.
+
+### Tests for User Story 6
+
+- [ ] T044 [P] [US6] Create `tests/phpunit/abilities/Test_Duplicate_Block.php` — source-inspection tests (registration, schema per contracts/abilities.md § 6)
+- [ ] T045 [P] [US6] Integration tests: (a) duplicate top-level with nested children, (b) duplicate nested block, (c) clone is a true deep copy (mutating one does not affect the other), (d) fail on `invalid_path`
+
+### Implementation for User Story 6
+
+- [ ] T046 [US6] Create `includes/Abilities/Content/Duplicate_Block.php` — extends `Ability_Definition`, input/output schema per contracts/abilities.md § 6
+- [ ] T047 [US6] Implement `Duplicate_Block::execute($input)` — parse tree, use `Block_Tree::get_at_path` to fetch the source block (PHP value-copy semantics per research.md R11 give a deep copy for free), compute next-sibling insert path, call `Block_Tree::insert_at_path`, serialize + write, return the cloned block with its new path
+- [ ] T048 [US6] Register `Duplicate_Block` in `AcrossAI_Core_Abilities_Bootstrap.php`
+- [ ] T049 [US6] Run `composer test -- --filter=Test_Duplicate_Block` — all cases pass
+
+**Checkpoint**: All P1 + P2 stories complete — feature ships as MVP+ if P3 is deferred to a follow-up.
+
+---
+
+## Phase 9: User Story 7 — Insert a saved pattern at any position (Priority: P3)
+
+**Goal**: Deliver `acrossai/insert-pattern` — resolve pattern by slug and expand into blocks at a target position.
+
+**Independent Test**: Given a known pattern slug in the active theme, invoke `insert-pattern` at `parent_path=[0], index=0, slug="<known>"`. Verify the pattern's constituent blocks appear at that location in order, with all their nested content intact.
+
+### Tests for User Story 7
+
+- [ ] T050 [P] [US7] Create `tests/phpunit/abilities/Test_Insert_Pattern.php` — source-inspection tests (registration, schema per contracts/abilities.md § 7)
+- [ ] T051 [P] [US7] Integration tests: (a) resolve unambiguous slug from theme, (b) resolve db slug, (c) fail on `pattern_not_found`, (d) fail on `multiple_locations` when slug exists in multiple sources without `source` disambiguation, (e) explicit `source` disambiguation succeeds, (f) `inserted_paths` array is correct and count matches pattern block count
+
+### Implementation for User Story 7
+
+- [ ] T052 [US7] Audit `includes/Abilities/Block/Read_Block_Pattern.php` for its pattern-source resolution helper — if inline, extract into `includes/Abilities/Utilities/Pattern_Source_Resolver.php` per research.md R5
+- [ ] T053 [US7] Create `includes/Abilities/Content/Insert_Pattern.php` — extends `Ability_Definition`, input/output schema per contracts/abilities.md § 7
+- [ ] T054 [US7] Implement `Insert_Pattern::execute($input)` — delegates slug resolution to the shared `Pattern_Source_Resolver` (returning `multiple_locations` when ambiguous), parses the pattern's block content via `parse_blocks`, iterates and calls `Block_Tree::insert_at_path` for each block in order, tracks `inserted_paths`, serializes + writes, returns response per contracts/abilities.md
+- [ ] T055 [US7] Register `Insert_Pattern` in `AcrossAI_Core_Abilities_Bootstrap.php`
+- [ ] T056 [US7] Run `composer test -- --filter=Test_Insert_Pattern` — all cases pass
+
+**Checkpoint**: All 7 user stories complete. Every FR-### from spec.md is now covered.
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify end-to-end quickstart, run full test + static-analysis + Plugin Check suites, tighten any rough edges surfaced during story implementation.
+
+- [ ] T057 [P] Execute `specs/066-block-tree-mutation-and-nested-editing/quickstart.md` end-to-end against a live WP install: 11-step walkthrough building the columns → column → heading/paragraph tree, updating, duplicating, removing, moving, inserting a pattern
+- [ ] T058 [P] Run full test suite: `composer test` — 0 failures
+- [ ] T059 [P] Run static analysis: `composer phpstan` — 0 errors at level 8
+- [ ] T060 [P] Run linting: `composer phpcs` — 0 errors WPCS strict
+- [ ] T061 [P] Run WordPress Plugin Check against the built plugin — 0 errors per Constitution §II
+- [ ] T062 Round-trip fidelity spot-check (SC-004): pick 3 realistic posts (article with images, columns layout, mixed classic+block content), call `get-post-blocks` then `update-post-block` with `path=[0], attributes={}` (no-op write), diff stored `post_content` — 95%+ byte-identical
+- [ ] T063 Verify backward-compat (SC-003): capture a request/response transcript of an existing `update-post-block` call using only `block_index` from before 066, replay on the branch, confirm byte-identical response
+- [ ] T064 Update `readme.txt` "Changelog" section with a summary of the 6 new abilities + `update-post-block` nested enhancement (do NOT reference external product names per project convention)
+- [ ] T065 Update `CHANGELOG.md` (if present) with the same summary
+- [ ] T066 Bump plugin version in `acrossai-abilities-manager.php` header (next patch/minor per prior release cadence — current version at 064's release was 0.0.23)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)** — no dependencies; run first
+- **Phase 2 (Foundational)** — depends on Phase 1; **BLOCKS all user stories** because every story consumes `Block_Tree`
+- **Phase 3 (US1 — Read)** — depends on Phase 2 only
+- **Phase 4 (US2 — Add)** — depends on Phase 2 only; may reference US1 (`get-post-blocks`) in tests but is not blocked by it
+- **Phase 5 (US3 — Remove)** — depends on Phase 2 only
+- **Phase 6 (US4 — Update nested)** — depends on Phase 2 only
+- **Phase 7 (US5 — Move)** — depends on Phase 2 only
+- **Phase 8 (US6 — Duplicate)** — depends on Phase 2 only
+- **Phase 9 (US7 — Insert pattern)** — depends on Phase 2 only; also depends on the pattern-source resolver in `Read_Block_Pattern` (T052 audit)
+- **Phase 10 (Polish)** — depends on all in-scope user story phases
+
+### Within Each User Story
+
+- Tests + implementation for that story live in that story's phase only
+- Bootstrap registration (`AcrossAI_Core_Abilities_Bootstrap.php`) is touched once per story — those tasks are inherently sequential across stories (same file)
+- Run that story's test filter (`composer test --filter=Test_<Ability>`) as the final task of each story
+
+### Parallel Opportunities
+
+- All Phase 2 tasks marked [P] can run in parallel (T003, T010 — different files)
+- **All 7 user story phases can run in parallel** once Phase 2 completes (if you have the capacity) — each touches its own file
+  - Different developers can each pick a story
+  - Or one developer can process them sequentially US1 → US7
+- Within each story, the `[P]` test-authoring tasks (T012+T013, T018+T019, etc.) run in parallel with the implementation tasks in the same phase
+- All Phase 10 polish tasks marked [P] run in parallel
+
+### File-conflict serialisation
+
+The only shared file is `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php` — six tasks touch it (T016, T022, T028, T042, T048, T055). Serialise those or merge into a single "register all 6" task if implementing in one pass.
+
+---
+
+## Parallel Example: User Story 1 kickoff
+
+```bash
+# Once Phase 2 is complete, in parallel:
+Task T012: Author tests/phpunit/abilities/Test_Get_Post_Blocks.php (source-inspection)
+Task T013: Add integration test for path annotation in same file
+
+# Simultaneously (different file):
+Task T014: Create includes/Abilities/Content/Get_Post_Blocks.php with schema
+# then serialise into it:
+Task T015: Implement Get_Post_Blocks::execute
+```
+
+## Parallel Example: Cross-story fan-out
+
+```bash
+# After Phase 2 checkpoint, spin up 6 workstreams:
+Developer A: Phase 3 (US1)  — Get_Post_Blocks
+Developer B: Phase 4 (US2)  — Add_Block
+Developer C: Phase 5 (US3)  — Remove_Block
+Developer D: Phase 6 (US4)  — Update_Post_Block nested
+Developer E: Phase 7 (US5)  — Move_Block
+Developer F: Phase 8 (US6)  — Duplicate_Block
+# US7 (Insert_Pattern) can join once T052 audit clears
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (P1 stories only — US1 through US4)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (`Block_Tree` utility) — **CRITICAL blocking phase**
+3. Complete Phases 3–6 in any order (US1, US2, US3, US4) — recommended sequence US1 → US2 → US3 → US4 so integration tests build on each other
+4. **STOP and VALIDATE**: run through quickstart.md Steps 1–6 + Step 11 (backward-compat check). Ship as an MVP PR if scope needs to be split.
+
+### Incremental Delivery — full feature in one PR (recommended per plan.md handoff)
+
+1. Setup + Foundational
+2. Add US1 → validate
+3. Add US2 → validate
+4. Add US3 → validate
+5. Add US4 → validate (all P1 done)
+6. Add US5, US6 → validate (P2 done)
+7. Add US7 → validate (P3 done)
+8. Polish phase 10
+9. Open PR against `main`
+
+### Parallel Team Strategy
+
+- Complete Setup + Foundational together (1–2 developers on `Block_Tree`)
+- Fan out US1–US7 to 6+ developers post-checkpoint (one story per developer)
+- Merge to feature branch as each story lands
+- Polish phase runs last with all developers converging
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [US#] label maps every user-story-phase task to its spec.md story for traceability
+- `AcrossAI_Core_Abilities_Bootstrap.php` is the one shared write across stories — merge those touches or serialise
+- Tests in this feature use the existing source-inspection pattern (`Test_Add_Post_Meta.php` as the reference) plus real-post integration tests via `WP_UnitTestCase` + `factory->post->create_and_get()`
+- Every story ends with `composer test --filter=<story-test>` — do not proceed until it's green
+- Commit after each task or logical group; the `after_*` extension hooks in `.specify/extensions.yml` will offer auto-commits
+- Avoid: touching multiple abilities in a single task, cross-story dependencies that break independence, custom SQL (use `wp_update_post` only)

--- a/tests/phpunit/abilities/Test_Add_Block.php
+++ b/tests/phpunit/abilities/Test_Add_Block.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Feature 066 — source-inspection tests for acrossai/add-block.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Add_Block extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Content/Add_Block.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/add-block'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-content'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_validates_block_name_before_persisting(): void {
+		$this->assertStringContainsString( 'Block_Tree::validate_block_name(', $this->src );
+		$this->assertStringContainsString( "'invalid_block_name'", $this->src );
+	}
+
+	public function test_validates_attributes_against_schema(): void {
+		$this->assertStringContainsString( 'Block_Tree::validate_attributes_against_schema(', $this->src );
+	}
+
+	public function test_delegates_to_block_tree_insert(): void {
+		$this->assertStringContainsString( 'Block_Tree::insert_at_path(', $this->src );
+	}
+
+	public function test_persists_via_wp_update_post(): void {
+		$this->assertStringContainsString( 'wp_update_post(', $this->src );
+		$this->assertStringContainsString( 'serialize_blocks(', $this->src );
+	}
+
+	public function test_input_schema_requires_all_five_fields(): void {
+		$this->assertStringContainsString(
+			"'required'             => array( 'post_id', 'parent_path', 'index', 'block' )",
+			$this->src
+		);
+	}
+
+	public function test_response_includes_new_path(): void {
+		$this->assertStringContainsString( "\$inserted['path']", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Block_Tree.php
+++ b/tests/phpunit/abilities/Test_Block_Tree.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Feature 066 — behavioural tests for the shared Block_Tree utility.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Block_Tree;
+use WP_UnitTestCase;
+use WP_Error;
+
+/**
+ * Behavioural coverage for every Block_Tree primitive.
+ */
+class Test_Block_Tree extends WP_UnitTestCase {
+
+	/**
+	 * Build a canonical fixture:
+	 *   [0] core/columns
+	 *     [0, 0] core/column
+	 *       [0, 0, 0] core/heading  (content: "H")
+	 *       [0, 0, 1] core/paragraph (content: "P1")
+	 *     [0, 1] core/column
+	 *       [0, 1, 0] core/paragraph (content: "P2")
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function fixture(): array {
+		$leaf = static function ( string $name, array $attrs ): array {
+			return array(
+				'blockName'    => $name,
+				'attrs'        => $attrs,
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			);
+		};
+		$col_a = array(
+			'blockName'    => 'core/column',
+			'attrs'        => array(),
+			'innerBlocks'  => array(
+				$leaf( 'core/heading', array( 'content' => 'H' ) ),
+				$leaf( 'core/paragraph', array( 'content' => 'P1' ) ),
+			),
+			'innerHTML'    => '',
+			'innerContent' => array( null, null ),
+		);
+		$col_b = array(
+			'blockName'    => 'core/column',
+			'attrs'        => array(),
+			'innerBlocks'  => array(
+				$leaf( 'core/paragraph', array( 'content' => 'P2' ) ),
+			),
+			'innerHTML'    => '',
+			'innerContent' => array( null ),
+		);
+		return array(
+			array(
+				'blockName'    => 'core/columns',
+				'attrs'        => array(),
+				'innerBlocks'  => array( $col_a, $col_b ),
+				'innerHTML'    => '',
+				'innerContent' => array( null, null ),
+			),
+		);
+	}
+
+	public function test_validate_block_name_accepts_canonical_shape(): void {
+		$this->assertTrue( Block_Tree::validate_block_name( 'core/paragraph' ) );
+		$this->assertTrue( Block_Tree::validate_block_name( 'my-plugin/some-block' ) );
+		$this->assertTrue( Block_Tree::validate_block_name( 'ns_1/block_1' ) );
+	}
+
+	public function test_validate_block_name_rejects_invalid(): void {
+		$this->assertFalse( Block_Tree::validate_block_name( '' ) );
+		$this->assertFalse( Block_Tree::validate_block_name( 'notaslug' ) );
+		$this->assertFalse( Block_Tree::validate_block_name( 'core/' ) );
+		$this->assertFalse( Block_Tree::validate_block_name( '/paragraph' ) );
+		$this->assertFalse( Block_Tree::validate_block_name( 'core/para graph' ) );
+	}
+
+	public function test_get_at_path_returns_expected_nodes(): void {
+		$blocks = $this->fixture();
+		$root   = Block_Tree::get_at_path( $blocks, array( 0 ) );
+		$this->assertIsArray( $root );
+		$this->assertSame( 'core/columns', $root['blockName'] );
+
+		$para = Block_Tree::get_at_path( $blocks, array( 0, 0, 1 ) );
+		$this->assertIsArray( $para );
+		$this->assertSame( 'core/paragraph', $para['blockName'] );
+		$this->assertSame( 'P1', $para['attrs']['content'] );
+	}
+
+	public function test_get_at_path_returns_null_for_invalid(): void {
+		$blocks = $this->fixture();
+		$this->assertNull( Block_Tree::get_at_path( $blocks, array() ) );
+		$this->assertNull( Block_Tree::get_at_path( $blocks, array( 5 ) ) );
+		$this->assertNull( Block_Tree::get_at_path( $blocks, array( 0, 9, 0 ) ) );
+	}
+
+	public function test_annotate_with_paths_populates_every_node(): void {
+		$annotated = Block_Tree::annotate_with_paths( $this->fixture() );
+		$this->assertSame( array( 0 ), $annotated[0]['path'] );
+		$this->assertSame( array( 0, 0 ), $annotated[0]['innerBlocks'][0]['path'] );
+		$this->assertSame( array( 0, 0, 1 ), $annotated[0]['innerBlocks'][0]['innerBlocks'][1]['path'] );
+		$this->assertSame( array( 0, 1, 0 ), $annotated[0]['innerBlocks'][1]['innerBlocks'][0]['path'] );
+	}
+
+	public function test_insert_at_root_shifts_siblings(): void {
+		$blocks = $this->fixture();
+		$new    = array( 'blockName' => 'core/heading', 'attrs' => array( 'content' => 'Top' ) );
+		$this->assertTrue( Block_Tree::insert_at_path( $blocks, array(), 0, $new ) );
+		$this->assertCount( 2, $blocks );
+		$this->assertSame( 'core/heading', $blocks[0]['blockName'] );
+		$this->assertSame( 'core/columns', $blocks[1]['blockName'] );
+	}
+
+	public function test_insert_nested_appends_when_index_exceeds_count(): void {
+		$blocks = $this->fixture();
+		$new    = array( 'blockName' => 'core/paragraph', 'attrs' => array( 'content' => 'appended' ) );
+		$this->assertTrue( Block_Tree::insert_at_path( $blocks, array( 0, 0 ), 999, $new ) );
+		$children = $blocks[0]['innerBlocks'][0]['innerBlocks'];
+		$this->assertCount( 3, $children );
+		$this->assertSame( 'appended', $children[2]['attrs']['content'] );
+	}
+
+	public function test_insert_returns_false_for_invalid_parent_path(): void {
+		$blocks = $this->fixture();
+		$new    = array( 'blockName' => 'core/paragraph', 'attrs' => array() );
+		$this->assertFalse( Block_Tree::insert_at_path( $blocks, array( 9 ), 0, $new ) );
+	}
+
+	public function test_remove_returns_removed_node_and_shifts_siblings(): void {
+		$blocks  = $this->fixture();
+		$removed = Block_Tree::remove_at_path( $blocks, array( 0, 0, 0 ) );
+		$this->assertIsArray( $removed );
+		$this->assertSame( 'core/heading', $removed['blockName'] );
+		$this->assertCount( 1, $blocks[0]['innerBlocks'][0]['innerBlocks'] );
+		$this->assertSame( 'core/paragraph', $blocks[0]['innerBlocks'][0]['innerBlocks'][0]['blockName'] );
+	}
+
+	public function test_remove_returns_null_for_invalid_path(): void {
+		$blocks = $this->fixture();
+		$this->assertNull( Block_Tree::remove_at_path( $blocks, array() ) );
+		$this->assertNull( Block_Tree::remove_at_path( $blocks, array( 0, 9 ) ) );
+	}
+
+	public function test_replace_swaps_block_in_place(): void {
+		$blocks     = $this->fixture();
+		$replacement = array( 'blockName' => 'core/heading', 'attrs' => array( 'content' => 'REPLACED' ) );
+		$this->assertTrue( Block_Tree::replace_at_path( $blocks, array( 0, 0, 1 ), $replacement ) );
+		$this->assertSame( 'core/heading', $blocks[0]['innerBlocks'][0]['innerBlocks'][1]['blockName'] );
+		$this->assertSame( 'REPLACED', $blocks[0]['innerBlocks'][0]['innerBlocks'][1]['attrs']['content'] );
+	}
+
+	public function test_replace_returns_false_for_invalid_path(): void {
+		$blocks = $this->fixture();
+		$this->assertFalse( Block_Tree::replace_at_path( $blocks, array(), array( 'blockName' => 'core/paragraph' ) ) );
+		$this->assertFalse( Block_Tree::replace_at_path( $blocks, array( 9 ), array( 'blockName' => 'core/paragraph' ) ) );
+	}
+
+	public function test_move_reparents_atomically(): void {
+		$blocks = $this->fixture();
+		$result = Block_Tree::move( $blocks, array( 0, 1, 0 ), array( 0, 0 ), 0 );
+		$this->assertTrue( $result );
+		// The paragraph moved from column B into column A at index 0.
+		$this->assertSame( 'core/paragraph', $blocks[0]['innerBlocks'][0]['innerBlocks'][0]['blockName'] );
+		$this->assertSame( 'P2', $blocks[0]['innerBlocks'][0]['innerBlocks'][0]['attrs']['content'] );
+		// Column B is now empty.
+		$this->assertCount( 0, $blocks[0]['innerBlocks'][1]['innerBlocks'] );
+	}
+
+	public function test_move_refuses_descendant_destination(): void {
+		$blocks = $this->fixture();
+		$result = Block_Tree::move( $blocks, array( 0 ), array( 0, 0 ), 0 );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'descendant_destination', $result->get_error_code() );
+	}
+
+	public function test_move_refuses_empty_source(): void {
+		$blocks = $this->fixture();
+		$result = Block_Tree::move( $blocks, array(), array( 0 ), 0 );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_path', $result->get_error_code() );
+	}
+
+	public function test_move_within_same_parent_adjusts_index(): void {
+		// Move column B [0,1] to [0], index 0 within same parent [0].
+		$blocks = $this->fixture();
+		$result = Block_Tree::move( $blocks, array( 0, 1 ), array( 0 ), 0 );
+		$this->assertTrue( $result );
+		// Column B is now first child of columns; former col A is second.
+		$this->assertSame( 'P2', $blocks[0]['innerBlocks'][0]['innerBlocks'][0]['attrs']['content'] );
+		$this->assertSame( 'H', $blocks[0]['innerBlocks'][1]['innerBlocks'][0]['attrs']['content'] );
+	}
+
+	// ------------------------------------------------------------------
+	// Source-inspection coverage for IO-adjacent methods (parse_post_blocks,
+	// assert_post_type_editable). These cannot be exercised behaviourally
+	// under the unit-only bootstrap (no factory/no real WP env) so we assert
+	// the code structure — matching the convention established by
+	// Test_Add_Post_Meta and other content-ability tests.
+	// ------------------------------------------------------------------
+
+	/**
+	 * The Block_Tree source, loaded once per test.
+	 *
+	 * @var string
+	 */
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Utilities/Block_Tree.php'
+		);
+	}
+
+	public function test_source_declares_forbidden_post_types(): void {
+		foreach ( array( 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset', 'oembed_cache', 'user_request' ) as $forbidden ) {
+			$this->assertStringContainsString( "'{$forbidden}'", $this->src );
+		}
+	}
+
+	public function test_source_uses_wp_error_for_editability_failures(): void {
+		$this->assertStringContainsString( "'post_not_found'", $this->src );
+		$this->assertStringContainsString( "'post_type_forbidden'", $this->src );
+		$this->assertStringContainsString( "'insufficient_capability'", $this->src );
+	}
+
+	public function test_parse_post_blocks_uses_capability_gate(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*\\\$required,\s*\\\$post_id\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_parse_post_blocks_delegates_to_core_parser(): void {
+		$this->assertStringContainsString( 'parse_blocks( (string) $post->post_content )', $this->src );
+	}
+
+	public function test_move_returns_descendant_destination_error(): void {
+		$this->assertStringContainsString( "'descendant_destination'", $this->src );
+	}
+
+	public function test_validate_attributes_soft_fails_when_type_unregistered(): void {
+		$result = Block_Tree::validate_attributes_against_schema( 'nonexistent/block-type', array( 'foo' => 'bar' ) );
+		$this->assertTrue( $result );
+	}
+}

--- a/tests/phpunit/abilities/Test_Duplicate_Block.php
+++ b/tests/phpunit/abilities/Test_Duplicate_Block.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Feature 066 — source-inspection tests for acrossai/duplicate-block.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Duplicate_Block extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Content/Duplicate_Block.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/duplicate-block'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-content'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_input_requires_non_empty_path(): void {
+		$this->assertStringContainsString( "'minItems' => 1", $this->src );
+	}
+
+	public function test_reads_source_and_inserts_clone(): void {
+		$this->assertStringContainsString( 'Block_Tree::get_at_path(', $this->src );
+		$this->assertStringContainsString( 'Block_Tree::insert_at_path(', $this->src );
+	}
+
+	public function test_clone_inserted_as_next_sibling(): void {
+		$this->assertStringContainsString( '$source_index + 1', $this->src );
+	}
+
+	public function test_persists_via_wp_update_post(): void {
+		$this->assertStringContainsString( 'wp_update_post(', $this->src );
+	}
+
+	public function test_response_annotates_clone_with_new_path(): void {
+		$this->assertStringContainsString( "\$cloned_block['path']", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Get_Post_Blocks.php
+++ b/tests/phpunit/abilities/Test_Get_Post_Blocks.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Feature 066 — source-inspection tests for acrossai/get-post-blocks.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Get_Post_Blocks extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Content/Get_Post_Blocks.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/get-post-blocks'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-content'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_readonly(): void {
+		$this->assertStringContainsString( "'readonly'    => true", $this->src );
+		$this->assertStringContainsString( "'destructive' => false", $this->src );
+		$this->assertStringContainsString( "'idempotent'  => true", $this->src );
+	}
+
+	public function test_delegates_to_block_tree_read(): void {
+		$this->assertStringContainsString( "Block_Tree::parse_post_blocks( \$post_id, 'read' )", $this->src );
+		$this->assertStringContainsString( 'Block_Tree::annotate_with_paths(', $this->src );
+	}
+
+	public function test_input_schema_requires_post_id(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id' )", $this->src );
+	}
+
+	public function test_output_exposes_blocks_and_total(): void {
+		$this->assertStringContainsString( "'blocks'  => array( 'type' => 'array' )", $this->src );
+		$this->assertStringContainsString( "'total'   => array( 'type' => 'integer' )", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Insert_Pattern.php
+++ b/tests/phpunit/abilities/Test_Insert_Pattern.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Feature 066 — source-inspection tests for acrossai/insert-pattern.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Insert_Pattern extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Content/Insert_Pattern.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/insert-pattern'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-content'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_delegates_slug_resolution_to_pattern_detector(): void {
+		// This is the DRY requirement — Insert_Pattern must not duplicate
+		// source-scanning logic already implemented in Pattern_Detector.
+		$this->assertStringContainsString( 'Pattern_Detector::locate(', $this->src );
+		$this->assertStringContainsString( 'Pattern_Detector::select(', $this->src );
+	}
+
+	public function test_input_schema_accepts_source_disambiguation(): void {
+		$this->assertStringContainsString( "'source'      => array(", $this->src );
+		$this->assertStringContainsString( "'db', 'theme', 'plugin'", $this->src );
+	}
+
+	public function test_input_requires_slug_and_position(): void {
+		$this->assertStringContainsString(
+			"'required'             => array( 'post_id', 'parent_path', 'index', 'slug' )",
+			$this->src
+		);
+	}
+
+	public function test_inserts_via_block_tree(): void {
+		$this->assertStringContainsString( 'Block_Tree::insert_at_path(', $this->src );
+	}
+
+	public function test_persists_via_wp_update_post(): void {
+		$this->assertStringContainsString( 'wp_update_post(', $this->src );
+	}
+
+	public function test_response_reports_inserted_paths(): void {
+		$this->assertStringContainsString( "'inserted_paths' => \$inserted_paths", $this->src );
+		$this->assertStringContainsString( "'count'          => count( \$inserted_paths )", $this->src );
+	}
+
+	public function test_sanitizes_slug(): void {
+		$this->assertStringContainsString( 'sanitize_title(', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Move_Block.php
+++ b/tests/phpunit/abilities/Test_Move_Block.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Feature 066 — source-inspection tests for acrossai/move-block.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Move_Block extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Content/Move_Block.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/move-block'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-content'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_input_requires_from_and_to(): void {
+		$this->assertStringContainsString(
+			"'required'             => array( 'post_id', 'from_path', 'to_parent_path', 'to_index' )",
+			$this->src
+		);
+	}
+
+	public function test_delegates_atomic_move_to_block_tree(): void {
+		$this->assertStringContainsString( 'Block_Tree::move(', $this->src );
+	}
+
+	public function test_persists_via_wp_update_post(): void {
+		$this->assertStringContainsString( 'wp_update_post(', $this->src );
+	}
+
+	public function test_response_includes_previous_path(): void {
+		$this->assertStringContainsString( "'previous_path' => \$from_path", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Remove_Block.php
+++ b/tests/phpunit/abilities/Test_Remove_Block.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Feature 066 — source-inspection tests for acrossai/remove-block.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Remove_Block extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Content/Remove_Block.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug_and_category(): void {
+		$this->assertStringContainsString( "'acrossai/remove-block'", $this->src );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-content'", $this->src );
+	}
+
+	public function test_permission_callback_gates_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\(\s*'manage_options'\s*\)/",
+			$this->src
+		);
+	}
+
+	public function test_annotations_destructive_true(): void {
+		$this->assertStringContainsString( "'destructive' => true", $this->src );
+	}
+
+	public function test_input_requires_non_empty_path(): void {
+		$this->assertStringContainsString( "'minItems' => 1", $this->src );
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'path' )", $this->src );
+	}
+
+	public function test_delegates_to_block_tree_remove(): void {
+		$this->assertStringContainsString( 'Block_Tree::remove_at_path(', $this->src );
+	}
+
+	public function test_persists_via_wp_update_post(): void {
+		$this->assertStringContainsString( 'wp_update_post(', $this->src );
+	}
+
+	public function test_response_returns_removed_block(): void {
+		$this->assertStringContainsString( "'removed' => \$removed", $this->src );
+	}
+
+	public function test_returns_invalid_path_error_code(): void {
+		$this->assertStringContainsString( "'invalid_path'", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Update_Post_Block_Nested.php
+++ b/tests/phpunit/abilities/Test_Update_Post_Block_Nested.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Feature 066 — source-inspection tests for the nested-path branch added to
+ * acrossai/update-post-block. Ensures the legacy branches remain intact and
+ * the new path branch is wired to Block_Tree.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.24
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Update_Post_Block_Nested extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$plugin_root = dirname( __DIR__, 3 );
+		$this->src   = (string) file_get_contents(
+			$plugin_root . '/includes/Abilities/Content/Update_Post_Block.php'
+		);
+	}
+
+	public function test_still_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_input_schema_still_accepts_legacy_fields(): void {
+		$this->assertStringContainsString( "'block_index' => array(", $this->src );
+		$this->assertStringContainsString( "'block_name'  => array( 'type' => 'string' )", $this->src );
+		$this->assertStringContainsString( "'occurrence'  => array(", $this->src );
+	}
+
+	public function test_input_schema_adds_optional_path(): void {
+		$this->assertStringContainsString( "'path'        => array(", $this->src );
+		// Path is NOT required — post_id remains the only required field.
+		$this->assertStringContainsString( "'required'             => array( 'post_id' )", $this->src );
+	}
+
+	public function test_path_branch_delegates_to_block_tree(): void {
+		$this->assertStringContainsString( 'Block_Tree::get_at_path(', $this->src );
+		$this->assertStringContainsString( 'Block_Tree::replace_at_path(', $this->src );
+	}
+
+	public function test_path_branch_short_circuits_before_legacy(): void {
+		// The path branch check must appear textually BEFORE the block_index
+		// branch to preserve the priority order documented in research R7.
+		$path_pos  = strpos( $this->src, 'sanitize_path_input' );
+		$index_pos = strpos( $this->src, "isset( \$input['block_index']" );
+		$this->assertNotFalse( $path_pos );
+		$this->assertNotFalse( $index_pos );
+		$this->assertLessThan( $index_pos, $path_pos );
+	}
+
+	public function test_legacy_block_index_branch_intact(): void {
+		$this->assertStringContainsString( "isset( \$input['block_index'] )", $this->src );
+		$this->assertStringContainsString( "\$blocks[ \$target_index ]", $this->src );
+	}
+
+	public function test_legacy_block_name_regex_intact(): void {
+		// Feature 055 regex must still be present so consumers relying on
+		// block_name+occurrence get identical validation behaviour.
+		$this->assertStringContainsString( '[A-Za-z0-9_-]+', $this->src );
+	}
+
+	public function test_top_level_only_comment_removed(): void {
+		$this->assertStringNotContainsString( 'Bounded scope: matches only top-level', $this->src );
+		$this->assertStringNotContainsString( 'Nested block editing is deferred', $this->src );
+	}
+
+	public function test_path_branch_returns_error_for_unresolved_path(): void {
+		$this->assertStringContainsString( 'Path does not resolve to a block', $this->src );
+	}
+
+	public function test_path_branch_persists_via_wp_update_post(): void {
+		// The path branch must go through the same serialize_blocks + wp_update_post pipeline.
+		$this->assertStringContainsString( 'serialize_blocks( $blocks )', $this->src );
+		$this->assertStringContainsString( 'wp_update_post(', $this->src );
+	}
+}


### PR DESCRIPTION
## Summary

- Six new abilities + one enhancement to `update-post-block` giving clients complete read/write control over the Gutenberg block tree, including nested blocks
- Shared `Block_Tree` utility centralises tree-path primitives (walk, get / insert / remove / replace / move, block-name and attribute-schema validation) — extracts what were previously private inline guards
- 100% backward compatible: existing `update-post-block` consumers using `block_index` or `block_name` + `occurrence` see zero behaviour change (SC-003)

## New / modified abilities

| Slug | Type | Purpose |
|---|---|---|
| `acrossai/get-post-blocks` | new · read | Return parsed block tree with per-node canonical paths (int[]) |
| `acrossai/add-block` | new · write | Insert at `parent_path` + sibling index (appends when index >= sibling count) |
| `acrossai/remove-block` | new · write | Remove at canonical path; returns removed payload for undo/log |
| `acrossai/duplicate-block` | new · write | Deep-clone at path, insert as next sibling |
| `acrossai/move-block` | new · write | Atomic move; refuses descendant destinations to prevent cycles |
| `acrossai/insert-pattern` | new · write | Resolve pattern slug (db / theme / plugin) and expand at `parent_path` + `index`; ambiguous slugs return `multiple_locations` |
| `acrossai/update-post-block` | modified | Adds optional `path` input for nested addressing; legacy branches untouched |

## Security parity

Every write inherits the update-post-block capability model — `manage_options` + `edit_posts` globally, `edit_post` per-post, and the post-type whitelist blocking `revision` / `nav_menu_item` / `custom_css` / `customize_changeset` / `oembed_cache` / `user_request`. `get-post-blocks` uses `read_post` per-post instead of `edit_post`. Attribute-schema validation is soft-fail when the block type is not registered so custom / third-party blocks remain authorable.

## Test plan

- [x] Full PHPUnit suite: **577 tests, 1365 assertions, 0 failures**
- [x] 82 new assertions across 8 test files (Test_Block_Tree + 7 per-ability)
- [x] phpcs (WPCS strict): 0 errors across 46 files
- [x] phpstan level 8: 0 errors
- [ ] Live-site quickstart walkthrough (11-step columns → column → heading/paragraph fixture per `specs/066-.../quickstart.md`)
- [ ] Plugin Check CI on the built plugin

## Spec artifacts

Under `specs/066-block-tree-mutation-and-nested-editing/`:
`spec.md` · `plan.md` · `research.md` · `data-model.md` · `contracts/abilities.md` · `quickstart.md` · `tasks.md` · `checklists/requirements.md`

Version bumped 0.0.23 → 0.0.24. Changelog entry added to `readme.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)