### PR TITLE
feat(067 continued): 11 template CRUD abilities (unreleased, no version bump)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -138,9 +138,22 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased (NOT YET RELEASED) =
-* **Feature 067 continued — 31 more Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available to anyone on the `main` branch but no plugin release / tag / distribution package has been cut. A future release will bundle these plus additional Feature 067 abilities under a single version bump.
+* **Feature 067 continued — 42 more Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available to anyone on the `main` branch but no plugin release / tag / distribution package has been cut. A future release will bundle these plus additional Feature 067 abilities under a single version bump.
 
-**Batch 5 — 11 site-management abilities (this commit):**
+**Batch 6 — 11 template abilities (this commit):**
+  * `acrossai/elementor-list-templates` — list saved templates with filters on `template_type` + `status` + pagination.
+  * `acrossai/elementor-get-template` — return one template's metadata + conditions + optional `_elementor_data`.
+  * `acrossai/elementor-create-template` — create a new template of type page / section / popup / header / footer / single / archive; sets taxonomy term + Elementor meta.
+  * `acrossai/elementor-update-template` — update title / page_settings / full data with `force_replace` guard.
+  * `acrossai/elementor-delete-template` — trash (default) or permanently delete with `force=true`.
+  * `acrossai/elementor-restore-template` — restore a trashed template.
+  * `acrossai/elementor-duplicate-template` — clone template preserving type + conditions + sub_type; regenerates element IDs.
+  * `acrossai/elementor-empty-trash` — permanently delete every trashed template; requires `confirm=true`.
+  * `acrossai/elementor-export-template` — export template as JSON-encodable object (title, template_type, sub_type, page_settings, content, conditions).
+  * `acrossai/elementor-import-template` — import from JSON export; regenerates element IDs; optional `overwrite_id` to replace an existing template.
+  * `acrossai/elementor-find-template-for-pattern` — rank saved templates by keyword match (title + tax term + widget-types in content); returns top N with scores.
+
+**Batch 5 — 11 site-management abilities:**
   * `acrossai/elementor-clear-cache` — clear Elementor cache at post / site / all scope; optional `regenerate_css=true` for a specific post.
   * `acrossai/elementor-replace-urls` — bulk find/replace URLs across every Elementor document on the site with `dry_run=true` default preview.
   * `acrossai/elementor-get-maintenance-mode` — read current maintenance mode settings (mode, template, exclude rules).
@@ -179,9 +192,9 @@ No data is sent to any external server without an explicit administrator action.
   * `acrossai/elementor-add-container` — insert Elementor v3+ container.
   * `acrossai/elementor-add-widget` — insert any registered widget (validated via `Widget_Controls`).
 
-**Test coverage:** 43 (b2) + 40 (b3) + 53 (b4) + 64 (b5) = 200 new source-inspection tests across 31 test files. Full suite: 836 tests, 1754 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
+**Test coverage:** 43 (b2) + 40 (b3) + 53 (b4) + 64 (b5) + 53 (b6) = 253 new source-inspection tests across 42 test files. Full suite: 889 tests, 1809 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
 
-**Total shipped Elementor abilities so far: 33 of 88.** Foundation + 2 released in 0.0.25 + 31 unreleased on main. Complete page-composition + site-management + discovery surface — clients can now create Elementor pages, discover widget schemas and pattern guidance, read documents, find/get/update/merge/delete/move/duplicate/reorder elements, add containers + widgets + shortcuts, patch text globally, clone whole documents between posts, clear cache, replace URLs site-wide, manage maintenance mode + Theme Builder conditions, read theme/kit/style-guide context.
+**Total shipped Elementor abilities so far: 44 of 88.** Foundation + 2 released in 0.0.25 + 42 unreleased on main. Complete page-composition + site-management + discovery + template CRUD surface — clients can now create Elementor pages, manage templates end-to-end (list/get/create/update/delete/restore/duplicate/empty-trash/export/import/find-pattern), discover widget schemas and pattern guidance, read documents, find/get/update/merge/delete/move/duplicate/reorder elements, add containers + widgets + shortcuts, patch text globally, clone whole documents, clear cache, replace URLs, manage maintenance mode + Theme Builder conditions.
 
 = 0.0.25 =
 * **New — Feature 067 Elementor Ability Suite (interim ship: foundation + 2 abilities).** First release of the planned 88-ability Elementor integration. This interim release delivers the full foundational infrastructure plus two highest-value abilities. Follow-up features (068+) will incrementally add the remaining 86 abilities.

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -473,6 +473,18 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Elementor\Get_Theme_Context();
 		new Elementor\Get_Style_Guide();
 		new Elementor\Evaluate_Render_Context();
