### PR TITLE
feat(067 continued): 6 element-lifecycle abilities (unreleased, no version bump)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -138,18 +138,26 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased (NOT YET RELEASED) =
-* **Feature 067 continued — 5 more Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available to anyone on the `main` branch but no plugin release / tag / distribution package has been cut. A future release will bundle these plus additional Feature 067 abilities under a single version bump.
+* **Feature 067 continued — 11 more Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available to anyone on the `main` branch but no plugin release / tag / distribution package has been cut. A future release will bundle these plus additional Feature 067 abilities under a single version bump.
 
-**Five new abilities under `acrossai/elementor-*` namespace, all gated on `class_exists( '\Elementor\Plugin' )`:**
-  * `acrossai/elementor-get-element` — read a single element by its 7-character hex ID; returns the element plus parent-ID path.
-  * `acrossai/elementor-find-elements` — search elements by `element_type` (container / widget / section / column), `widget_type`, and/or `contains` text; returns matches with paths.
-  * `acrossai/elementor-update-element` — replace an element by ID with a new payload. Guarded by `force_replace=true` when the replacement is materially smaller than the existing element (fewer children or <50% of prior settings).
-  * `acrossai/elementor-add-container` — insert a new Elementor v3+ container at root or nested inside another element; auto-generates 7-char hex ID.
-  * `acrossai/elementor-add-widget` — insert any registered Elementor widget (free / Pro / third-party). Widget type validated against Elementor's live registry via `Widget_Controls::get_type()` before writing.
+**Batch 3 — 6 more element-lifecycle abilities (this commit):**
+  * `acrossai/elementor-merge-element-settings` — deep-merge new settings into an element by ID. Additive (no force_replace guard needed); reports `changed_keys` in the response.
+  * `acrossai/elementor-delete-element` — remove an element by ID. Guarded by `force_delete=true` for top-level or populated (with-children) elements.
+  * `acrossai/elementor-remove-element` — safer alias for `delete-element` with identical semantics.
+  * `acrossai/elementor-move-element` — atomic move to a new parent/position with descendant-guard preventing cycle-creating moves into own subtree.
+  * `acrossai/elementor-duplicate-element` — deep-clone an element (all nested children included) with fresh IDs generated throughout the cloned subtree; inserted as the next sibling.
+  * `acrossai/elementor-reorder-elements` — reorder direct children of a parent (or root); children omitted from `ordered_element_ids` retain their prior relative order and are appended after.
 
-**Test coverage:** 43 new source-inspection tests across 5 test files. Full suite: 679 tests, 1582 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
+**Batch 2 — 5 abilities merged earlier:**
+  * `acrossai/elementor-get-element` — read a single element by 7-char hex ID.
+  * `acrossai/elementor-find-elements` — search by `element_type` / `widget_type` / contains-text.
+  * `acrossai/elementor-update-element` — replace by ID with `force_replace` guard.
+  * `acrossai/elementor-add-container` — insert Elementor v3+ container.
+  * `acrossai/elementor-add-widget` — insert any registered widget (validated via `Widget_Controls`).
 
-**Total shipped Elementor abilities so far: 7 of 88** (`get-widget-controls`, `get-data`, `get-element`, `find-elements`, `update-element`, `add-container`, `add-widget`). Client can now discover schemas + read documents + find/edit elements + compose pages from scratch via `add-container` + `add-widget`.
+**Test coverage:** 43 (batch 2) + 40 (batch 3) = 83 new source-inspection tests across 11 test files. Full suite: 719 tests, 1629 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
+
+**Total shipped Elementor abilities so far: 13 of 88.** Foundation + 2 released in 0.0.25 + 11 unreleased on main. Complete element-scoped R/W surface — clients can now discover schemas, read documents, find/get/update/merge/delete/move/duplicate/reorder elements, and compose pages from scratch.
 
 = 0.0.25 =
 * **New — Feature 067 Elementor Ability Suite (interim ship: foundation + 2 abilities).** First release of the planned 88-ability Elementor integration. This interim release delivers the full foundational infrastructure plus two highest-value abilities. Follow-up features (068+) will incrementally add the remaining 86 abilities.

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -442,6 +442,12 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Elementor\Update_Element();
 		new Elementor\Add_Container();
 		new Elementor\Add_Widget();
