### PR TITLE
feat(067 continued): 9 page-composition abilities (unreleased, no version bump)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -138,9 +138,20 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased (NOT YET RELEASED) =
-* **Feature 067 continued — 11 more Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available to anyone on the `main` branch but no plugin release / tag / distribution package has been cut. A future release will bundle these plus additional Feature 067 abilities under a single version bump.
+* **Feature 067 continued — 20 more Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available to anyone on the `main` branch but no plugin release / tag / distribution package has been cut. A future release will bundle these plus additional Feature 067 abilities under a single version bump.
 
-**Batch 3 — 6 more element-lifecycle abilities (this commit):**
+**Batch 4 — 9 page-composition abilities (this commit):**
+  * `acrossai/elementor-create-page` — insert a new post/page pre-configured for Elementor (sets `_elementor_edit_mode`, `_elementor_template_type`, `_elementor_version`; seeds empty `_elementor_data`). Returns edit URL.
+  * `acrossai/elementor-update-page-settings` — merge new page-level settings into `_elementor_page_settings`. `force_replace` guard on materially-smaller payloads.
+  * `acrossai/elementor-patch-data` — find/replace text within the raw Elementor JSON string; updates every widget containing the match in one pass.
+  * `acrossai/elementor-clone-data` — copy the full Elementor tree from one post to another with fresh element IDs throughout. Optionally include page settings. `force_replace` guard on populated targets.
+  * `acrossai/elementor-add-heading` — widget shortcut (title, header_size h1-h6, align, title_color).
+  * `acrossai/elementor-add-text-editor` — widget shortcut (editor HTML, align).
+  * `acrossai/elementor-add-image` — widget shortcut (image ID or URL, size, align, caption, link).
+  * `acrossai/elementor-add-button` — widget shortcut (text, link, size xs-xl, align).
+  * `acrossai/elementor-add-post-tabs` — higher-order shortcut: Nested Tabs widget where each tab contains a native Posts widget (optionally filtered by taxonomy term or query args).
+
+**Batch 3 — 6 element-lifecycle abilities (previously in this section):**
   * `acrossai/elementor-merge-element-settings` — deep-merge new settings into an element by ID. Additive (no force_replace guard needed); reports `changed_keys` in the response.
   * `acrossai/elementor-delete-element` — remove an element by ID. Guarded by `force_delete=true` for top-level or populated (with-children) elements.
   * `acrossai/elementor-remove-element` — safer alias for `delete-element` with identical semantics.
@@ -155,9 +166,9 @@ No data is sent to any external server without an explicit administrator action.
   * `acrossai/elementor-add-container` — insert Elementor v3+ container.
   * `acrossai/elementor-add-widget` — insert any registered widget (validated via `Widget_Controls`).
 
-**Test coverage:** 43 (batch 2) + 40 (batch 3) = 83 new source-inspection tests across 11 test files. Full suite: 719 tests, 1629 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
+**Test coverage:** 43 (batch 2) + 40 (batch 3) + 53 (batch 4) = 136 new source-inspection tests across 20 test files. Full suite: 772 tests, 1686 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
 
-**Total shipped Elementor abilities so far: 13 of 88.** Foundation + 2 released in 0.0.25 + 11 unreleased on main. Complete element-scoped R/W surface — clients can now discover schemas, read documents, find/get/update/merge/delete/move/duplicate/reorder elements, and compose pages from scratch.
+**Total shipped Elementor abilities so far: 22 of 88.** Foundation + 2 released in 0.0.25 + 20 unreleased on main. Complete page-composition surface — clients can now create Elementor pages, discover widget schemas, read documents, find/get/update/merge/delete/move/duplicate/reorder elements, add containers + widgets + heading/text/image/button/post-tabs shortcuts, patch text globally, and clone whole documents between posts.
 
 = 0.0.25 =
 * **New — Feature 067 Elementor Ability Suite (interim ship: foundation + 2 abilities).** First release of the planned 88-ability Elementor integration. This interim release delivers the full foundational infrastructure plus two highest-value abilities. Follow-up features (068+) will incrementally add the remaining 86 abilities.

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -448,6 +448,17 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Elementor\Move_Element();
 		new Elementor\Duplicate_Element();
 		new Elementor\Reorder_Elements();
