### PR TITLE
feat(067 continued): 7 kits & site-settings abilities (unreleased, no version bump)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -138,9 +138,18 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased (NOT YET RELEASED) =
-* **Feature 067 continued — 42 more Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available to anyone on the `main` branch but no plugin release / tag / distribution package has been cut. A future release will bundle these plus additional Feature 067 abilities under a single version bump.
+* **Feature 067 continued — 49 more Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available to anyone on the `main` branch but no plugin release / tag / distribution package has been cut. A future release will bundle these plus additional Feature 067 abilities under a single version bump.
 
-**Batch 6 — 11 template abilities (this commit):**
+**Batch 7 — 7 kits & site-settings abilities (this commit):**
+  * `acrossai/elementor-list-kits` — list all Elementor kits; marks active kit.
+  * `acrossai/elementor-get-kit-settings` — read kit settings (defaults to active kit).
+  * `acrossai/elementor-update-kit-settings` — merge new settings; `force_replace` for full overwrite; site-wide cache invalidation.
+  * `acrossai/elementor-set-active-kit` — switch site-wide active kit; invalidates cache.
+  * `acrossai/elementor-list-global-widgets` — list global (reusable) widgets from elementor_library CPT.
+  * `acrossai/elementor-list-experiments` — list feature flags with current + default state.
+  * `acrossai/elementor-update-experiment` — toggle experiment state (active | inactive | default).
+
+**Batch 6 — 11 template abilities:**
   * `acrossai/elementor-list-templates` — list saved templates with filters on `template_type` + `status` + pagination.
   * `acrossai/elementor-get-template` — return one template's metadata + conditions + optional `_elementor_data`.
   * `acrossai/elementor-create-template` — create a new template of type page / section / popup / header / footer / single / archive; sets taxonomy term + Elementor meta.
@@ -192,9 +201,9 @@ No data is sent to any external server without an explicit administrator action.
   * `acrossai/elementor-add-container` — insert Elementor v3+ container.
   * `acrossai/elementor-add-widget` — insert any registered widget (validated via `Widget_Controls`).
 
-**Test coverage:** 43 (b2) + 40 (b3) + 53 (b4) + 64 (b5) + 53 (b6) = 253 new source-inspection tests across 42 test files. Full suite: 889 tests, 1809 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
+**Test coverage:** 43 (b2) + 40 (b3) + 53 (b4) + 64 (b5) + 53 (b6) + 33 (b7) = 286 new source-inspection tests across 49 test files. Full suite: 922 tests, 1842 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
 
-**Total shipped Elementor abilities so far: 44 of 88.** Foundation + 2 released in 0.0.25 + 42 unreleased on main. Complete page-composition + site-management + discovery + template CRUD surface — clients can now create Elementor pages, manage templates end-to-end (list/get/create/update/delete/restore/duplicate/empty-trash/export/import/find-pattern), discover widget schemas and pattern guidance, read documents, find/get/update/merge/delete/move/duplicate/reorder elements, add containers + widgets + shortcuts, patch text globally, clone whole documents, clear cache, replace URLs, manage maintenance mode + Theme Builder conditions.
+**Total shipped Elementor abilities so far: 51 of 88.** Foundation + 2 released in 0.0.25 + 49 unreleased on main. Complete page-composition + site-management + discovery + template CRUD + kits & site-settings surface — clients now have full Elementor authoring, template lifecycle, and site-wide design-token control.
 
 = 0.0.25 =
 * **New — Feature 067 Elementor Ability Suite (interim ship: foundation + 2 abilities).** First release of the planned 88-ability Elementor integration. This interim release delivers the full foundational infrastructure plus two highest-value abilities. Follow-up features (068+) will incrementally add the remaining 86 abilities.

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -485,6 +485,14 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new Elementor\Export_Template();
 		new Elementor\Import_Template();
 		new Elementor\Find_Template_For_Pattern();