+		new Elementor\Merge_Element_Settings();
+		new Elementor\Delete_Element();
+		new Elementor\Remove_Element();
+		new Elementor\Move_Element();
+		new Elementor\Duplicate_Element();
+		new Elementor\Reorder_Elements();
 	}
 
 	/**

--- a/includes/Abilities/Elementor/Delete_Element.php
+++ b/includes/Abilities/Elementor/Delete_Element.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Feature 067 — delete an Elementor element by ID.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Delete the element at element_id. Populated (non-empty) or top-level
+ * elements require force_delete=true to prevent accidental wipes.
+ */
+class Delete_Element extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-delete-element',
+			'args' => array(
+				'label'               => __( 'Delete Elementor Element', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Remove the Elementor element at the given ID. Guarded by force_delete=true for populated or top-level elements.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'      => array( 'type' => 'integer', 'minimum' => 1 ),
+						'element_id'   => array( 'type' => 'string' ),
+						'force_delete' => array( 'type' => 'boolean', 'default' => false ),
+						'cache_scope'  => array( 'type' => 'string', 'enum' => array( 'none', 'post', 'site' ), 'default' => 'post' ),
+					),
+					'required'             => array( 'post_id', 'element_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'post_id'    => array( 'type' => 'integer' ),
+						'element_id' => array( 'type' => 'string' ),
+						'removed'    => array( 'type' => 'object' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return $this->fail( 0, '', (string) $check->get_error_code(), (string) $check->get_error_message() );
+		}
+		$post_id      = absint( $input['post_id'] ?? 0 );
+		$element_id   = isset( $input['element_id'] ) ? (string) $input['element_id'] : '';
+		$force_delete = ! empty( $input['force_delete'] );
+		$cache_scope  = isset( $input['cache_scope'] ) ? (string) $input['cache_scope'] : 'post';
+
+		if ( ! Document_Repository::is_valid_element_id( $element_id ) ) {
+			return $this->fail( $post_id, $element_id, 'invalid_element_id', __( 'element_id must be a 7-character hex string.', 'acrossai-abilities-manager' ) );
+		}
+
+		$doc = Document_Repository::load_document( $post_id, 'edit' );
+		if ( is_wp_error( $doc ) ) {
+			return $this->fail( $post_id, $element_id, (string) $doc->get_error_code(), (string) $doc->get_error_message() );
+		}
+
+		$existing = Document_Repository::find_element_by_id( $doc['data'], $element_id );
+		if ( null === $existing ) {
+			return $this->fail( $post_id, $element_id, 'element_not_found', __( 'Element not found in this post.', 'acrossai-abilities-manager' ) );
+		}
+
+		// Force-guard: top-level or populated (has children) elements need explicit force_delete.
+		$is_top_level = array() === $existing['path'];
+		$has_children = isset( $existing['element']['elements'] ) && is_array( $existing['element']['elements'] ) && count( $existing['element']['elements'] ) > 0;
+		if ( ! $force_delete && ( $is_top_level || $has_children ) ) {
+			return $this->fail(
+				$post_id,
+				$element_id,
+				'force_delete_required',
+				$is_top_level
+					? __( 'Cannot delete a top-level element without force_delete=true.', 'acrossai-abilities-manager' )
+					: __( 'Cannot delete a populated element without force_delete=true.', 'acrossai-abilities-manager' )
+			);
+		}
+
+		$removed = Document_Repository::remove_element_by_id( $doc['data'], $element_id );
+		if ( null === $removed ) {
+			return $this->fail( $post_id, $element_id, 'element_not_found', __( 'Failed to remove element.', 'acrossai-abilities-manager' ) );
+		}
+
+		$saved = Document_Repository::save_data( $post_id, $doc['data'], $cache_scope );
+		if ( is_wp_error( $saved ) ) {
+			return $this->fail( $post_id, $element_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		return array(
+			'success'    => true,
+			'post_id'    => $post_id,
+			'element_id' => $element_id,
+			'removed'    => $removed,
+			/* translators: 1: element id, 2: post id */
+			'message'    => sprintf( __( 'Deleted element %1$s from post #%2$d.', 'acrossai-abilities-manager' ), $element_id, $post_id ),
+		);
+	}
+
+	/**
+	 * @param int    $post_id
+	 * @param string $element_id
+	 * @param string $code
+	 * @param string $message
+	 * @return array<string,mixed>
+	 */
+	private function fail( int $post_id, string $element_id, string $code, string $message ): array {
+		$out = array(
+			'success'    => false,
+			'post_id'    => $post_id,
+			'message'    => $message,
+			'error_code' => $code,
+		);
+		if ( '' !== $element_id ) {
+			$out['element_id'] = $element_id;
+		}
+		return $out;
+	}
+}

--- a/includes/Abilities/Elementor/Duplicate_Element.php
+++ b/includes/Abilities/Elementor/Duplicate_Element.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Feature 067 — duplicate an Elementor element with fresh IDs.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Deep-clone an element and insert the clone as the next sibling of
+ * the source. IDs throughout the cloned subtree are regenerated.
+ */
+class Duplicate_Element extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-duplicate-element',
+			'args' => array(
+				'label'               => __( 'Duplicate Elementor Element', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Deep-clone an Elementor element (including all nested children) and insert the clone as the next sibling of the source. IDs are regenerated throughout the cloned subtree.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'     => array( 'type' => 'integer', 'minimum' => 1 ),
+						'element_id'  => array( 'type' => 'string' ),
+						'cache_scope' => array( 'type' => 'string', 'enum' => array( 'none', 'post', 'site' ), 'default' => 'post' ),
+					),
+					'required'             => array( 'post_id', 'element_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'           => array( 'type' => 'boolean' ),
+						'post_id'           => array( 'type' => 'integer' ),
+						'source_element_id' => array( 'type' => 'string' ),
+						'clone_element_id'  => array( 'type' => 'string' ),
+						'message'           => array( 'type' => 'string' ),
+						'error_code'        => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return $this->fail( 0, '', (string) $check->get_error_code(), (string) $check->get_error_message() );
+		}
+		$post_id     = absint( $input['post_id'] ?? 0 );
+		$element_id  = isset( $input['element_id'] ) ? (string) $input['element_id'] : '';
+		$cache_scope = isset( $input['cache_scope'] ) ? (string) $input['cache_scope'] : 'post';
+
+		if ( ! Document_Repository::is_valid_element_id( $element_id ) ) {
+			return $this->fail( $post_id, $element_id, 'invalid_element_id', __( 'element_id must be a 7-character hex string.', 'acrossai-abilities-manager' ) );
+		}
+
+		$doc = Document_Repository::load_document( $post_id, 'edit' );
+		if ( is_wp_error( $doc ) ) {
+			return $this->fail( $post_id, $element_id, (string) $doc->get_error_code(), (string) $doc->get_error_message() );
+		}
+
+		$source = Document_Repository::find_element_by_id( $doc['data'], $element_id );
+		if ( null === $source ) {
+			return $this->fail( $post_id, $element_id, 'element_not_found', __( 'Element not found.', 'acrossai-abilities-manager' ) );
+		}
+
+		// Deep-clone and regenerate every ID in the subtree.
+		$clone            = Document_Repository::reassign_subtree_ids( $source['element'] );
+		$clone_element_id = (string) $clone['id'];
+
+		$parent_id = ! empty( $source['path'] ) ? (string) end( $source['path'] ) : null;
+		// Find the source's sibling index inside its parent so we can insert the clone at index+1.
+		$sibling_index = $this->find_sibling_index( $doc['data'], $parent_id, $element_id );
+
+		if ( ! Document_Repository::insert_element( $doc['data'], $parent_id, $sibling_index + 1, $clone ) ) {
+			return $this->fail( $post_id, $element_id, 'element_not_found', __( 'Failed to insert clone.', 'acrossai-abilities-manager' ) );
+		}
+
+		$saved = Document_Repository::save_data( $post_id, $doc['data'], $cache_scope );
+		if ( is_wp_error( $saved ) ) {
+			return $this->fail( $post_id, $element_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		return array(
+			'success'           => true,
+			'post_id'           => $post_id,
+			'source_element_id' => $element_id,
+			'clone_element_id'  => $clone_element_id,
+			/* translators: 1: source, 2: clone, 3: post id */
+			'message'           => sprintf( __( 'Duplicated element %1$s as %2$s on post #%3$d.', 'acrossai-abilities-manager' ), $element_id, $clone_element_id, $post_id ),
+		);
+	}
+
+	/**
+	 * Find the sibling index of $target_id under $parent_id (or root).
+	 *
+	 * @param array<int, array<string, mixed>> $elements Root tree.
+	 * @param string|null                      $parent_id
+	 * @param string                           $target_id
+	 * @return int Sibling index (0-based), or -1 if not found.
+	 */
+	private function find_sibling_index( array $elements, ?string $parent_id, string $target_id ): int {
+		if ( null === $parent_id ) {
+			foreach ( $elements as $index => $element ) {
+				if ( isset( $element['id'] ) && (string) $element['id'] === $target_id ) {
+					return (int) $index;
+				}
+			}
+			return -1;
+		}
+		$parent = Document_Repository::find_element_by_id( $elements, $parent_id );
+		if ( null === $parent || ! isset( $parent['element']['elements'] ) || ! is_array( $parent['element']['elements'] ) ) {
+			return -1;
+		}
+		foreach ( $parent['element']['elements'] as $index => $child ) {
+			if ( isset( $child['id'] ) && (string) $child['id'] === $target_id ) {
+				return (int) $index;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * @param int    $post_id
+	 * @param string $element_id
+	 * @param string $code
+	 * @param string $message
+	 * @return array<string,mixed>
+	 */
+	private function fail( int $post_id, string $element_id, string $code, string $message ): array {
+		$out = array(
+			'success'    => false,
+			'post_id'    => $post_id,
+			'message'    => $message,
+			'error_code' => $code,
+		);
+		if ( '' !== $element_id ) {
+			$out['source_element_id'] = $element_id;
+		}
+		return $out;
+	}
+}

--- a/includes/Abilities/Elementor/Merge_Element_Settings.php
+++ b/includes/Abilities/Elementor/Merge_Element_Settings.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Feature 067 — deep-merge settings into a single Elementor element.
+ *
+ * Safer than update-element for targeted patches — modifies only the
+ * specified settings keys and leaves everything else untouched. No
+ * force_replace guard needed because the operation is inherently
+ * additive.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Deep-merge settings into the element at element_id.
+ */
+class Merge_Element_Settings extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-merge-element-settings',
+			'args' => array(
+				'label'               => __( 'Merge Elementor Element Settings', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Deep-merge new settings into a single Elementor element by ID. Only the supplied setting keys are changed; siblings and unchanged settings are preserved.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'     => array( 'type' => 'integer', 'minimum' => 1 ),
+						'element_id'  => array( 'type' => 'string' ),
+						'settings'    => array( 'type' => 'object' ),
+						'cache_scope' => array( 'type' => 'string', 'enum' => array( 'none', 'post', 'site' ), 'default' => 'post' ),
+					),
+					'required'             => array( 'post_id', 'element_id', 'settings' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'post_id'      => array( 'type' => 'integer' ),
+						'element_id'   => array( 'type' => 'string' ),
+						'element'      => array( 'type' => 'object' ),
+						'changed_keys' => array( 'type' => 'array' ),
+						'message'      => array( 'type' => 'string' ),
+						'error_code'   => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return $this->fail( 0, '', (string) $check->get_error_code(), (string) $check->get_error_message() );
+		}
+		$post_id     = absint( $input['post_id'] ?? 0 );
+		$element_id  = isset( $input['element_id'] ) ? (string) $input['element_id'] : '';
+		$new_settings = isset( $input['settings'] ) && is_array( $input['settings'] ) ? $input['settings'] : array();
+		$cache_scope = isset( $input['cache_scope'] ) ? (string) $input['cache_scope'] : 'post';
+
+		if ( ! Document_Repository::is_valid_element_id( $element_id ) ) {
+			return $this->fail( $post_id, $element_id, 'invalid_element_id', __( 'element_id must be a 7-character hex string.', 'acrossai-abilities-manager' ) );
+		}
+
+		$doc = Document_Repository::load_document( $post_id, 'edit' );
+		if ( is_wp_error( $doc ) ) {
+			return $this->fail( $post_id, $element_id, (string) $doc->get_error_code(), (string) $doc->get_error_message() );
+		}
+
+		$existing = Document_Repository::find_element_by_id( $doc['data'], $element_id );
+		if ( null === $existing ) {
+			return $this->fail( $post_id, $element_id, 'element_not_found', __( 'Element not found in this post.', 'acrossai-abilities-manager' ) );
+		}
+
+		$merged_element             = $existing['element'];
+		$prior_settings             = isset( $merged_element['settings'] ) && is_array( $merged_element['settings'] ) ? $merged_element['settings'] : array();
+		$merged_element['settings'] = self::deep_merge( $prior_settings, $new_settings );
+		$changed_keys               = array_keys( $new_settings );
+
+		if ( ! Document_Repository::replace_element_by_id( $doc['data'], $element_id, $merged_element ) ) {
+			return $this->fail( $post_id, $element_id, 'element_not_found', __( 'Failed to update element.', 'acrossai-abilities-manager' ) );
+		}
+
+		$saved = Document_Repository::save_data( $post_id, $doc['data'], $cache_scope );
+		if ( is_wp_error( $saved ) ) {
+			return $this->fail( $post_id, $element_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		return array(
+			'success'      => true,
+			'post_id'      => $post_id,
+			'element_id'   => $element_id,
+			'element'      => $merged_element,
+			'changed_keys' => $changed_keys,
+			/* translators: 1: count, 2: element id, 3: post id */
+			'message'      => sprintf( __( 'Merged %1$d settings into element %2$s on post #%3$d.', 'acrossai-abilities-manager' ), count( $changed_keys ), $element_id, $post_id ),
+		);
+	}
+
+	/**
+	 * Deep-merge $override into $base. Arrays are merged recursively; scalars replace.
+	 *
+	 * @param array<string, mixed> $base
+	 * @param array<string, mixed> $override
+	 * @return array<string, mixed>
+	 */
+	private static function deep_merge( array $base, array $override ): array {
+		foreach ( $override as $key => $value ) {
+			if ( is_array( $value ) && isset( $base[ $key ] ) && is_array( $base[ $key ] ) ) {
+				$base[ $key ] = self::deep_merge( $base[ $key ], $value );
+			} else {
+				$base[ $key ] = $value;
+			}
+		}
+		return $base;
+	}
+
+	/**
+	 * @param int    $post_id
+	 * @param string $element_id
+	 * @param string $code
+	 * @param string $message
+	 * @return array<string,mixed>
+	 */
+	private function fail( int $post_id, string $element_id, string $code, string $message ): array {
+		$out = array(
+			'success'    => false,
+			'post_id'    => $post_id,
+			'message'    => $message,
+			'error_code' => $code,
+		);
+		if ( '' !== $element_id ) {
+			$out['element_id'] = $element_id;
+		}
+		return $out;
+	}
+}

--- a/includes/Abilities/Elementor/Move_Element.php
+++ b/includes/Abilities/Elementor/Move_Element.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Feature 067 — move an Elementor element to a new parent/position.
+ *
+ * Atomic: remove + insert on an in-memory tree copy so callers never
+ * see the intermediate state. Refuses moves whose destination lies
+ * inside the source's own subtree (would create a cycle).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Move an element to a new parent/position atomically.
+ */
+class Move_Element extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-move-element',
+			'args' => array(
+				'label'               => __( 'Move Elementor Element', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Move an Elementor element to a new parent and sibling position. Atomic: source and destination are updated together. Refuses moves whose destination lies inside the source subtree.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'       => array( 'type' => 'integer', 'minimum' => 1 ),
+						'element_id'    => array( 'type' => 'string' ),
+						'new_parent_id' => array( 'type' => array( 'string', 'null' ) ),
+						'position'      => array( 'type' => 'integer', 'minimum' => 0 ),
+						'cache_scope'   => array( 'type' => 'string', 'enum' => array( 'none', 'post', 'site' ), 'default' => 'post' ),
+					),
+					'required'             => array( 'post_id', 'element_id', 'position' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'            => array( 'type' => 'boolean' ),
+						'post_id'            => array( 'type' => 'integer' ),
+						'element_id'         => array( 'type' => 'string' ),
+						'previous_parent_id' => array( 'type' => array( 'string', 'null' ) ),
+						'new_parent_id'      => array( 'type' => array( 'string', 'null' ) ),
+						'position'           => array( 'type' => 'integer' ),
+						'message'            => array( 'type' => 'string' ),
+						'error_code'         => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return $this->fail( 0, '', (string) $check->get_error_code(), (string) $check->get_error_message() );
+		}
+		$post_id       = absint( $input['post_id'] ?? 0 );
+		$element_id    = isset( $input['element_id'] ) ? (string) $input['element_id'] : '';
+		$new_parent_id = ( isset( $input['new_parent_id'] ) && '' !== $input['new_parent_id'] ) ? (string) $input['new_parent_id'] : null;
+		$position      = (int) ( $input['position'] ?? 0 );
+		$cache_scope   = isset( $input['cache_scope'] ) ? (string) $input['cache_scope'] : 'post';
+
+		if ( ! Document_Repository::is_valid_element_id( $element_id ) ) {
+			return $this->fail( $post_id, $element_id, 'invalid_element_id', __( 'element_id must be a 7-character hex string.', 'acrossai-abilities-manager' ) );
+		}
+		if ( null !== $new_parent_id && ! Document_Repository::is_valid_element_id( $new_parent_id ) ) {
+			return $this->fail( $post_id, $element_id, 'invalid_element_id', __( 'new_parent_id must be a 7-character hex string.', 'acrossai-abilities-manager' ) );
+		}
+
+		$doc = Document_Repository::load_document( $post_id, 'edit' );
+		if ( is_wp_error( $doc ) ) {
+			return $this->fail( $post_id, $element_id, (string) $doc->get_error_code(), (string) $doc->get_error_message() );
+		}
+
+		$source = Document_Repository::find_element_by_id( $doc['data'], $element_id );
+		if ( null === $source ) {
+			return $this->fail( $post_id, $element_id, 'element_not_found', __( 'Source element not found.', 'acrossai-abilities-manager' ) );
+		}
+
+		// Descendant guard: destination must not lie inside the source subtree.
+		if ( null !== $new_parent_id ) {
+			$dest = Document_Repository::find_element_by_id( $doc['data'], $new_parent_id );
+			if ( null === $dest ) {
+				return $this->fail( $post_id, $element_id, 'element_not_found', __( 'Destination parent not found.', 'acrossai-abilities-manager' ) );
+			}
+			// If element_id is in dest's parent path OR dest is element_id itself, it's a cycle.
+			if ( $new_parent_id === $element_id || in_array( $element_id, $dest['path'], true ) ) {
+				return $this->fail( $post_id, $element_id, 'descendant_destination', __( 'Cannot move an element into its own subtree.', 'acrossai-abilities-manager' ) );
+			}
+		}
+
+		$previous_parent_id = ! empty( $source['path'] ) ? (string) end( $source['path'] ) : null;
+
+		// Atomic move: remove from current position, then insert into destination.
+		$moved = Document_Repository::remove_element_by_id( $doc['data'], $element_id );
+		if ( null === $moved ) {
+			return $this->fail( $post_id, $element_id, 'element_not_found', __( 'Failed to remove source element.', 'acrossai-abilities-manager' ) );
+		}
+		if ( ! Document_Repository::insert_element( $doc['data'], $new_parent_id, $position, $moved ) ) {
+			// Attempt rollback by re-inserting at original position (best-effort).
+			Document_Repository::insert_element( $doc['data'], $previous_parent_id, 0, $moved );
+			return $this->fail( $post_id, $element_id, 'element_not_found', __( 'Failed to insert at destination.', 'acrossai-abilities-manager' ) );
+		}
+
+		$saved = Document_Repository::save_data( $post_id, $doc['data'], $cache_scope );
+		if ( is_wp_error( $saved ) ) {
+			return $this->fail( $post_id, $element_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		return array(
+			'success'            => true,
+			'post_id'            => $post_id,
+			'element_id'         => $element_id,
+			'previous_parent_id' => $previous_parent_id,
+			'new_parent_id'      => $new_parent_id,
+			'position'           => $position,
+			/* translators: 1: element id, 2: post id */
+			'message'            => sprintf( __( 'Moved element %1$s on post #%2$d.', 'acrossai-abilities-manager' ), $element_id, $post_id ),
+		);
+	}
+
+	/**
+	 * @param int    $post_id
+	 * @param string $element_id
+	 * @param string $code
+	 * @param string $message
+	 * @return array<string,mixed>
+	 */
+	private function fail( int $post_id, string $element_id, string $code, string $message ): array {
+		$out = array(
+			'success'    => false,
+			'post_id'    => $post_id,
+			'message'    => $message,
+			'error_code' => $code,
+		);
+		if ( '' !== $element_id ) {
+			$out['element_id'] = $element_id;
+		}
+		return $out;
+	}
+}

--- a/includes/Abilities/Elementor/Remove_Element.php
+++ b/includes/Abilities/Elementor/Remove_Element.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Feature 067 — safer alias for delete-element (force_delete defaults true only for leaf non-top-level).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Remove an element with the same force-guard as delete-element, but
+ * exposed under a more forgiving verb.
+ */
+class Remove_Element extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-remove-element',
+			'args' => array(
+				'label'               => __( 'Remove Elementor Element', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Remove the Elementor element at the given ID. Semantically identical to delete-element; force_delete required for populated or top-level elements.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'      => array( 'type' => 'integer', 'minimum' => 1 ),
+						'element_id'   => array( 'type' => 'string' ),
+						'force_delete' => array( 'type' => 'boolean', 'default' => false ),
+						'cache_scope'  => array( 'type' => 'string', 'enum' => array( 'none', 'post', 'site' ), 'default' => 'post' ),
+					),
+					'required'             => array( 'post_id', 'element_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'post_id'    => array( 'type' => 'integer' ),
+						'element_id' => array( 'type' => 'string' ),
+						'removed'    => array( 'type' => 'object' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		// Delegate to Delete_Element for identical semantics — a client-friendly alias.
+		$delete = new Delete_Element();
+		return $delete->execute( $input );
+	}
+}

--- a/includes/Abilities/Elementor/Reorder_Elements.php
+++ b/includes/Abilities/Elementor/Reorder_Elements.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Feature 067 — reorder direct children of a parent (or root).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Reorder direct children of a parent (or root children if parent_id is null).
+ * Children not mentioned in ordered_element_ids are appended in their original order.
+ */
+class Reorder_Elements extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-reorder-elements',
+			'args' => array(
+				'label'               => __( 'Reorder Elementor Elements', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Reorder the direct children of a parent (or root children when parent_id is null). Children not listed in ordered_element_ids retain their prior relative order and are appended after.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'             => array( 'type' => 'integer', 'minimum' => 1 ),
+						'parent_id'           => array( 'type' => array( 'string', 'null' ) ),
+						'ordered_element_ids' => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+						'cache_scope'         => array( 'type' => 'string', 'enum' => array( 'none', 'post', 'site' ), 'default' => 'post' ),
+					),
+					'required'             => array( 'post_id', 'ordered_element_ids' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'post_id'    => array( 'type' => 'integer' ),
+						'parent_id'  => array( 'type' => array( 'string', 'null' ) ),
+						'new_order'  => array( 'type' => 'array' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return $this->fail( 0, null, (string) $check->get_error_code(), (string) $check->get_error_message() );
+		}
+		$post_id     = absint( $input['post_id'] ?? 0 );
+		$parent_id   = ( isset( $input['parent_id'] ) && '' !== $input['parent_id'] ) ? (string) $input['parent_id'] : null;
+		$ordered_ids = isset( $input['ordered_element_ids'] ) && is_array( $input['ordered_element_ids'] )
+			? array_map( 'strval', $input['ordered_element_ids'] )
+			: array();
+		$cache_scope = isset( $input['cache_scope'] ) ? (string) $input['cache_scope'] : 'post';
+
+		if ( null !== $parent_id && ! Document_Repository::is_valid_element_id( $parent_id ) ) {
+			return $this->fail( $post_id, $parent_id, 'invalid_element_id', __( 'parent_id must be a 7-character hex string.', 'acrossai-abilities-manager' ) );
+		}
+		if ( empty( $ordered_ids ) ) {
+			return $this->fail( $post_id, $parent_id, 'invalid_payload', __( 'ordered_element_ids must be a non-empty array.', 'acrossai-abilities-manager' ) );
+		}
+
+		$doc = Document_Repository::load_document( $post_id, 'edit' );
+		if ( is_wp_error( $doc ) ) {
+			return $this->fail( $post_id, $parent_id, (string) $doc->get_error_code(), (string) $doc->get_error_message() );
+		}
+
+		$result = Document_Repository::reorder_children( $doc['data'], $parent_id, $ordered_ids );
+		if ( is_wp_error( $result ) ) {
+			return $this->fail( $post_id, $parent_id, (string) $result->get_error_code(), (string) $result->get_error_message() );
+		}
+
+		$saved = Document_Repository::save_data( $post_id, $doc['data'], $cache_scope );
+		if ( is_wp_error( $saved ) ) {
+			return $this->fail( $post_id, $parent_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		// Read back the effective order so the response reflects the true state (including appended leftovers).
+		$new_order = array();
+		if ( null === $parent_id ) {
+			foreach ( $doc['data'] as $child ) {
+				if ( isset( $child['id'] ) ) {
+					$new_order[] = (string) $child['id'];
+				}
+			}
+		} else {
+			$parent = Document_Repository::find_element_by_id( $doc['data'], $parent_id );
+			if ( null !== $parent && isset( $parent['element']['elements'] ) && is_array( $parent['element']['elements'] ) ) {
+				foreach ( $parent['element']['elements'] as $child ) {
+					if ( isset( $child['id'] ) ) {
+						$new_order[] = (string) $child['id'];
+					}
+				}
+			}
+		}
+
+		return array(
+			'success'   => true,
+			'post_id'   => $post_id,
+			'parent_id' => $parent_id,
+			'new_order' => $new_order,
+			/* translators: 1: count, 2: post id */
+			'message'   => sprintf( __( 'Reordered %1$d children on post #%2$d.', 'acrossai-abilities-manager' ), count( $new_order ), $post_id ),
+		);
+	}
+
+	/**
+	 * @param int         $post_id
+	 * @param string|null $parent_id
+	 * @param string      $code
+	 * @param string      $message
+	 * @return array<string,mixed>
+	 */
+	private function fail( int $post_id, ?string $parent_id, string $code, string $message ): array {
+		return array(
+			'success'    => false,
+			'post_id'    => $post_id,
+			'parent_id'  => $parent_id,
+			'message'    => $message,
+			'error_code' => $code,
+		);
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -107,6 +107,12 @@
 			<file>tests/phpunit/abilities/Test_Elementor_Update_Element.php</file>
 			<file>tests/phpunit/abilities/Test_Elementor_Add_Container.php</file>
 			<file>tests/phpunit/abilities/Test_Elementor_Add_Widget.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Merge_Element_Settings.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Delete_Element.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Remove_Element.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Move_Element.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Duplicate_Element.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Reorder_Elements.php</file>
 			<file>tests/phpunit/abilities/Test_Move_Block.php</file>
 			<file>tests/phpunit/abilities/Test_Duplicate_Block.php</file>
 			<file>tests/phpunit/abilities/Test_Insert_Pattern.php</file>

--- a/tests/phpunit/abilities/Test_Elementor_Delete_Element.php
+++ b/tests/phpunit/abilities/Test_Elementor_Delete_Element.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Feature 067 — Delete_Element tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Delete_Element extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Delete_Element.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-delete-element'", $this->src );
+	}
+
+	public function test_destructive_annotation(): void {
+		$this->assertStringContainsString( "'destructive' => true", $this->src );
+	}
+
+	public function test_force_delete_flag_and_error_code(): void {
+		$this->assertStringContainsString( "'force_delete'", $this->src );
+		$this->assertStringContainsString( "'force_delete_required'", $this->src );
+	}
+
+	public function test_guards_top_level_and_populated_elements(): void {
+		$this->assertStringContainsString( '$is_top_level', $this->src );
+		$this->assertStringContainsString( '$has_children', $this->src );
+	}
+
+	public function test_uses_remove_element_by_id(): void {
+		$this->assertStringContainsString( 'Document_Repository::remove_element_by_id', $this->src );
+	}
+
+	public function test_defense_in_depth_gate(): void {
+		$this->assertStringContainsString( 'assert_elementor_available()', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Duplicate_Element.php
+++ b/tests/phpunit/abilities/Test_Elementor_Duplicate_Element.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Feature 067 — Duplicate_Element tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Duplicate_Element extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Duplicate_Element.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-duplicate-element'", $this->src );
+	}
+
+	public function test_reassigns_subtree_ids(): void {
+		$this->assertStringContainsString( 'Document_Repository::reassign_subtree_ids', $this->src );
+	}
+
+	public function test_inserts_clone_as_next_sibling(): void {
+		$this->assertStringContainsString( '$sibling_index + 1', $this->src );
+	}
+
+	public function test_reports_source_and_clone_ids(): void {
+		$this->assertStringContainsString( "'source_element_id'", $this->src );
+		$this->assertStringContainsString( "'clone_element_id'", $this->src );
+	}
+
+	public function test_defense_in_depth_gate(): void {
+		$this->assertStringContainsString( 'assert_elementor_available()', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Merge_Element_Settings.php
+++ b/tests/phpunit/abilities/Test_Elementor_Merge_Element_Settings.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Feature 067 — Merge_Element_Settings tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Merge_Element_Settings extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Merge_Element_Settings.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-merge-element-settings'", $this->src );
+	}
+
+	public function test_input_requires_post_id_element_id_and_settings(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'element_id', 'settings' )", $this->src );
+	}
+
+	public function test_idempotent_annotation(): void {
+		$this->assertStringContainsString( "'idempotent' => true", $this->src );
+		$this->assertStringContainsString( "'destructive' => false", $this->src );
+	}
+
+	public function test_uses_deep_merge_helper(): void {
+		$this->assertStringContainsString( 'private static function deep_merge(', $this->src );
+	}
+
+	public function test_reports_changed_keys(): void {
+		$this->assertStringContainsString( "'changed_keys'", $this->src );
+	}
+
+	public function test_defense_in_depth_gate(): void {
+		$this->assertStringContainsString( 'assert_elementor_available()', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Move_Element.php
+++ b/tests/phpunit/abilities/Test_Elementor_Move_Element.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Feature 067 — Move_Element tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Move_Element extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Move_Element.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-move-element'", $this->src );
+	}
+
+	public function test_input_requires_post_id_element_id_position(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'element_id', 'position' )", $this->src );
+	}
+
+	public function test_supports_new_parent_id_null_for_root(): void {
+		$this->assertStringContainsString( "array( 'string', 'null' )", $this->src );
+	}
+
+	public function test_descendant_guard(): void {
+		$this->assertStringContainsString( "'descendant_destination'", $this->src );
+		$this->assertStringContainsString( 'in_array( $element_id, $dest[\'path\'], true )', $this->src );
+	}
+
+	public function test_atomic_remove_then_insert(): void {
+		$this->assertStringContainsString( 'Document_Repository::remove_element_by_id', $this->src );
+		$this->assertStringContainsString( 'Document_Repository::insert_element', $this->src );
+	}
+
+	public function test_reports_previous_parent_id(): void {
+		$this->assertStringContainsString( "'previous_parent_id'", $this->src );
+	}
+
+	public function test_defense_in_depth_gate(): void {
+		$this->assertStringContainsString( 'assert_elementor_available()', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Remove_Element.php
+++ b/tests/phpunit/abilities/Test_Elementor_Remove_Element.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Feature 067 — Remove_Element tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Remove_Element extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Remove_Element.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-remove-element'", $this->src );
+	}
+
+	public function test_destructive_annotation(): void {
+		$this->assertStringContainsString( "'destructive' => true", $this->src );
+	}
+
+	public function test_delegates_to_delete_element(): void {
+		$this->assertStringContainsString( '$delete = new Delete_Element()', $this->src );
+		$this->assertStringContainsString( '$delete->execute( $input )', $this->src );
+	}
+
+	public function test_input_has_force_delete_alias(): void {
+		$this->assertStringContainsString( "'force_delete'", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Reorder_Elements.php
+++ b/tests/phpunit/abilities/Test_Elementor_Reorder_Elements.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Feature 067 — Reorder_Elements tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Reorder_Elements extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Reorder_Elements.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-reorder-elements'", $this->src );
+	}
+
+	public function test_input_requires_post_id_and_ordered_ids(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'ordered_element_ids' )", $this->src );
+	}
+
+	public function test_supports_parent_id_null_for_root(): void {
+		$this->assertStringContainsString( "array( 'string', 'null' )", $this->src );
+	}
+
+	public function test_uses_reorder_children(): void {
+		$this->assertStringContainsString( 'Document_Repository::reorder_children', $this->src );
+	}
+
+	public function test_reads_back_effective_order(): void {
+		$this->assertStringContainsString( "'new_order'", $this->src );
+	}
+
+	public function test_defense_in_depth_gate(): void {
+		$this->assertStringContainsString( 'assert_elementor_available()', $this->src );
+	}
+}


### PR DESCRIPTION
## Summary

- Third batch of Feature 067 abilities merged to main **without a plugin version bump**. Plugin version stays at 0.0.25.
- Ships as an "Unreleased" changelog entry — no tag, no GitHub release.
- Completes the P1 element-scoped read/write surface.

## What's new — 6 abilities

| Slug | Purpose |
|---|---|
| `acrossai/elementor-merge-element-settings` | Deep-merge new settings into an element by ID. Additive; reports `changed_keys` |
| `acrossai/elementor-delete-element` | Remove element by ID; `force_delete=true` required for top-level or populated elements |
| `acrossai/elementor-remove-element` | Safer alias for `delete-element` with identical semantics |
| `acrossai/elementor-move-element` | Atomic move to new parent/position with descendant-guard |
| `acrossai/elementor-duplicate-element` | Deep-clone with fresh IDs throughout subtree; inserted as next sibling |
| `acrossai/elementor-reorder-elements` | Reorder direct children of parent (or root); omitted children retain prior order |

## Total shipped Elementor abilities: 13 of 88

Combined with previous merges:
- **Discovery**: `get-widget-controls`
- **Read**: `get-data`, `get-element`, `find-elements`
- **Write (element-scoped)**: `update-element`, `merge-element-settings`, `delete-element`, `remove-element`, `move-element`, `duplicate-element`, `reorder-elements`
- **Compose**: `add-container`, `add-widget`

Complete element R/W surface — clients can now build, edit, and reorganise Elementor pages end-to-end.

## Test plan

- [x] Full PHPUnit suite: **719 tests, 1629 assertions, 0 failures** (was 679 before this PR)
- [x] phpcs (WPCS strict): 0 errors
- [x] phpstan (level 8): 0 errors
- [ ] Plugin Check CI

## Not shipped in this PR

- No version bump (stays at 0.0.25)
- No git tag
- No GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)