+		// Document-scoped ops.
+		new Elementor\Create_Page();
+		new Elementor\Update_Page_Settings();
+		new Elementor\Patch_Data();
+		new Elementor\Clone_Data();
+		// Widget shortcuts.
+		new Elementor\Add_Heading();
+		new Elementor\Add_Text_Editor();
+		new Elementor\Add_Image();
+		new Elementor\Add_Button();
+		new Elementor\Add_Post_Tabs();
 	}
 
 	/**

--- a/includes/Abilities/Elementor/Add_Button.php
+++ b/includes/Abilities/Elementor/Add_Button.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Feature 067 — convenience wrapper: add an Elementor button widget.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Insert an Elementor button widget with text, link, size, and alignment.
+ */
+class Add_Button extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-add-button',
+			'args' => array(
+				'label'               => __( 'Add Elementor Button', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Insert an Elementor button widget with text, link, size, and alignment.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'   => array( 'type' => 'integer', 'minimum' => 1 ),
+						'parent_id' => array( 'type' => array( 'string', 'null' ) ),
+						'position'  => array( 'type' => 'integer', 'minimum' => 0 ),
+						'text'      => array( 'type' => 'string' ),
+						'link'      => array(
+							'type'       => 'object',
+							'properties' => array(
+								'url'         => array( 'type' => 'string' ),
+								'is_external' => array( 'type' => 'boolean' ),
+								'nofollow'    => array( 'type' => 'boolean' ),
+							),
+						),
+						'size'      => array( 'type' => 'string', 'enum' => array( 'xs', 'sm', 'md', 'lg', 'xl' ) ),
+						'align'     => array( 'type' => 'string', 'enum' => array( 'left', 'center', 'right', 'justify' ) ),
+					),
+					'required'             => array( 'post_id', 'text' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'post_id'    => array( 'type' => 'integer' ),
+						'element_id' => array( 'type' => 'string' ),
+						'element'    => array( 'type' => 'object' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$settings = array();
+		if ( isset( $input['text'] ) ) {
+			$settings['text'] = $input['text'];
+		}
+		if ( isset( $input['link'] ) ) {
+			$settings['link'] = $input['link'];
+		}
+		if ( isset( $input['size'] ) ) {
+			$settings['size'] = $input['size'];
+		}
+		if ( isset( $input['align'] ) ) {
+			$settings['align'] = $input['align'];
+		}
+		$delegate = new Add_Widget();
+		return $delegate->execute( array(
+			'post_id'     => $input['post_id'] ?? 0,
+			'widget_type' => 'button',
+			'parent_id'   => $input['parent_id'] ?? null,
+			'position'    => $input['position'] ?? 0,
+			'settings'    => $settings,
+		) );
+	}
+}

--- a/includes/Abilities/Elementor/Add_Heading.php
+++ b/includes/Abilities/Elementor/Add_Heading.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Feature 067 — convenience wrapper: add an Elementor heading widget.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Thin wrapper over Add_Widget with a type-specific input schema
+ * covering the heading widget's most-common settings.
+ */
+class Add_Heading extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-add-heading',
+			'args' => array(
+				'label'               => __( 'Add Elementor Heading', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Insert an Elementor heading widget with title, header size (h1-h6), alignment, and colour.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'     => array( 'type' => 'integer', 'minimum' => 1 ),
+						'parent_id'   => array( 'type' => array( 'string', 'null' ) ),
+						'position'    => array( 'type' => 'integer', 'minimum' => 0 ),
+						'title'       => array( 'type' => 'string' ),
+						'header_size' => array( 'type' => 'string', 'enum' => array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ) ),
+						'align'       => array( 'type' => 'string', 'enum' => array( 'left', 'center', 'right', 'justify' ) ),
+						'title_color' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'post_id', 'title' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'post_id'    => array( 'type' => 'integer' ),
+						'element_id' => array( 'type' => 'string' ),
+						'element'    => array( 'type' => 'object' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$settings = array();
+		foreach ( array( 'title', 'header_size', 'align', 'title_color' ) as $key ) {
+			if ( isset( $input[ $key ] ) ) {
+				$settings[ $key ] = $input[ $key ];
+			}
+		}
+		$delegate = new Add_Widget();
+		return $delegate->execute( array(
+			'post_id'     => $input['post_id'] ?? 0,
+			'widget_type' => 'heading',
+			'parent_id'   => $input['parent_id'] ?? null,
+			'position'    => $input['position'] ?? 0,
+			'settings'    => $settings,
+		) );
+	}
+}

--- a/includes/Abilities/Elementor/Add_Image.php
+++ b/includes/Abilities/Elementor/Add_Image.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Feature 067 — convenience wrapper: add an Elementor image widget.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Insert an Elementor image widget from an attachment ID or URL.
+ */
+class Add_Image extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-add-image',
+			'args' => array(
+				'label'               => __( 'Add Elementor Image', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Insert an Elementor image widget from an attachment ID or URL, with optional size, alignment, caption, and link.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'   => array( 'type' => 'integer', 'minimum' => 1 ),
+						'parent_id' => array( 'type' => array( 'string', 'null' ) ),
+						'position'  => array( 'type' => 'integer', 'minimum' => 0 ),
+						'image'     => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'  => array( 'type' => 'integer', 'minimum' => 0 ),
+								'url' => array( 'type' => 'string' ),
+							),
+						),
+						'size'      => array( 'type' => 'string' ),
+						'align'     => array( 'type' => 'string', 'enum' => array( 'left', 'center', 'right' ) ),
+						'caption'   => array( 'type' => 'string' ),
+						'link'      => array(
+							'type'       => 'object',
+							'properties' => array(
+								'url'          => array( 'type' => 'string' ),
+								'is_external'  => array( 'type' => 'boolean' ),
+								'nofollow'     => array( 'type' => 'boolean' ),
+							),
+						),
+					),
+					'required'             => array( 'post_id', 'image' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'post_id'    => array( 'type' => 'integer' ),
+						'element_id' => array( 'type' => 'string' ),
+						'element'    => array( 'type' => 'object' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$settings = array();
+		if ( isset( $input['image'] ) && is_array( $input['image'] ) ) {
+			$settings['image'] = $input['image'];
+		}
+		foreach ( array( 'size' => 'image_size', 'align' => 'align', 'caption' => 'caption', 'link' => 'link' ) as $in_key => $set_key ) {
+			if ( isset( $input[ $in_key ] ) ) {
+				$settings[ $set_key ] = $input[ $in_key ];
+			}
+		}
+		$delegate = new Add_Widget();
+		return $delegate->execute( array(
+			'post_id'     => $input['post_id'] ?? 0,
+			'widget_type' => 'image',
+			'parent_id'   => $input['parent_id'] ?? null,
+			'position'    => $input['position'] ?? 0,
+			'settings'    => $settings,
+		) );
+	}
+}