+		// Templates (Group 4 — full CRUD).
+		new Elementor\List_Templates();
+		new Elementor\Get_Template();
+		new Elementor\Create_Template();
+		new Elementor\Update_Template();
+		new Elementor\Delete_Template();
+		new Elementor\Restore_Template();
+		new Elementor\Duplicate_Template();
+		new Elementor\Empty_Trash();
+		new Elementor\Export_Template();
+		new Elementor\Import_Template();
+		new Elementor\Find_Template_For_Pattern();
 	}
 
 	/**

--- a/includes/Abilities/Elementor/Create_Template.php
+++ b/includes/Abilities/Elementor/Create_Template.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Feature 067 — create a new Elementor template.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Create_Template extends Ability_Definition {
+
+	private const VALID_TYPES = array( 'page', 'section', 'popup', 'header', 'footer', 'single', 'archive', 'kit', 'container' );
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-create-template',
+			'args' => array(
+				'label'               => __( 'Create Elementor Template', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Create a new Elementor template. Supports type = page | section | popup | header | footer | single | archive.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'title'          => array( 'type' => 'string' ),
+						'type'           => array( 'type' => 'string', 'enum' => self::VALID_TYPES ),
+						'status'         => array( 'type' => 'string', 'default' => 'publish' ),
+						'data'           => array( 'type' => 'array' ),
+						'conditions'     => array( 'type' => 'array' ),
+						'popup_settings' => array( 'type' => 'object' ),
+					),
+					'required'   => array( 'title', 'type' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'template_id' => array( 'type' => 'integer' ),
+						'edit_url'    => array( 'type' => 'string' ),
+						'message'     => array( 'type' => 'string' ),
+						'error_code'  => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$title  = isset( $input['title'] ) ? sanitize_text_field( (string) $input['title'] ) : '';
+		$type   = isset( $input['type'] ) ? sanitize_key( (string) $input['type'] ) : '';
+		$status = isset( $input['status'] ) ? sanitize_key( (string) $input['status'] ) : 'publish';
+		$data   = isset( $input['data'] ) && is_array( $input['data'] ) ? $input['data'] : array();
+		$conds  = isset( $input['conditions'] ) && is_array( $input['conditions'] ) ? $input['conditions'] : array();
+		$popup  = isset( $input['popup_settings'] ) && is_array( $input['popup_settings'] ) ? $input['popup_settings'] : array();
+
+		if ( '' === $title || ! in_array( $type, self::VALID_TYPES, true ) ) {
+			return array( 'success' => false, 'message' => __( 'title and a valid type are required.', 'acrossai-abilities-manager' ), 'error_code' => 'invalid_template_type' );
+		}
+
+		$template_id = wp_insert_post( array(
+			'post_title'  => $title,
+			'post_type'   => Template_Query::CPT,
+			'post_status' => $status,
+		), true );
+		if ( is_wp_error( $template_id ) ) {
+			return array( 'success' => false, 'message' => (string) $template_id->get_error_message(), 'error_code' => (string) $template_id->get_error_code() );
+		}
+		$template_id = (int) $template_id;
+
+		wp_set_object_terms( $template_id, $type, Template_Query::TYPE_TAX, false );
+		update_post_meta( $template_id, '_elementor_edit_mode', 'builder' );
+		update_post_meta( $template_id, '_elementor_template_type', $type );
+		if ( defined( 'ELEMENTOR_VERSION' ) ) {
+			update_post_meta( $template_id, '_elementor_version', ELEMENTOR_VERSION );
+		}
+		Document_Repository::save_data( $template_id, $data, 'none' );
+		if ( ! empty( $conds ) ) {
+			update_post_meta( $template_id, '_elementor_conditions', $conds );
+		}
+		if ( ! empty( $popup ) && 'popup' === $type ) {
+			update_post_meta( $template_id, '_elementor_page_settings', $popup );
+		}
+
+		return array(
+			'success'     => true,
+			'template_id' => $template_id,
+			'edit_url'    => admin_url( sprintf( 'post.php?post=%d&action=elementor', $template_id ) ),
+			/* translators: 1: type, 2: id */
+			'message'     => sprintf( __( 'Created %1$s template #%2$d.', 'acrossai-abilities-manager' ), $type, $template_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Delete_Template.php
+++ b/includes/Abilities/Elementor/Delete_Template.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Feature 067 — trash or permanently delete an Elementor template.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Delete_Template extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-delete-template',
+			'args' => array(
+				'label'               => __( 'Delete Elementor Template', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Move an Elementor template to trash (default) or permanently delete when force=true.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'template_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+						'force'       => array( 'type' => 'boolean', 'default' => false ),
+					),
+					'required'   => array( 'template_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'template_id' => array( 'type' => 'integer' ),
+						'action'      => array( 'type' => 'string' ),
+						'message'     => array( 'type' => 'string' ),
+						'error_code'  => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$template_id = absint( $input['template_id'] ?? 0 );
+		$force       = ! empty( $input['force'] );
+		$post        = get_post( $template_id );
+		if ( ! $post instanceof \WP_Post || Template_Query::CPT !== $post->post_type ) {
+			return array( 'success' => false, 'message' => __( 'Template not found.', 'acrossai-abilities-manager' ), 'error_code' => 'post_not_found' );
+		}
+		$result = $force ? wp_delete_post( $template_id, true ) : wp_trash_post( $template_id );
+		$action = $force ? 'deleted' : 'trashed';
+		if ( ! $result ) {
+			return array( 'success' => false, 'template_id' => $template_id, 'message' => __( 'Failed to delete template.', 'acrossai-abilities-manager' ), 'error_code' => 'delete_failed' );
+		}
+		return array(
+			'success'     => true,
+			'template_id' => $template_id,
+			'action'      => $action,
+			/* translators: 1: action, 2: template id */
+			'message'     => sprintf( __( '%1$s template #%2$d.', 'acrossai-abilities-manager' ), ucfirst( $action ), $template_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Duplicate_Template.php
+++ b/includes/Abilities/Elementor/Duplicate_Template.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Feature 067 — duplicate an Elementor template.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Duplicate_Template extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-duplicate-template',
+			'args' => array(
+				'label'               => __( 'Duplicate Elementor Template', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Duplicate a saved Elementor template with fresh element IDs, preserving type + conditions + sub_type.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'template_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+						'title'       => array( 'type' => 'string' ),
+					),
+					'required'   => array( 'template_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'               => array( 'type' => 'boolean' ),
+						'source_template_id'    => array( 'type' => 'integer' ),
+						'duplicate_template_id' => array( 'type' => 'integer' ),
+						'message'               => array( 'type' => 'string' ),
+						'error_code'            => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$src_id = absint( $input['template_id'] ?? 0 );
+		$title  = isset( $input['title'] ) ? sanitize_text_field( (string) $input['title'] ) : '';
+		$src    = get_post( $src_id );
+		if ( ! $src instanceof \WP_Post || Template_Query::CPT !== $src->post_type ) {
+			return array( 'success' => false, 'message' => __( 'Source template not found.', 'acrossai-abilities-manager' ), 'error_code' => 'post_not_found' );
+		}
+		if ( '' === $title ) {
+			$title = $src->post_title . ' — copy';
+		}
+
+		$dup_id = wp_insert_post( array(
+			'post_title'  => $title,
+			'post_type'   => Template_Query::CPT,
+			'post_status' => (string) $src->post_status,
+		), true );
+		if ( is_wp_error( $dup_id ) ) {
+			return array( 'success' => false, 'message' => (string) $dup_id->get_error_message(), 'error_code' => (string) $dup_id->get_error_code() );
+		}
+		$dup_id = (int) $dup_id;
+
+		// Copy taxonomy term.
+		$terms = wp_get_object_terms( $src_id, Template_Query::TYPE_TAX, array( 'fields' => 'slugs' ) );
+		if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+			wp_set_object_terms( $dup_id, $terms, Template_Query::TYPE_TAX, false );
+		}
+
+		// Copy critical meta and data with fresh element IDs.
+		foreach ( array( '_elementor_edit_mode', '_elementor_template_type', '_elementor_template_sub_type', '_elementor_version', '_elementor_page_settings', '_elementor_conditions' ) as $key ) {
+			$val = get_post_meta( $src_id, $key, true );
+			if ( '' !== $val ) {
+				update_post_meta( $dup_id, $key, $val );
+			}
+		}
+		$src_data = Document_Repository::decode_data( Document_Repository::get_raw_data( $src_id ) );
+		$cloned   = array();
+		foreach ( $src_data as $element ) {
+			if ( is_array( $element ) ) {
+				$cloned[] = Document_Repository::reassign_subtree_ids( $element );
+			}
+		}
+		Document_Repository::save_data( $dup_id, $cloned, 'none' );
+
+		return array(
+			'success'               => true,
+			'source_template_id'    => $src_id,
+			'duplicate_template_id' => $dup_id,
+			/* translators: 1: source, 2: dup */
+			'message'               => sprintf( __( 'Duplicated template #%1$d as #%2$d.', 'acrossai-abilities-manager' ), $src_id, $dup_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Empty_Trash.php
+++ b/includes/Abilities/Elementor/Empty_Trash.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Feature 067 — permanently delete all trashed Elementor templates.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Empty_Trash extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-empty-trash',
+			'args' => array(
+				'label'               => __( 'Empty Elementor Template Trash', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Permanently delete every trashed Elementor template. Requires confirm=true.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'confirm' => array( 'type' => 'boolean' ),
+					),
+					'required'   => array( 'confirm' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'deleted_count' => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
+						'error_code'    => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		if ( empty( $input['confirm'] ) ) {
+			return array( 'success' => false, 'message' => __( 'confirm=true is required.', 'acrossai-abilities-manager' ), 'error_code' => 'force_delete_required' );
+		}
+		$trashed = Template_Query::query( array( 'status' => 'trash', 'limit' => -1 ) );
+		$deleted = 0;
+		foreach ( $trashed as $post ) {
+			if ( wp_delete_post( (int) $post->ID, true ) ) {
+				++$deleted;
+			}
+		}
+		return array(
+			'success'       => true,
+			'deleted_count' => $deleted,
+			/* translators: %d: deleted count */
+			'message'       => sprintf( __( 'Permanently deleted %d trashed templates.', 'acrossai-abilities-manager' ), $deleted ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Export_Template.php
+++ b/includes/Abilities/Elementor/Export_Template.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Feature 067 — export an Elementor template as JSON.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Export_Template extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-export-template',
+			'args' => array(
+				'label'               => __( 'Export Elementor Template', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Export an Elementor template as a JSON-encodable object for portability across sites.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'template_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+					),
+					'required'   => array( 'template_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'template_id' => array( 'type' => 'integer' ),
+						'data'        => array( 'type' => 'object' ),
+						'message'     => array( 'type' => 'string' ),
+						'error_code'  => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$template_id = absint( $input['template_id'] ?? 0 );
+		$post = get_post( $template_id );
+		if ( ! $post instanceof \WP_Post || Template_Query::CPT !== $post->post_type ) {
+			return array( 'success' => false, 'message' => __( 'Template not found.', 'acrossai-abilities-manager' ), 'error_code' => 'post_not_found' );
+		}
+		$summary = Template_Query::to_summary( $post, true );
+		$export  = array(
+			'version'       => defined( 'ELEMENTOR_VERSION' ) ? (string) ELEMENTOR_VERSION : '',
+			'title'         => $summary['title'],
+			'template_type' => $summary['template_type'],
+			'sub_type'      => $summary['sub_type'],
+			'page_settings' => get_post_meta( $template_id, '_elementor_page_settings', true ) ?: array(),
+			'content'       => $summary['data'],
+			'conditions'    => $summary['conditions'],
+		);
+		return array(
+			'success'     => true,
+			'template_id' => $template_id,
+			'data'        => $export,
+			/* translators: %d: template id */
+			'message'     => sprintf( __( 'Exported template #%d.', 'acrossai-abilities-manager' ), $template_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Find_Template_For_Pattern.php
+++ b/includes/Abilities/Elementor/Find_Template_For_Pattern.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Feature 067 — search templates by pattern keywords.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Find_Template_For_Pattern extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-find-template-for-pattern',
+			'args' => array(
+				'label'               => __( 'Find Elementor Template For Pattern', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Rank saved Elementor templates by keyword match (title / template_type / widget-types present in content). Use before raw authoring to reuse existing patterns.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'pattern_keywords' => array( 'type' => 'string' ),
+						'template_type'    => array( 'type' => 'string' ),
+						'limit'            => array( 'type' => 'integer', 'default' => 5 ),
+					),
+					'required'   => array( 'pattern_keywords' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'   => array( 'type' => 'boolean' ),
+						'templates' => array( 'type' => 'array' ),
+						'count'     => array( 'type' => 'integer' ),
+						'message'   => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$keywords      = (string) ( $input['pattern_keywords'] ?? '' );
+		$template_type = (string) ( $input['template_type'] ?? '' );
+		$limit         = (int) ( $input['limit'] ?? 5 );
+
+		if ( '' === trim( $keywords ) ) {
+			return array( 'success' => false, 'message' => __( 'pattern_keywords is required.', 'acrossai-abilities-manager' ), 'error_code' => 'invalid_payload' );
+		}
+		$posts   = Template_Query::query( array( 'template_type' => $template_type, 'limit' => 200 ) );
+		$ranked  = Template_Query::rank_by_pattern( $posts, $keywords, max( 1, $limit ) );
+		return array(
+			'success'   => true,
+			'templates' => $ranked,
+			'count'     => count( $ranked ),
+			/* translators: 1: count, 2: keywords */
+			'message'   => sprintf( __( 'Ranked %1$d templates for keywords "%2$s".', 'acrossai-abilities-manager' ), count( $ranked ), $keywords ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Get_Template.php
+++ b/includes/Abilities/Elementor/Get_Template.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Feature 067 — read a single Elementor template.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Get_Template extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-get-template',
+			'args' => array(
+				'label'               => __( 'Get Elementor Template', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return a single Elementor template with metadata, conditions, and optional _elementor_data payload.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'template_id'  => array( 'type' => 'integer', 'minimum' => 1 ),
+						'include_data' => array( 'type' => 'boolean', 'default' => false ),
+					),
+					'required'   => array( 'template_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'  => array( 'type' => 'boolean' ),
+						'template' => array( 'type' => 'object' ),
+						'message'  => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$template_id  = absint( $input['template_id'] ?? 0 );
+		$include_data = ! empty( $input['include_data'] );
+		$post = get_post( $template_id );
+		if ( ! $post instanceof \WP_Post || Template_Query::CPT !== $post->post_type ) {
+			return array( 'success' => false, 'message' => __( 'Template not found.', 'acrossai-abilities-manager' ), 'error_code' => 'post_not_found' );
+		}
+		return array(
+			'success'  => true,
+			'template' => Template_Query::to_summary( $post, $include_data ),
+			/* translators: %d: template id */
+			'message'  => sprintf( __( 'Returned template #%d.', 'acrossai-abilities-manager' ), $template_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Import_Template.php
+++ b/includes/Abilities/Elementor/Import_Template.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Feature 067 — import an Elementor template from a JSON export.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Import_Template extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-import-template',
+			'args' => array(
+				'label'               => __( 'Import Elementor Template', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Import an Elementor template from a JSON export (as produced by export-template). Regenerates element IDs to avoid collisions.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'data'         => array( 'type' => 'object' ),
+						'title'        => array( 'type' => 'string' ),
+						'overwrite_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+					),
+					'required'   => array( 'data' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'template_id' => array( 'type' => 'integer' ),
+						'message'     => array( 'type' => 'string' ),
+						'error_code'  => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$data         = isset( $input['data'] ) && is_array( $input['data'] ) ? $input['data'] : array();
+		$title        = isset( $input['title'] ) ? sanitize_text_field( (string) $input['title'] ) : (string) ( $data['title'] ?? 'Imported Template' );
+		$overwrite_id = absint( $input['overwrite_id'] ?? 0 );
+
+		if ( empty( $data ) || ! isset( $data['content'] ) || ! is_array( $data['content'] ) ) {
+			return array( 'success' => false, 'message' => __( 'Invalid export payload — content array required.', 'acrossai-abilities-manager' ), 'error_code' => 'invalid_payload' );
+		}
+		$template_type = isset( $data['template_type'] ) ? sanitize_key( (string) $data['template_type'] ) : 'page';
+
+		if ( $overwrite_id > 0 ) {
+			$existing = get_post( $overwrite_id );
+			if ( ! $existing instanceof \WP_Post || Template_Query::CPT !== $existing->post_type ) {
+				return array( 'success' => false, 'message' => __( 'overwrite_id does not point to an Elementor template.', 'acrossai-abilities-manager' ), 'error_code' => 'post_not_found' );
+			}
+			$template_id = $overwrite_id;
+			wp_update_post( array( 'ID' => $template_id, 'post_title' => $title ) );
+		} else {
+			$template_id = wp_insert_post( array(
+				'post_title'  => $title,
+				'post_type'   => Template_Query::CPT,
+				'post_status' => 'publish',
+			), true );
+			if ( is_wp_error( $template_id ) ) {
+				return array( 'success' => false, 'message' => (string) $template_id->get_error_message(), 'error_code' => (string) $template_id->get_error_code() );
+			}
+			$template_id = (int) $template_id;
+		}
+
+		wp_set_object_terms( $template_id, $template_type, Template_Query::TYPE_TAX, false );
+		update_post_meta( $template_id, '_elementor_edit_mode', 'builder' );
+		update_post_meta( $template_id, '_elementor_template_type', $template_type );
+		if ( defined( 'ELEMENTOR_VERSION' ) ) {
+			update_post_meta( $template_id, '_elementor_version', ELEMENTOR_VERSION );
+		}
+		if ( isset( $data['sub_type'] ) && '' !== $data['sub_type'] ) {
+			update_post_meta( $template_id, '_elementor_template_sub_type', (string) $data['sub_type'] );
+		}
+		if ( isset( $data['page_settings'] ) && is_array( $data['page_settings'] ) ) {
+			update_post_meta( $template_id, '_elementor_page_settings', $data['page_settings'] );
+		}
+		if ( isset( $data['conditions'] ) && is_array( $data['conditions'] ) ) {
+			update_post_meta( $template_id, '_elementor_conditions', $data['conditions'] );
+		}
+
+		// Regenerate element IDs to avoid collisions with existing content.
+		$cloned = array();
+		foreach ( $data['content'] as $element ) {
+			if ( is_array( $element ) ) {
+				$cloned[] = Document_Repository::reassign_subtree_ids( $element );
+			}
+		}
+		Document_Repository::save_data( $template_id, $cloned, 'post' );
+
+		return array(
+			'success'     => true,
+			'template_id' => $template_id,
+			/* translators: %d: template id */
+			'message'     => sprintf( __( 'Imported template as #%d.', 'acrossai-abilities-manager' ), $template_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/List_Templates.php
+++ b/includes/Abilities/Elementor/List_Templates.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Feature 067 — list saved Elementor templates.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class List_Templates extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-list-templates',
+			'args' => array(
+				'label'               => __( 'List Elementor Templates', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List saved Elementor templates (elementor_library CPT). Filter by template_type and status.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'template_type' => array( 'type' => 'string' ),
+						'status'        => array( 'type' => 'string', 'default' => 'publish' ),
+						'limit'         => array( 'type' => 'integer', 'default' => 50 ),
+						'offset'        => array( 'type' => 'integer', 'default' => 0 ),
+					),
+					'required'   => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'   => array( 'type' => 'boolean' ),
+						'templates' => array( 'type' => 'array' ),
+						'count'     => array( 'type' => 'integer' ),
+						'message'   => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$posts = Template_Query::query( array(
+			'template_type' => (string) ( $input['template_type'] ?? '' ),
+			'status'        => (string) ( $input['status'] ?? 'publish' ),
+			'limit'         => (int) ( $input['limit'] ?? 50 ),
+			'offset'        => (int) ( $input['offset'] ?? 0 ),
+		) );
+		$templates = array_map( static fn( $p ) => Template_Query::to_summary( $p, false ), $posts );
+
+		return array(
+			'success'   => true,
+			'templates' => array_values( $templates ),
+			'count'     => count( $templates ),
+			/* translators: %d: count */
+			'message'   => sprintf( __( 'Returned %d templates.', 'acrossai-abilities-manager' ), count( $templates ) ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Restore_Template.php
+++ b/includes/Abilities/Elementor/Restore_Template.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Feature 067 — restore an Elementor template from trash.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Restore_Template extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-restore-template',
+			'args' => array(
+				'label'               => __( 'Restore Elementor Template', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Restore a trashed Elementor template.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'template_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+					),
+					'required'   => array( 'template_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'template_id' => array( 'type' => 'integer' ),
+						'message'     => array( 'type' => 'string' ),
+						'error_code'  => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$template_id = absint( $input['template_id'] ?? 0 );
+		$post = get_post( $template_id );
+		if ( ! $post instanceof \WP_Post || Template_Query::CPT !== $post->post_type ) {
+			return array( 'success' => false, 'message' => __( 'Template not found.', 'acrossai-abilities-manager' ), 'error_code' => 'post_not_found' );
+		}
+		$result = wp_untrash_post( $template_id );
+		if ( ! $result ) {
+			return array( 'success' => false, 'template_id' => $template_id, 'message' => __( 'Failed to restore template.', 'acrossai-abilities-manager' ), 'error_code' => 'restore_failed' );
+		}
+		return array(
+			'success'     => true,
+			'template_id' => $template_id,
+			/* translators: %d: template id */
+			'message'     => sprintf( __( 'Restored template #%d.', 'acrossai-abilities-manager' ), $template_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Update_Template.php
+++ b/includes/Abilities/Elementor/Update_Template.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Feature 067 — update an existing Elementor template.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Update_Template extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-update-template',
+			'args' => array(
+				'label'               => __( 'Update Elementor Template', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Update an Elementor template — change title, page_settings, or replace the full data tree. force_replace=true required for destructive full-data overwrites.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'template_id'    => array( 'type' => 'integer', 'minimum' => 1 ),
+						'title'          => array( 'type' => 'string' ),
+						'data'           => array( 'type' => 'array' ),
+						'page_settings'  => array( 'type' => 'object' ),
+						'force_replace'  => array( 'type' => 'boolean', 'default' => false ),
+					),
+					'required'   => array( 'template_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'template_id' => array( 'type' => 'integer' ),
+						'message'     => array( 'type' => 'string' ),
+						'error_code'  => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$template_id   = absint( $input['template_id'] ?? 0 );
+		$title         = isset( $input['title'] ) ? sanitize_text_field( (string) $input['title'] ) : null;
+		$data          = isset( $input['data'] ) && is_array( $input['data'] ) ? $input['data'] : null;
+		$page_settings = isset( $input['page_settings'] ) && is_array( $input['page_settings'] ) ? $input['page_settings'] : null;
+		$force_replace = ! empty( $input['force_replace'] );
+
+		$post = get_post( $template_id );
+		if ( ! $post instanceof \WP_Post || Template_Query::CPT !== $post->post_type ) {
+			return array( 'success' => false, 'message' => __( 'Template not found.', 'acrossai-abilities-manager' ), 'error_code' => 'post_not_found' );
+		}
+
+		if ( null !== $data ) {
+			$existing = Document_Repository::decode_data( Document_Repository::get_raw_data( $template_id ) );
+			if ( ! $force_replace && Document_Repository::is_document_populated( $existing ) && count( $data ) < count( $existing ) ) {
+				return array( 'success' => false, 'template_id' => $template_id, 'message' => __( 'Data payload smaller than existing. Pass force_replace=true.', 'acrossai-abilities-manager' ), 'error_code' => 'force_replace_required' );
+			}
+			Document_Repository::save_data( $template_id, $data, 'post' );
+		}
+		if ( null !== $title ) {
+			wp_update_post( array( 'ID' => $template_id, 'post_title' => $title ) );
+		}
+		if ( null !== $page_settings ) {
+			update_post_meta( $template_id, '_elementor_page_settings', $page_settings );
+		}
+
+		return array(
+			'success'     => true,
+			'template_id' => $template_id,
+			/* translators: %d: template id */
+			'message'     => sprintf( __( 'Updated template #%d.', 'acrossai-abilities-manager' ), $template_id ),
+		);
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -133,6 +133,17 @@
 			<file>tests/phpunit/abilities/Test_Elementor_Get_Theme_Context.php</file>
 			<file>tests/phpunit/abilities/Test_Elementor_Get_Style_Guide.php</file>
 			<file>tests/phpunit/abilities/Test_Elementor_Evaluate_Render_Context.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_List_Templates.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Get_Template.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Create_Template.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Update_Template.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Delete_Template.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Restore_Template.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Duplicate_Template.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Empty_Trash.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Export_Template.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Import_Template.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Find_Template_For_Pattern.php</file>
 			<file>tests/phpunit/abilities/Test_Move_Block.php</file>
 			<file>tests/phpunit/abilities/Test_Duplicate_Block.php</file>
 			<file>tests/phpunit/abilities/Test_Insert_Pattern.php</file>

--- a/tests/phpunit/abilities/Test_Elementor_Create_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Create_Template.php
@@ -1,0 +1,15 @@
+<?php
+/** Feature 067 — Create_Template tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Create_Template extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Create_Template.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-create-template'", $this->src ); }
+	public function test_type_enum_includes_common(): void { $this->assertStringContainsString( "'page', 'section', 'popup', 'header', 'footer', 'single', 'archive'", $this->src ); }
+	public function test_requires_title_and_type(): void { $this->assertStringContainsString( "'required'   => array( 'title', 'type' )", $this->src ); }
+	public function test_sets_taxonomy_term(): void { $this->assertStringContainsString( 'wp_set_object_terms(', $this->src ); }
+	public function test_seeds_elementor_data(): void { $this->assertStringContainsString( 'Document_Repository::save_data(', $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Delete_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Delete_Template.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Delete_Template tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Delete_Template extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Delete_Template.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-delete-template'", $this->src ); }
+	public function test_uses_trash_by_default(): void { $this->assertStringContainsString( 'wp_trash_post(', $this->src ); }
+	public function test_force_permanent_delete(): void { $this->assertStringContainsString( 'wp_delete_post( $template_id, true )', $this->src ); }
+	public function test_destructive(): void { $this->assertStringContainsString( "'destructive' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Duplicate_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Duplicate_Template.php
@@ -1,0 +1,13 @@
+<?php
+/** Feature 067 — Duplicate_Template tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Duplicate_Template extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Duplicate_Template.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-duplicate-template'", $this->src ); }
+	public function test_reassigns_element_ids(): void { $this->assertStringContainsString( 'Document_Repository::reassign_subtree_ids', $this->src ); }
+	public function test_preserves_conditions_and_sub_type(): void { $this->assertStringContainsString( "'_elementor_conditions'", $this->src ); $this->assertStringContainsString( "'_elementor_template_sub_type'", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Empty_Trash.php
+++ b/tests/phpunit/abilities/Test_Elementor_Empty_Trash.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Empty_Trash tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Empty_Trash extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Empty_Trash.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-empty-trash'", $this->src ); }
+	public function test_requires_confirm(): void { $this->assertStringContainsString( "'required'   => array( 'confirm' )", $this->src ); }
+	public function test_refuses_without_confirm(): void { $this->assertStringContainsString( "'force_delete_required'", $this->src ); }
+	public function test_destructive(): void { $this->assertStringContainsString( "'destructive' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Export_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Export_Template.php
@@ -1,0 +1,13 @@
+<?php
+/** Feature 067 — Export_Template tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Export_Template extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Export_Template.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-export-template'", $this->src ); }
+	public function test_returns_content_and_page_settings(): void { $this->assertStringContainsString( "'content'", $this->src ); $this->assertStringContainsString( "'page_settings'", $this->src ); }
+	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Find_Template_For_Pattern.php
+++ b/tests/phpunit/abilities/Test_Elementor_Find_Template_For_Pattern.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Find_Template_For_Pattern tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Find_Template_For_Pattern extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Find_Template_For_Pattern.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-find-template-for-pattern'", $this->src ); }
+	public function test_requires_keywords(): void { $this->assertStringContainsString( "'required'   => array( 'pattern_keywords' )", $this->src ); }
+	public function test_uses_rank_by_pattern(): void { $this->assertStringContainsString( 'Template_Query::rank_by_pattern', $this->src ); }
+	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Get_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Template.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Get_Template tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Get_Template extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Get_Template.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-get-template'", $this->src ); }
+	public function test_requires_template_id(): void { $this->assertStringContainsString( "'required'   => array( 'template_id' )", $this->src ); }
+	public function test_uses_template_query_summary(): void { $this->assertStringContainsString( 'Template_Query::to_summary(', $this->src ); }
+	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Import_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Import_Template.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Import_Template tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Import_Template extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Import_Template.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-import-template'", $this->src ); }
+	public function test_requires_data(): void { $this->assertStringContainsString( "'required'   => array( 'data' )", $this->src ); }
+	public function test_regenerates_element_ids(): void { $this->assertStringContainsString( 'Document_Repository::reassign_subtree_ids', $this->src ); }
+	public function test_supports_overwrite_id(): void { $this->assertStringContainsString( '$overwrite_id', $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_List_Templates.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Templates.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — List_Templates tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_List_Templates extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Templates.php' ); }
+	public function test_extends_ability_definition(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-templates'", $this->src ); }
+	public function test_uses_template_query(): void { $this->assertStringContainsString( 'Template_Query::query(', $this->src ); }
+	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
+	public function test_gate(): void { $this->assertStringContainsString( 'assert_elementor_available()', $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Restore_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Restore_Template.php
@@ -1,0 +1,13 @@
+<?php
+/** Feature 067 — Restore_Template tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Restore_Template extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Restore_Template.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-restore-template'", $this->src ); }
+	public function test_uses_untrash(): void { $this->assertStringContainsString( 'wp_untrash_post(', $this->src ); }
+	public function test_idempotent(): void { $this->assertStringContainsString( "'idempotent' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Update_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Template.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Update_Template tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Update_Template extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Update_Template.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-update-template'", $this->src ); }
+	public function test_force_replace_guard(): void { $this->assertStringContainsString( "'force_replace_required'", $this->src ); }
+	public function test_destructive(): void { $this->assertStringContainsString( "'destructive' => true", $this->src ); }
+	public function test_uses_save_data(): void { $this->assertStringContainsString( 'Document_Repository::save_data(', $this->src ); }
+}


### PR DESCRIPTION
## Summary

- Sixth batch of Feature 067 abilities merged to main **without a plugin version bump**. Plugin version stays at 0.0.25.
- Ships as "Unreleased" changelog entry.
- Delivers full Elementor template lifecycle management.

## What's new — 11 abilities

| Slug | Purpose |
|---|---|
| `elementor-list-templates` | List with template_type + status filters + pagination |
| `elementor-get-template` | Read one template with metadata + conditions + optional data |
| `elementor-create-template` | Create page/section/popup/header/footer/single/archive template |
| `elementor-update-template` | Update title / page_settings / full data with force_replace guard |
| `elementor-delete-template` | Trash (default) or permanently delete with force=true |
| `elementor-restore-template` | Restore trashed template |
| `elementor-duplicate-template` | Clone preserving type + conditions + sub_type; regenerates IDs |
| `elementor-empty-trash` | Permanently delete all trashed templates; confirm=true required |
| `elementor-export-template` | Export as JSON-encodable object for portability |
| `elementor-import-template` | Import from JSON; regenerates IDs; optional overwrite_id |
| `elementor-find-template-for-pattern` | Rank templates by keyword match; returns top N with scores |

## Total shipped Elementor abilities: 44 of 88 (exactly half)

## Test plan

- [x] Full PHPUnit suite: **889 tests, 1809 assertions, 0 failures** (was 836)
- [x] phpcs (WPCS strict): 0 errors
- [x] phpstan (level 8): 0 errors

## Not shipped

- No version bump (stays at 0.0.25) · No git tag · No GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)