+		// Kits & site settings.
+		new Elementor\List_Kits();
+		new Elementor\Get_Kit_Settings();
+		new Elementor\Update_Kit_Settings();
+		new Elementor\Set_Active_Kit();
+		new Elementor\List_Global_Widgets();
+		new Elementor\List_Experiments();
+		new Elementor\Update_Experiment();
 	}
 
 	/**

--- a/includes/Abilities/Elementor/Get_Kit_Settings.php
+++ b/includes/Abilities/Elementor/Get_Kit_Settings.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Feature 067 — read Elementor kit settings.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Get_Kit_Settings extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-get-kit-settings',
+			'args' => array(
+				'label'               => __( 'Get Elementor Kit Settings', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return the settings for an Elementor kit (defaults to active kit) — colors, typography, buttons, forms, layout, custom CSS.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array( 'kit_id' => array( 'type' => 'integer', 'minimum' => 1 ) ),
+					'required' => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'kit_id'     => array( 'type' => 'integer' ),
+						'settings'   => array( 'type' => 'object' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'kit_id' => 0, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$kit_id = absint( $input['kit_id'] ?? 0 );
+		if ( 0 === $kit_id ) {
+			$kit_id = (int) get_option( 'elementor_active_kit', 0 );
+		}
+		if ( $kit_id <= 0 ) {
+			return array( 'success' => false, 'kit_id' => 0, 'message' => __( 'No kit found.', 'acrossai-abilities-manager' ), 'error_code' => 'kit_not_found' );
+		}
+		$settings = get_post_meta( $kit_id, '_elementor_page_settings', true );
+		$settings = is_array( $settings ) ? $settings : array();
+		return array(
+			'success'  => true,
+			'kit_id'   => $kit_id,
+			'settings' => $settings,
+			/* translators: %d: kit id */
+			'message'  => sprintf( __( 'Returned settings for kit #%d.', 'acrossai-abilities-manager' ), $kit_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/List_Experiments.php
+++ b/includes/Abilities/Elementor/List_Experiments.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Feature 067 — list Elementor experiments.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List Elementor experiment feature flags with their current state.
+ */
+class List_Experiments extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-list-experiments',
+			'args' => array(
+				'label'               => __( 'List Elementor Experiments', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List Elementor experiment feature flags with their current state (active | inactive | default) and default state.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array( 'type' => 'object', 'properties' => array(), 'required' => array(), 'additionalProperties' => false ),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'experiments' => array( 'type' => 'array' ),
+						'count'       => array( 'type' => 'integer' ),
+						'message'     => array( 'type' => 'string' ),
+						'error_code'  => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$experiments = array();
+		$instance    = \Elementor\Plugin::$instance;
+		if ( isset( $instance->experiments ) && method_exists( $instance->experiments, 'get_features' ) ) {
+			$features = (array) $instance->experiments->get_features();
+			foreach ( $features as $name => $feature ) {
+				if ( ! is_array( $feature ) ) {
+					continue;
+				}
+				$experiments[] = array(
+					'name'          => (string) $name,
+					'title'         => (string) ( $feature['title'] ?? $name ),
+					'state'         => (string) ( $feature['state'] ?? 'default' ),
+					'default_state' => (string) ( $feature['default'] ?? 'inactive' ),
+					'description'   => (string) ( $feature['description'] ?? '' ),
+					'release_status' => (string) ( $feature['release_status'] ?? '' ),
+				);
+			}
+		}
+		return array(
+			'success'     => true,
+			'experiments' => $experiments,
+			'count'       => count( $experiments ),
+			/* translators: %d: count */
+			'message'     => sprintf( __( 'Returned %d experiments.', 'acrossai-abilities-manager' ), count( $experiments ) ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/List_Global_Widgets.php
+++ b/includes/Abilities/Elementor/List_Global_Widgets.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Feature 067 — list Elementor global widgets.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return the list of global (reusable) widgets stored as
+ * elementor_library posts with template_type=widget.
+ */
+class List_Global_Widgets extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-list-global-widgets',
+			'args' => array(
+				'label'               => __( 'List Elementor Global Widgets', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List all Elementor global (reusable) widgets — elementor_library posts with template_type=widget.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array( 'type' => 'object', 'properties' => array(), 'required' => array(), 'additionalProperties' => false ),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'         => array( 'type' => 'boolean' ),
+						'global_widgets'  => array( 'type' => 'array' ),
+						'count'           => array( 'type' => 'integer' ),
+						'message'         => array( 'type' => 'string' ),
+						'error_code'      => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$posts   = Template_Query::query( array( 'template_type' => 'widget', 'status' => 'any', 'limit' => -1 ) );
+		$widgets = array_map( static fn( $p ) => Template_Query::to_summary( $p, false ), $posts );
+		return array(
+			'success'        => true,
+			'global_widgets' => array_values( $widgets ),
+			'count'          => count( $widgets ),
+			/* translators: %d: count */
+			'message'        => sprintf( __( 'Returned %d global widgets.', 'acrossai-abilities-manager' ), count( $widgets ) ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/List_Kits.php
+++ b/includes/Abilities/Elementor/List_Kits.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Feature 067 — list Elementor kits.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class List_Kits extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-list-kits',
+			'args' => array(
+				'label'               => __( 'List Elementor Kits', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List all Elementor Kits (elementor_library posts with template_type=kit). Marks the active kit.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array( 'type' => 'object', 'properties' => array(), 'required' => array(), 'additionalProperties' => false ),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'kits'          => array( 'type' => 'array' ),
+						'active_kit_id' => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
+						'error_code'    => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$active_id = (int) get_option( 'elementor_active_kit', 0 );
+		$posts     = Template_Query::query( array( 'template_type' => 'kit', 'status' => 'any', 'limit' => -1 ) );
+		$kits      = array();
+		foreach ( $posts as $post ) {
+			$kits[] = array(
+				'id'        => (int) $post->ID,
+				'title'     => (string) $post->post_title,
+				'status'    => (string) $post->post_status,
+				'is_active' => $active_id === (int) $post->ID,
+			);
+		}
+		return array(
+			'success'       => true,
+			'kits'          => $kits,
+			'active_kit_id' => $active_id,
+			/* translators: %d: count */
+			'message'       => sprintf( __( 'Returned %d kits.', 'acrossai-abilities-manager' ), count( $kits ) ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Set_Active_Kit.php
+++ b/includes/Abilities/Elementor/Set_Active_Kit.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Feature 067 — set the active Elementor kit.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Template_Query;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Set_Active_Kit extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-set-active-kit',
+			'args' => array(
+				'label'               => __( 'Set Active Elementor Kit', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Switch the site-wide active Elementor kit. Invalidates Elementor CSS cache site-wide.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array( 'kit_id' => array( 'type' => 'integer', 'minimum' => 1 ) ),
+					'required' => array( 'kit_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'          => array( 'type' => 'boolean' ),
+						'previous_kit_id'  => array( 'type' => 'integer' ),
+						'active_kit_id'    => array( 'type' => 'integer' ),
+						'message'          => array( 'type' => 'string' ),
+						'error_code'       => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'previous_kit_id' => 0, 'active_kit_id' => 0, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$kit_id = absint( $input['kit_id'] ?? 0 );
+		$post   = get_post( $kit_id );
+		if ( ! $post instanceof \WP_Post || Template_Query::CPT !== $post->post_type ) {
+			return array( 'success' => false, 'previous_kit_id' => 0, 'active_kit_id' => 0, 'message' => __( 'Kit not found.', 'acrossai-abilities-manager' ), 'error_code' => 'kit_not_found' );
+		}
+		$previous = (int) get_option( 'elementor_active_kit', 0 );
+		update_option( 'elementor_active_kit', $kit_id );
+		Document_Repository::invalidate_cache( $kit_id, 'site' );
+		return array(
+			'success'          => true,
+			'previous_kit_id'  => $previous,
+			'active_kit_id'    => $kit_id,
+			/* translators: %d: kit id */
+			'message'          => sprintf( __( 'Active Elementor kit set to #%d.', 'acrossai-abilities-manager' ), $kit_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Update_Experiment.php
+++ b/includes/Abilities/Elementor/Update_Experiment.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Feature 067 — update an Elementor experiment feature flag state.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Update an Elementor experiment state via elementor_experiment_ option.
+ */
+class Update_Experiment extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-update-experiment',
+			'args' => array(
+				'label'               => __( 'Update Elementor Experiment', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Update an Elementor experiment state (active | inactive | default). Writes to elementor_experiment_<name> option.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array(
+						'experiment' => array( 'type' => 'string' ),
+						'state'      => array( 'type' => 'string', 'enum' => array( 'active', 'inactive', 'default' ) ),
+					),
+					'required' => array( 'experiment', 'state' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'experiment'     => array( 'type' => 'string' ),
+						'previous_state' => array( 'type' => 'string' ),
+						'new_state'      => array( 'type' => 'string' ),
+						'message'        => array( 'type' => 'string' ),
+						'error_code'     => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'experiment' => '', 'previous_state' => '', 'new_state' => '', 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$experiment = isset( $input['experiment'] ) ? sanitize_key( (string) $input['experiment'] ) : '';
+		$state      = isset( $input['state'] ) ? sanitize_key( (string) $input['state'] ) : '';
+		if ( '' === $experiment || ! in_array( $state, array( 'active', 'inactive', 'default' ), true ) ) {
+			return array( 'success' => false, 'experiment' => $experiment, 'previous_state' => '', 'new_state' => '', 'message' => __( 'experiment and state are required.', 'acrossai-abilities-manager' ), 'error_code' => 'invalid_payload' );
+		}
+		$option_key = 'elementor_experiment-' . $experiment;
+		$previous   = (string) get_option( $option_key, 'default' );
+		update_option( $option_key, $state );
+		Document_Repository::invalidate_cache( 0, 'site' );
+		return array(
+			'success'        => true,
+			'experiment'     => $experiment,
+			'previous_state' => $previous,
+			'new_state'      => $state,
+			/* translators: 1: experiment, 2: state */
+			'message'        => sprintf( __( 'Experiment "%1$s" set to %2$s.', 'acrossai-abilities-manager' ), $experiment, $state ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Update_Kit_Settings.php
+++ b/includes/Abilities/Elementor/Update_Kit_Settings.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Feature 067 — update Elementor kit settings.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Update_Kit_Settings extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-update-kit-settings',
+			'args' => array(
+				'label'               => __( 'Update Elementor Kit Settings', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Merge new kit settings into the active kit (or specified kit_id). force_replace=true replaces the full settings object.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array(
+						'kit_id'        => array( 'type' => 'integer', 'minimum' => 1 ),
+						'settings'      => array( 'type' => 'object' ),
+						'force_replace' => array( 'type' => 'boolean', 'default' => false ),
+					),
+					'required' => array( 'settings' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'      => array( 'type' => 'boolean' ),
+						'kit_id'       => array( 'type' => 'integer' ),
+						'changed_keys' => array( 'type' => 'array' ),
+						'message'      => array( 'type' => 'string' ),
+						'error_code'   => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'kit_id' => 0, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$kit_id        = absint( $input['kit_id'] ?? 0 );
+		$new_settings  = isset( $input['settings'] ) && is_array( $input['settings'] ) ? $input['settings'] : array();
+		$force_replace = ! empty( $input['force_replace'] );
+		if ( 0 === $kit_id ) {
+			$kit_id = (int) get_option( 'elementor_active_kit', 0 );
+		}
+		if ( $kit_id <= 0 || ! get_post( $kit_id ) ) {
+			return array( 'success' => false, 'kit_id' => $kit_id, 'message' => __( 'Kit not found.', 'acrossai-abilities-manager' ), 'error_code' => 'kit_not_found' );
+		}
+		$existing = get_post_meta( $kit_id, '_elementor_page_settings', true );
+		$existing = is_array( $existing ) ? $existing : array();
+		$merged   = $force_replace ? $new_settings : array_merge( $existing, $new_settings );
+		update_post_meta( $kit_id, '_elementor_page_settings', $merged );
+		Document_Repository::invalidate_cache( $kit_id, 'site' );
+		return array(
+			'success'      => true,
+			'kit_id'       => $kit_id,
+			'changed_keys' => array_keys( $new_settings ),
+			/* translators: 1: count, 2: kit id */
+			'message'      => sprintf( __( 'Updated %1$d settings on kit #%2$d.', 'acrossai-abilities-manager' ), count( $new_settings ), $kit_id ),
+		);
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -144,6 +144,13 @@
 			<file>tests/phpunit/abilities/Test_Elementor_Export_Template.php</file>
 			<file>tests/phpunit/abilities/Test_Elementor_Import_Template.php</file>
 			<file>tests/phpunit/abilities/Test_Elementor_Find_Template_For_Pattern.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_List_Kits.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Get_Kit_Settings.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Update_Kit_Settings.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Set_Active_Kit.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_List_Global_Widgets.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_List_Experiments.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Update_Experiment.php</file>
 			<file>tests/phpunit/abilities/Test_Move_Block.php</file>
 			<file>tests/phpunit/abilities/Test_Duplicate_Block.php</file>
 			<file>tests/phpunit/abilities/Test_Insert_Pattern.php</file>

--- a/tests/phpunit/abilities/Test_Elementor_Get_Kit_Settings.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Kit_Settings.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Get_Kit_Settings tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Get_Kit_Settings extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Get_Kit_Settings.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-get-kit-settings'", $this->src ); }
+	public function test_defaults_to_active_kit(): void { $this->assertStringContainsString( "get_option( 'elementor_active_kit', 0 )", $this->src ); }
+	public function test_reads_page_settings_meta(): void { $this->assertStringContainsString( "get_post_meta( \$kit_id, '_elementor_page_settings', true )", $this->src ); }
+	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_List_Experiments.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Experiments.php
@@ -1,0 +1,13 @@
+<?php
+/** Feature 067 — List_Experiments tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_List_Experiments extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Experiments.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-experiments'", $this->src ); }
+	public function test_uses_experiments_manager(): void { $this->assertStringContainsString( '$instance->experiments->get_features()', $this->src ); }
+	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_List_Global_Widgets.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Global_Widgets.php
@@ -1,0 +1,13 @@
+<?php
+/** Feature 067 — List_Global_Widgets tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_List_Global_Widgets extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Global_Widgets.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-global-widgets'", $this->src ); }
+	public function test_queries_widget_template_type(): void { $this->assertStringContainsString( "'template_type' => 'widget'", $this->src ); }
+	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_List_Kits.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Kits.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — List_Kits tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_List_Kits extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Kits.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-kits'", $this->src ); }
+	public function test_queries_kit_template_type(): void { $this->assertStringContainsString( "'template_type' => 'kit'", $this->src ); }
+	public function test_marks_active_kit(): void { $this->assertStringContainsString( "get_option( 'elementor_active_kit', 0 )", $this->src ); }
+	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Set_Active_Kit.php
+++ b/tests/phpunit/abilities/Test_Elementor_Set_Active_Kit.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Set_Active_Kit tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Set_Active_Kit extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Set_Active_Kit.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-set-active-kit'", $this->src ); }
+	public function test_requires_kit_id(): void { $this->assertStringContainsString( "'required' => array( 'kit_id' )", $this->src ); }
+	public function test_updates_active_kit_option(): void { $this->assertStringContainsString( "update_option( 'elementor_active_kit', \$kit_id )", $this->src ); }
+	public function test_returns_previous(): void { $this->assertStringContainsString( "'previous_kit_id'", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Update_Experiment.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Experiment.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Update_Experiment tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Update_Experiment extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Update_Experiment.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-update-experiment'", $this->src ); }
+	public function test_state_enum(): void { $this->assertStringContainsString( "'active', 'inactive', 'default'", $this->src ); }
+	public function test_writes_experiment_option(): void { $this->assertStringContainsString( "update_option( \$option_key, \$state )", $this->src ); }
+	public function test_returns_previous_state(): void { $this->assertStringContainsString( "'previous_state'", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Update_Kit_Settings.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Kit_Settings.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Update_Kit_Settings tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Update_Kit_Settings extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Update_Kit_Settings.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-update-kit-settings'", $this->src ); }
+	public function test_supports_force_replace(): void { $this->assertStringContainsString( "'force_replace'", $this->src ); }
+	public function test_invalidates_cache_site_scope(): void { $this->assertStringContainsString( "Document_Repository::invalidate_cache( \$kit_id, 'site' )", $this->src ); }
+	public function test_writes_page_settings(): void { $this->assertStringContainsString( "update_post_meta( \$kit_id, '_elementor_page_settings'", $this->src ); }
+}


### PR DESCRIPTION
## Summary

- Seventh batch of Feature 067 abilities merged to main **without a plugin version bump**. Version stays at 0.0.25.
- Ships as "Unreleased" changelog entry.
- Delivers site-wide design-token + experiment management.

## What's new — 7 abilities

| Slug | Purpose |
|---|---|
| `elementor-list-kits` | List all kits; marks active |
| `elementor-get-kit-settings` | Read kit settings (defaults to active) |
| `elementor-update-kit-settings` | Merge settings; `force_replace` for overwrite; site-cache invalidation |
| `elementor-set-active-kit` | Switch active kit |
| `elementor-list-global-widgets` | List reusable widgets |
| `elementor-list-experiments` | List feature flags |
| `elementor-update-experiment` | Toggle experiment state |

## Total shipped Elementor abilities: 51 of 88

## Test plan

- [x] Full PHPUnit suite: **922 tests, 1842 assertions, 0 failures**
- [x] phpcs (WPCS strict): 0 errors · phpstan (level 8): 0 errors

## Not shipped

- No version bump (stays at 0.0.25) · No git tag · No GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)