--- a/includes/Abilities/Elementor/Add_Post_Tabs.php
+++ b/includes/Abilities/Elementor/Add_Post_Tabs.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Feature 067 — convenience wrapper: build native Nested Tabs where each
+ * tab contains a Posts widget.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Insert a nested-tabs widget with one Posts widget per tab. Higher-order
+ * shortcut that composes several element types.
+ */
+class Add_Post_Tabs extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-add-post-tabs',
+			'args' => array(
+				'label'               => __( 'Add Elementor Post Tabs', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Insert a Nested Tabs widget where each tab contains a native Posts widget. Each tab can filter by taxonomy term or a custom query.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'   => array( 'type' => 'integer', 'minimum' => 1 ),
+						'parent_id' => array( 'type' => array( 'string', 'null' ) ),
+						'position'  => array( 'type' => 'integer', 'minimum' => 0 ),
+						'tabs'      => array(
+							'type'  => 'array',
+							'items' => array(
+								'type'       => 'object',
+								'properties' => array(
+									'title'    => array( 'type' => 'string' ),
+									'taxonomy' => array( 'type' => 'string' ),
+									'term_id'  => array( 'type' => 'integer' ),
+									'query'    => array( 'type' => 'object' ),
+								),
+							),
+						),
+					),
+					'required'             => array( 'post_id', 'tabs' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'post_id'    => array( 'type' => 'integer' ),
+						'element_id' => array( 'type' => 'string' ),
+						'tab_count'  => array( 'type' => 'integer' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'post_id' => 0, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+
+		$post_id   = absint( $input['post_id'] ?? 0 );
+		$parent_id = ( isset( $input['parent_id'] ) && '' !== $input['parent_id'] ) ? (string) $input['parent_id'] : null;
+		$position  = (int) ( $input['position'] ?? 0 );
+		$tabs      = isset( $input['tabs'] ) && is_array( $input['tabs'] ) ? array_values( $input['tabs'] ) : array();
+
+		if ( empty( $tabs ) ) {
+			return array( 'success' => false, 'post_id' => $post_id, 'message' => __( 'At least one tab is required.', 'acrossai-abilities-manager' ), 'error_code' => 'invalid_payload' );
+		}
+
+		$doc = Document_Repository::load_document( $post_id, 'edit' );
+		if ( is_wp_error( $doc ) ) {
+			return array( 'success' => false, 'post_id' => $post_id, 'message' => (string) $doc->get_error_message(), 'error_code' => (string) $doc->get_error_code() );
+		}
+
+		// Build nested-tabs element with one Posts widget per tab.
+		$tabs_id           = Document_Repository::generate_element_id();
+		$tab_items         = array();
+		$tab_content_items = array();
+		foreach ( $tabs as $index => $tab_input ) {
+			if ( ! is_array( $tab_input ) ) {
+				continue;
+			}
+			$tab_item_id = Document_Repository::generate_element_id();
+			$tab_items[] = array( '_id' => $tab_item_id, 'tab_title' => (string) ( $tab_input['title'] ?? 'Tab ' . ( $index + 1 ) ) );
+
+			$posts_settings = array();
+			if ( ! empty( $tab_input['taxonomy'] ) && ! empty( $tab_input['term_id'] ) ) {
+				$posts_settings['query_' . $tab_input['taxonomy'] . '_ids'] = array( (int) $tab_input['term_id'] );
+			}
+			if ( ! empty( $tab_input['query'] ) && is_array( $tab_input['query'] ) ) {
+				$posts_settings = array_merge( $posts_settings, $tab_input['query'] );
+			}
+			$tab_content_items[] = array(
+				'id'         => Document_Repository::generate_element_id(),
+				'elType'     => 'container',
+				'settings'   => array( 'content_width' => 'full' ),
+				'isInner'    => true,
+				'elements'   => array(
+					array(
+						'id'         => Document_Repository::generate_element_id(),
+						'elType'     => 'widget',
+						'widgetType' => 'posts',
+						'settings'   => $posts_settings,
+						'elements'   => array(),
+					),
+				),
+			);
+		}
+
+		$nested_tabs = array(
+			'id'         => $tabs_id,
+			'elType'     => 'widget',
+			'widgetType' => 'nested-tabs',
+			'settings'   => array(
+				'tabs'                     => $tab_items,
+				'horizontal_scroll'        => 'disable',
+				'tabs_direction'           => 'top',
+				'tabs_alignment'           => 'flex-start',
+			),
+			'elements'   => $tab_content_items,
+		);
+
+		if ( ! Document_Repository::insert_element( $doc['data'], $parent_id, $position, $nested_tabs ) ) {
+			return array( 'success' => false, 'post_id' => $post_id, 'message' => __( 'Failed to insert Nested Tabs element.', 'acrossai-abilities-manager' ), 'error_code' => 'element_not_found' );
+		}
+		$saved = Document_Repository::save_data( $post_id, $doc['data'], 'post' );
+		if ( is_wp_error( $saved ) ) {
+			return array( 'success' => false, 'post_id' => $post_id, 'message' => (string) $saved->get_error_message(), 'error_code' => (string) $saved->get_error_code() );
+		}
+
+		return array(
+			'success'    => true,
+			'post_id'    => $post_id,
+			'element_id' => $tabs_id,
+			'tab_count'  => count( $tab_items ),
+			/* translators: 1: count, 2: element id, 3: post id */
+			'message'    => sprintf( __( 'Inserted post-tabs widget %2$s with %1$d tabs on post #%3$d.', 'acrossai-abilities-manager' ), count( $tab_items ), $tabs_id, $post_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Add_Text_Editor.php
+++ b/includes/Abilities/Elementor/Add_Text_Editor.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Feature 067 — convenience wrapper: add an Elementor text-editor widget.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Insert an Elementor text-editor widget.
+ */
+class Add_Text_Editor extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-add-text-editor',
+			'args' => array(
+				'label'               => __( 'Add Elementor Text Editor', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Insert an Elementor text-editor widget with HTML content and alignment.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'   => array( 'type' => 'integer', 'minimum' => 1 ),
+						'parent_id' => array( 'type' => array( 'string', 'null' ) ),
+						'position'  => array( 'type' => 'integer', 'minimum' => 0 ),
+						'editor'    => array( 'type' => 'string' ),
+						'align'     => array( 'type' => 'string', 'enum' => array( 'left', 'center', 'right', 'justify' ) ),
+					),
+					'required'             => array( 'post_id', 'editor' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'post_id'    => array( 'type' => 'integer' ),
+						'element_id' => array( 'type' => 'string' ),
+						'element'    => array( 'type' => 'object' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$settings = array();
+		foreach ( array( 'editor', 'align' ) as $key ) {
+			if ( isset( $input[ $key ] ) ) {
+				$settings[ $key ] = $input[ $key ];
+			}
+		}
+		$delegate = new Add_Widget();
+		return $delegate->execute( array(
+			'post_id'     => $input['post_id'] ?? 0,
+			'widget_type' => 'text-editor',
+			'parent_id'   => $input['parent_id'] ?? null,
+			'position'    => $input['position'] ?? 0,
+			'settings'    => $settings,
+		) );
+	}
+}

--- a/includes/Abilities/Elementor/Clone_Data.php
+++ b/includes/Abilities/Elementor/Clone_Data.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Feature 067 — clone Elementor document data from one post to another.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Copy the full Elementor tree (and optionally page settings) from
+ * source_post_id to target_post_id. Regenerates every element ID in
+ * the cloned tree. Guarded by force_replace when target has content.
+ */
+class Clone_Data extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-clone-data',
+			'args' => array(
+				'label'               => __( 'Clone Elementor Document Data', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Copy the full Elementor tree from one post to another with fresh element IDs throughout. Optionally include page settings. Guarded by force_replace when the target already has content.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'source_post_id'        => array( 'type' => 'integer', 'minimum' => 1 ),
+						'target_post_id'        => array( 'type' => 'integer', 'minimum' => 1 ),
+						'include_page_settings' => array( 'type' => 'boolean', 'default' => false ),
+						'force_replace'         => array( 'type' => 'boolean', 'default' => false ),
+					),
+					'required'             => array( 'source_post_id', 'target_post_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'source_post_id' => array( 'type' => 'integer' ),
+						'target_post_id' => array( 'type' => 'integer' ),
+						'element_count'  => array( 'type' => 'integer' ),
+						'message'        => array( 'type' => 'string' ),
+						'error_code'     => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'source_post_id' => 0, 'target_post_id' => 0, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$source_post_id        = absint( $input['source_post_id'] ?? 0 );
+		$target_post_id        = absint( $input['target_post_id'] ?? 0 );
+		$include_page_settings = ! empty( $input['include_page_settings'] );
+		$force_replace         = ! empty( $input['force_replace'] );
+
+		if ( $source_post_id === $target_post_id ) {
+			return $this->fail( $source_post_id, $target_post_id, 'invalid_payload', __( 'source_post_id and target_post_id must differ.', 'acrossai-abilities-manager' ) );
+		}
+
+		$source = Document_Repository::load_document( $source_post_id, 'read' );
+		if ( is_wp_error( $source ) ) {
+			return $this->fail( $source_post_id, $target_post_id, (string) $source->get_error_code(), (string) $source->get_error_message() );
+		}
+		$target = Document_Repository::load_document( $target_post_id, 'edit' );
+		if ( is_wp_error( $target ) ) {
+			return $this->fail( $source_post_id, $target_post_id, (string) $target->get_error_code(), (string) $target->get_error_message() );
+		}
+
+		if ( ! $force_replace && Document_Repository::is_document_populated( $target['data'] ) ) {
+			return $this->fail( $source_post_id, $target_post_id, 'force_replace_required', __( 'Target post already has Elementor content. Pass force_replace=true to overwrite.', 'acrossai-abilities-manager' ) );
+		}
+
+		// Deep-clone the source tree with fresh IDs.
+		$cloned = array();
+		foreach ( $source['data'] as $element ) {
+			if ( is_array( $element ) ) {
+				$cloned[] = Document_Repository::reassign_subtree_ids( $element );
+			}
+		}
+
+		$saved = Document_Repository::save_data( $target_post_id, $cloned, 'post' );
+		if ( is_wp_error( $saved ) ) {
+			return $this->fail( $source_post_id, $target_post_id, (string) $saved->get_error_code(), (string) $saved->get_error_message() );
+		}
+
+		if ( $include_page_settings && ! empty( $source['page_settings'] ) ) {
+			update_post_meta( $target_post_id, '_elementor_page_settings', $source['page_settings'] );
+		}
+
+		$element_count = 0;
+		Document_Repository::walk_tree( $cloned, static function () use ( &$element_count ): void { ++$element_count; } );
+
+		return array(
+			'success'        => true,
+			'source_post_id' => $source_post_id,
+			'target_post_id' => $target_post_id,
+			'element_count'  => $element_count,
+			/* translators: 1: element count, 2: source, 3: target */
+			'message'        => sprintf( __( 'Cloned %1$d elements from post #%2$d to post #%3$d.', 'acrossai-abilities-manager' ), $element_count, $source_post_id, $target_post_id ),
+		);
+	}
+
+	/**
+	 * @param int    $source
+	 * @param int    $target
+	 * @param string $code
+	 * @param string $message
+	 * @return array<string,mixed>
+	 */
+	private function fail( int $source, int $target, string $code, string $message ): array {
+		return array(
+			'success'        => false,
+			'source_post_id' => $source,
+			'target_post_id' => $target,
+			'message'        => $message,
+			'error_code'     => $code,
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Create_Page.php
+++ b/includes/Abilities/Elementor/Create_Page.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Feature 067 — create a new post/page pre-configured for Elementor.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Insert a new post/page and configure it as an Elementor document
+ * (sets _elementor_edit_mode, _elementor_template_type, _elementor_version).
+ */
+class Create_Page extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-create-page',
+			'args' => array(
+				'label'               => __( 'Create Elementor Page', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Create a new post or page with Elementor builder mode enabled. Returns the new post ID and edit URL.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'title'         => array( 'type' => 'string' ),
+						'post_type'     => array( 'type' => 'string', 'default' => 'page' ),
+						'status'        => array( 'type' => 'string', 'enum' => array( 'draft', 'publish', 'private' ), 'default' => 'draft' ),
+						'template'      => array( 'type' => 'string' ),
+						'page_settings' => array( 'type' => 'object' ),
+					),
+					'required'             => array( 'title' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'  => array( 'type' => 'boolean' ),
+						'post_id'  => array( 'type' => 'integer' ),
+						'edit_url' => array( 'type' => 'string' ),
+						'message'  => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+
+		$title         = isset( $input['title'] ) ? sanitize_text_field( (string) $input['title'] ) : '';
+		$post_type     = isset( $input['post_type'] ) ? sanitize_key( (string) $input['post_type'] ) : 'page';
+		$status        = isset( $input['status'] ) ? sanitize_key( (string) $input['status'] ) : 'draft';
+		$template      = isset( $input['template'] ) ? sanitize_text_field( (string) $input['template'] ) : '';
+		$page_settings = isset( $input['page_settings'] ) && is_array( $input['page_settings'] ) ? $input['page_settings'] : array();
+
+		if ( '' === $title ) {
+			return array( 'success' => false, 'message' => __( 'title is required.', 'acrossai-abilities-manager' ), 'error_code' => 'invalid_payload' );
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => $title,
+				'post_type'   => $post_type,
+				'post_status' => $status,
+			),
+			true
+		);
+		if ( is_wp_error( $post_id ) ) {
+			return array( 'success' => false, 'message' => (string) $post_id->get_error_message(), 'error_code' => (string) $post_id->get_error_code() );
+		}
+		$post_id = (int) $post_id;
+
+		// Configure the post for Elementor authoring.
+		update_post_meta( $post_id, '_elementor_edit_mode', 'builder' );
+		$template_type = 'page' === $post_type ? 'wp-page' : 'wp-post';
+		update_post_meta( $post_id, '_elementor_template_type', $template_type );
+		if ( defined( 'ELEMENTOR_VERSION' ) ) {
+			update_post_meta( $post_id, '_elementor_version', ELEMENTOR_VERSION );
+		}
+		// Seed _elementor_data with an empty array so the editor treats the doc as Elementor.
+		Document_Repository::save_data( $post_id, array(), 'none' );
+		if ( '' !== $template ) {
+			update_post_meta( $post_id, '_wp_page_template', $template );
+		}
+		if ( ! empty( $page_settings ) ) {
+			update_post_meta( $post_id, '_elementor_page_settings', $page_settings );
+		}
+
+		$edit_url = admin_url( sprintf( 'post.php?post=%d&action=elementor', $post_id ) );
+
+		return array(
+			'success'  => true,
+			'post_id'  => $post_id,
+			'edit_url' => $edit_url,
+			/* translators: 1: post type, 2: post id */
+			'message'  => sprintf( __( 'Created Elementor %1$s #%2$d.', 'acrossai-abilities-manager' ), $post_type, $post_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Patch_Data.php
+++ b/includes/Abilities/Elementor/Patch_Data.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Feature 067 — find/replace text within an Elementor document.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Search-and-replace text within an Elementor document's serialised JSON.
+ * Case-sensitive; returns the replacement count.
+ */
+class Patch_Data extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-patch-data',
+			'args' => array(
+				'label'               => __( 'Patch Elementor Document Data', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Find and replace text within an Elementor document\'s serialised JSON. Operates on the raw string so it can update text in any control (headings, text-editors, buttons, image alt-text, etc.) in one pass. Case-sensitive.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'     => array( 'type' => 'integer', 'minimum' => 1 ),
+						'find'        => array( 'type' => 'string' ),
+						'replace'     => array( 'type' => 'string' ),
+						'cache_scope' => array( 'type' => 'string', 'enum' => array( 'none', 'post', 'site' ), 'default' => 'post' ),
+					),
+					'required'             => array( 'post_id', 'find', 'replace' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'post_id'      => array( 'type' => 'integer' ),
+						'replacements' => array( 'type' => 'integer' ),
+						'message'      => array( 'type' => 'string' ),
+						'error_code'   => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'post_id' => 0, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$post_id     = absint( $input['post_id'] ?? 0 );
+		$find        = isset( $input['find'] ) ? (string) $input['find'] : '';
+		$replace     = isset( $input['replace'] ) ? (string) $input['replace'] : '';
+		$cache_scope = isset( $input['cache_scope'] ) ? (string) $input['cache_scope'] : 'post';
+
+		if ( '' === $find ) {
+			return array( 'success' => false, 'post_id' => $post_id, 'message' => __( 'find is required.', 'acrossai-abilities-manager' ), 'error_code' => 'invalid_payload' );
+		}
+
+		$doc = Document_Repository::load_document( $post_id, 'edit' );
+		if ( is_wp_error( $doc ) ) {
+			return array( 'success' => false, 'post_id' => $post_id, 'message' => (string) $doc->get_error_message(), 'error_code' => (string) $doc->get_error_code() );
+		}
+
+		$raw    = (string) $doc['raw_data'];
+		$count  = 0;
+		$patched = str_replace( $find, $replace, $raw, $count );
+		if ( 0 === $count ) {
+			return array(
+				'success'      => true,
+				'post_id'      => $post_id,
+				'replacements' => 0,
+				'message'      => __( 'No matches found — nothing changed.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$parsed = Document_Repository::decode_data( $patched );
+		$saved  = Document_Repository::save_data( $post_id, $parsed, $cache_scope );
+		if ( is_wp_error( $saved ) ) {
+			return array( 'success' => false, 'post_id' => $post_id, 'message' => (string) $saved->get_error_message(), 'error_code' => (string) $saved->get_error_code() );
+		}
+
+		return array(
+			'success'      => true,
+			'post_id'      => $post_id,
+			'replacements' => (int) $count,
+			/* translators: 1: count, 2: post id */
+			'message'      => sprintf( __( 'Replaced %1$d occurrences in post #%2$d.', 'acrossai-abilities-manager' ), $count, $post_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Update_Page_Settings.php
+++ b/includes/Abilities/Elementor/Update_Page_Settings.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Feature 067 — update Elementor document-level page settings.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Merge new page_settings into _elementor_page_settings post meta.
+ * Guarded by force_replace when the new payload is materially smaller.
+ */
+class Update_Page_Settings extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-update-page-settings',
+			'args' => array(
+				'label'               => __( 'Update Elementor Page Settings', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Update the Elementor document-level page settings (layout, title, background, custom CSS). Merges new keys into existing settings; use force_replace=true to overwrite the full settings object.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'post_id'       => array( 'type' => 'integer', 'minimum' => 1 ),
+						'page_settings' => array( 'type' => 'object' ),
+						'force_replace' => array( 'type' => 'boolean', 'default' => false ),
+					),
+					'required'             => array( 'post_id', 'page_settings' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'post_id'       => array( 'type' => 'integer' ),
+						'page_settings' => array( 'type' => 'object' ),
+						'message'       => array( 'type' => 'string' ),
+						'error_code'    => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'core',
+						'sub_group'       => 'elementor',
+						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'post_id' => 0, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$post_id       = absint( $input['post_id'] ?? 0 );
+		$new_settings  = isset( $input['page_settings'] ) && is_array( $input['page_settings'] ) ? $input['page_settings'] : array();
+		$force_replace = ! empty( $input['force_replace'] );
+
+		$doc = Document_Repository::load_document( $post_id, 'edit' );
+		if ( is_wp_error( $doc ) ) {
+			return array( 'success' => false, 'post_id' => $post_id, 'message' => (string) $doc->get_error_message(), 'error_code' => (string) $doc->get_error_code() );
+		}
+
+		$existing = is_array( $doc['page_settings'] ) ? $doc['page_settings'] : array();
+		if ( ! $force_replace && count( $existing ) > 0 && count( $new_settings ) < ( count( $existing ) / 2 ) ) {
+			return array(
+				'success'    => false,
+				'post_id'    => $post_id,
+				'message'    => __( 'New page_settings is materially smaller than existing. Pass force_replace=true to overwrite.', 'acrossai-abilities-manager' ),
+				'error_code' => 'force_replace_required',
+			);
+		}
+
+		$merged = $force_replace ? $new_settings : array_merge( $existing, $new_settings );
+		update_post_meta( $post_id, '_elementor_page_settings', $merged );
+		Document_Repository::invalidate_cache( $post_id, 'post' );
+
+		return array(
+			'success'       => true,
+			'post_id'       => $post_id,
+			'page_settings' => $merged,
+			/* translators: %d: post id */
+			'message'       => sprintf( __( 'Updated page settings on post #%d.', 'acrossai-abilities-manager' ), $post_id ),
+		);
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -113,6 +113,15 @@
 			<file>tests/phpunit/abilities/Test_Elementor_Move_Element.php</file>
 			<file>tests/phpunit/abilities/Test_Elementor_Duplicate_Element.php</file>
 			<file>tests/phpunit/abilities/Test_Elementor_Reorder_Elements.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Create_Page.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Update_Page_Settings.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Patch_Data.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Clone_Data.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Add_Heading.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Add_Text_Editor.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Add_Image.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Add_Button.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Add_Post_Tabs.php</file>
 			<file>tests/phpunit/abilities/Test_Move_Block.php</file>
 			<file>tests/phpunit/abilities/Test_Duplicate_Block.php</file>
 			<file>tests/phpunit/abilities/Test_Insert_Pattern.php</file>

--- a/tests/phpunit/abilities/Test_Elementor_Add_Button.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Button.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Feature 067 — Add_Button tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Add_Button extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Add_Button.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-add-button'", $this->src );
+	}
+
+	public function test_requires_post_id_and_text(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'text' )", $this->src );
+	}
+
+	public function test_size_enum(): void {
+		$this->assertStringContainsString( "'xs', 'sm', 'md', 'lg', 'xl'", $this->src );
+	}
+
+	public function test_delegates_to_add_widget(): void {
+		$this->assertStringContainsString( "'widget_type' => 'button'", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Add_Heading.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Heading.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Feature 067 — Add_Heading tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Add_Heading extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Add_Heading.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-add-heading'", $this->src );
+	}
+
+	public function test_requires_post_id_and_title(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'title' )", $this->src );
+	}
+
+	public function test_header_size_enum(): void {
+		$this->assertStringContainsString( "'h1', 'h2', 'h3', 'h4', 'h5', 'h6'", $this->src );
+	}
+
+	public function test_delegates_to_add_widget(): void {
+		$this->assertStringContainsString( '$delegate = new Add_Widget()', $this->src );
+		$this->assertStringContainsString( "'widget_type' => 'heading'", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Add_Image.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Image.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Feature 067 — Add_Image tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Add_Image extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Add_Image.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-add-image'", $this->src );
+	}
+
+	public function test_requires_post_id_and_image(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'image' )", $this->src );
+	}
+
+	public function test_delegates_to_add_widget(): void {
+		$this->assertStringContainsString( "'widget_type' => 'image'", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Add_Post_Tabs.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Post_Tabs.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Feature 067 — Add_Post_Tabs tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Add_Post_Tabs extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Add_Post_Tabs.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-add-post-tabs'", $this->src );
+	}
+
+	public function test_requires_post_id_and_tabs(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'tabs' )", $this->src );
+	}
+
+	public function test_builds_nested_tabs_widget(): void {
+		$this->assertStringContainsString( "'widgetType' => 'nested-tabs'", $this->src );
+	}
+
+	public function test_each_tab_contains_posts_widget(): void {
+		$this->assertStringContainsString( "'widgetType' => 'posts'", $this->src );
+	}
+
+	public function test_returns_tab_count(): void {
+		$this->assertStringContainsString( "'tab_count'", $this->src );
+	}
+
+	public function test_defense_in_depth_gate(): void {
+		$this->assertStringContainsString( 'assert_elementor_available()', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Add_Text_Editor.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Text_Editor.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Feature 067 — Add_Text_Editor tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Add_Text_Editor extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Add_Text_Editor.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-add-text-editor'", $this->src );
+	}
+
+	public function test_requires_post_id_and_editor(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'editor' )", $this->src );
+	}
+
+	public function test_delegates_to_add_widget(): void {
+		$this->assertStringContainsString( "'widget_type' => 'text-editor'", $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Clone_Data.php
+++ b/tests/phpunit/abilities/Test_Elementor_Clone_Data.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Feature 067 — Clone_Data tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Clone_Data extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Clone_Data.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-clone-data'", $this->src );
+	}
+
+	public function test_requires_source_and_target(): void {
+		$this->assertStringContainsString( "'required'             => array( 'source_post_id', 'target_post_id' )", $this->src );
+	}
+
+	public function test_force_replace_guard_on_populated_target(): void {
+		$this->assertStringContainsString( "'force_replace_required'", $this->src );
+		$this->assertStringContainsString( 'is_document_populated', $this->src );
+	}
+
+	public function test_reassigns_subtree_ids(): void {
+		$this->assertStringContainsString( 'Document_Repository::reassign_subtree_ids', $this->src );
+	}
+
+	public function test_optionally_copies_page_settings(): void {
+		$this->assertStringContainsString( '$include_page_settings', $this->src );
+	}
+
+	public function test_defense_in_depth_gate(): void {
+		$this->assertStringContainsString( 'assert_elementor_available()', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Create_Page.php
+++ b/tests/phpunit/abilities/Test_Elementor_Create_Page.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Feature 067 — Create_Page tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Create_Page extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Create_Page.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-create-page'", $this->src );
+	}
+
+	public function test_input_requires_title(): void {
+		$this->assertStringContainsString( "'required'             => array( 'title' )", $this->src );
+	}
+
+	public function test_configures_elementor_meta(): void {
+		$this->assertStringContainsString( "'_elementor_edit_mode', 'builder'", $this->src );
+		$this->assertStringContainsString( "'_elementor_template_type'", $this->src );
+		$this->assertStringContainsString( "'_elementor_version'", $this->src );
+	}
+
+	public function test_seeds_empty_elementor_data(): void {
+		$this->assertStringContainsString( "Document_Repository::save_data( \$post_id, array(), 'none' )", $this->src );
+	}
+
+	public function test_returns_edit_url(): void {
+		$this->assertStringContainsString( "'edit_url'", $this->src );
+	}
+
+	public function test_defense_in_depth_gate(): void {
+		$this->assertStringContainsString( 'assert_elementor_available()', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Patch_Data.php
+++ b/tests/phpunit/abilities/Test_Elementor_Patch_Data.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Feature 067 — Patch_Data tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Patch_Data extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Patch_Data.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-patch-data'", $this->src );
+	}
+
+	public function test_requires_post_id_find_replace(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'find', 'replace' )", $this->src );
+	}
+
+	public function test_uses_str_replace(): void {
+		$this->assertStringContainsString( 'str_replace( $find, $replace, $raw, $count )', $this->src );
+	}
+
+	public function test_returns_replacement_count(): void {
+		$this->assertStringContainsString( "'replacements'", $this->src );
+	}
+
+	public function test_destructive_annotation(): void {
+		$this->assertStringContainsString( "'destructive' => true", $this->src );
+	}
+
+	public function test_defense_in_depth_gate(): void {
+		$this->assertStringContainsString( 'assert_elementor_available()', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Elementor_Update_Page_Settings.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Page_Settings.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Feature 067 — Update_Page_Settings tests.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Elementor_Update_Page_Settings extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Update_Page_Settings.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/elementor-update-page-settings'", $this->src );
+	}
+
+	public function test_requires_post_id_and_page_settings(): void {
+		$this->assertStringContainsString( "'required'             => array( 'post_id', 'page_settings' )", $this->src );
+	}
+
+	public function test_force_replace_guard(): void {
+		$this->assertStringContainsString( "'force_replace_required'", $this->src );
+	}
+
+	public function test_updates_page_settings_meta(): void {
+		$this->assertStringContainsString( "update_post_meta( \$post_id, '_elementor_page_settings',", $this->src );
+	}
+
+	public function test_invalidates_cache(): void {
+		$this->assertStringContainsString( 'Document_Repository::invalidate_cache', $this->src );
+	}
+
+	public function test_defense_in_depth_gate(): void {
+		$this->assertStringContainsString( 'assert_elementor_available()', $this->src );
+	}
+}


### PR DESCRIPTION
## Summary

- Fourth batch of Feature 067 abilities merged to main **without a plugin version bump**. Version stays at 0.0.25.
- Ships as an "Unreleased" changelog entry.
- Delivers the full page-composition surface: create pages, patch/clone documents, 5 widget shortcuts.

## What's new — 9 abilities

**Document-scoped operations (4):**
| Slug | Purpose |
|---|---|
| `acrossai/elementor-create-page` | Insert new post/page pre-configured for Elementor with edit_mode / template_type / version meta and edit URL |
| `acrossai/elementor-update-page-settings` | Merge new settings into `_elementor_page_settings`; `force_replace` guard |
| `acrossai/elementor-patch-data` | Find/replace text in raw Elementor JSON — updates every matching widget in one pass |
| `acrossai/elementor-clone-data` | Copy full tree from source to target with fresh IDs; optional page settings; `force_replace` guard |

**Widget shortcuts (5):** heading, text-editor, image, button, post-tabs — each with a type-specific input schema that delegates to `Add_Widget` internally.

## Total shipped Elementor abilities: 22 of 88

Combined with previous merges, clients can now create Elementor pages end-to-end: discover widget schemas → create page → add containers → add widgets (via shortcut or generic) → find/edit/move/duplicate/reorder elements → patch text globally → clone documents to reuse.

## Test plan

- [x] Full PHPUnit suite: **772 tests, 1686 assertions, 0 failures** (was 719 before this PR)
- [x] phpcs (WPCS strict): 0 errors
- [x] phpstan (level 8): 0 errors
- [ ] Plugin Check CI

## Not shipped in this PR

- No version bump (stays at 0.0.25)
- No git tag
- No GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)