### PR TITLE
feat(067 continued): 8 Elementor Pro-gated abilities (unreleased, no version bump)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -138,9 +138,21 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased (NOT YET RELEASED) =
-* **Feature 067 continued — 49 more Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available to anyone on the `main` branch but no plugin release / tag / distribution package has been cut. A future release will bundle these plus additional Feature 067 abilities under a single version bump.
+* **Feature 067 continued — 57 more Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available to anyone on the `main` branch but no plugin release / tag / distribution package has been cut. A future release will bundle these plus additional Feature 067 abilities under a single version bump.
 
-**Batch 7 — 7 kits & site-settings abilities (this commit):**
+**Batch 8 — 8 Elementor Pro-gated abilities (this commit):**
+  * `acrossai/elementor-list-custom-code` — list Custom Code snippets from `elementor_snippet` CPT; optional location filter.
+  * `acrossai/elementor-get-custom-code` — read one snippet including its code body.
+  * `acrossai/elementor-create-custom-code` — create snippet with title, code, location (head / body_start / body_end / footer), priority, status.
+  * `acrossai/elementor-update-custom-code` — update snippet fields.
+  * `acrossai/elementor-delete-custom-code` — trash (default) or permanently delete with `force=true`.
+  * `acrossai/elementor-list-form-submissions` — list Form widget submissions from the `e_submissions` table; optional `form_id` filter + `include_values` flag. Graceful degradation when the Pro submissions table is missing.
+  * `acrossai/elementor-get-form-submission` — read one submission by ID; optional field values.
+  * `acrossai/elementor-delete-form-submission` — permanently delete submission + its `e_submissions_values` rows; requires `confirm=true`.
+
+All 8 Pro abilities gated on **both** `class_exists( '\Elementor\Plugin' )` **and** `class_exists( '\ElementorPro\Plugin' ) || defined( 'ELEMENTOR_PRO_VERSION' )` — silently absent on sites without Elementor Pro. Runtime deactivation returns `error_code: elementor_pro_missing`.
+
+**Batch 7 — 7 kits & site-settings abilities:**
   * `acrossai/elementor-list-kits` — list all Elementor kits; marks active kit.
   * `acrossai/elementor-get-kit-settings` — read kit settings (defaults to active kit).
   * `acrossai/elementor-update-kit-settings` — merge new settings; `force_replace` for full overwrite; site-wide cache invalidation.
@@ -201,9 +213,9 @@ No data is sent to any external server without an explicit administrator action.
   * `acrossai/elementor-add-container` — insert Elementor v3+ container.
   * `acrossai/elementor-add-widget` — insert any registered widget (validated via `Widget_Controls`).
 
-**Test coverage:** 43 (b2) + 40 (b3) + 53 (b4) + 64 (b5) + 53 (b6) + 33 (b7) = 286 new source-inspection tests across 49 test files. Full suite: 922 tests, 1842 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
+**Test coverage:** 43 (b2) + 40 (b3) + 53 (b4) + 64 (b5) + 53 (b6) + 33 (b7) + 45 (b8) = 331 new source-inspection tests across 57 test files. Full suite: 967 tests, 1890 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
 
-**Total shipped Elementor abilities so far: 51 of 88.** Foundation + 2 released in 0.0.25 + 49 unreleased on main. Complete page-composition + site-management + discovery + template CRUD + kits & site-settings surface — clients now have full Elementor authoring, template lifecycle, and site-wide design-token control.
+**Total shipped Elementor abilities so far: 59 of 88.** Foundation + 2 released in 0.0.25 + 57 unreleased on main. Complete page-composition + site-management + discovery + template CRUD + kits & site-settings + Elementor Pro (Custom Code + Form Submissions) surface. Only design audits remain.
 
 = 0.0.25 =
 * **New — Feature 067 Elementor Ability Suite (interim ship: foundation + 2 abilities).** First release of the planned 88-ability Elementor integration. This interim release delivers the full foundational infrastructure plus two highest-value abilities. Follow-up features (068+) will incrementally add the remaining 86 abilities.

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -501,7 +501,15 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 	 * @return void
 	 */
 	private function register_elementor_pro_abilities(): void {
-		// Ability instantiations added incrementally per Feature 067 Phase 13
-		// of tasks.md (Custom Code CRUD + Form Submissions).
+		// Custom Code CRUD (elementor_snippet CPT).
+		new Elementor\List_Custom_Code();
+		new Elementor\Get_Custom_Code();
+		new Elementor\Create_Custom_Code();
+		new Elementor\Update_Custom_Code();
+		new Elementor\Delete_Custom_Code();
+		// Form Submissions (Elementor Pro's e_submissions table).
+		new Elementor\List_Form_Submissions();
+		new Elementor\Get_Form_Submission();
+		new Elementor\Delete_Form_Submission();
 	}
 }

--- a/includes/Abilities/Elementor/Create_Custom_Code.php
+++ b/includes/Abilities/Elementor/Create_Custom_Code.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Feature 067 — create an Elementor Pro custom code snippet.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Create_Custom_Code extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-create-custom-code',
+			'args' => array(
+				'label'               => __( 'Create Elementor Pro Custom Code', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Create a new Elementor Pro Custom Code snippet with title, code, location, priority, and status. Requires Elementor Pro.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array(
+						'title'    => array( 'type' => 'string' ),
+						'code'     => array( 'type' => 'string' ),
+						'location' => array( 'type' => 'string', 'enum' => array( 'head', 'body_start', 'body_end', 'footer' ) ),
+						'priority' => array( 'type' => 'integer', 'default' => 10 ),
+						'status'   => array( 'type' => 'string', 'enum' => array( 'publish', 'draft' ), 'default' => 'publish' ),
+					),
+					'required' => array( 'title', 'code', 'location' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'snippet_id' => array( 'type' => 'integer' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$pro = Document_Repository::assert_elementor_pro_available();
+		if ( is_wp_error( $pro ) ) {
+			return array( 'success' => false, 'message' => (string) $pro->get_error_message(), 'error_code' => (string) $pro->get_error_code() );
+		}
+		$title    = isset( $input['title'] ) ? sanitize_text_field( (string) $input['title'] ) : '';
+		$code     = isset( $input['code'] ) ? (string) $input['code'] : '';
+		$location = isset( $input['location'] ) ? sanitize_key( (string) $input['location'] ) : '';
+		$priority = (int) ( $input['priority'] ?? 10 );
+		$status   = isset( $input['status'] ) ? sanitize_key( (string) $input['status'] ) : 'publish';
+
+		if ( '' === $title || '' === $code || '' === $location ) {
+			return array( 'success' => false, 'message' => __( 'title, code, and location are required.', 'acrossai-abilities-manager' ), 'error_code' => 'invalid_payload' );
+		}
+
+		$snippet_id = wp_insert_post( array(
+			'post_title'   => $title,
+			'post_content' => $code,
+			'post_type'    => List_Custom_Code::CPT,
+			'post_status'  => $status,
+		), true );
+		if ( is_wp_error( $snippet_id ) ) {
+			return array( 'success' => false, 'message' => (string) $snippet_id->get_error_message(), 'error_code' => (string) $snippet_id->get_error_code() );
+		}
+		$snippet_id = (int) $snippet_id;
+		update_post_meta( $snippet_id, '_elementor_snippet_location', $location );
+		update_post_meta( $snippet_id, '_elementor_snippet_priority', $priority );
+
+		return array(
+			'success'    => true,
+			'snippet_id' => $snippet_id,
+			/* translators: %d: id */
+			'message'    => sprintf( __( 'Created Pro custom code snippet #%d.', 'acrossai-abilities-manager' ), $snippet_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Delete_Custom_Code.php
+++ b/includes/Abilities/Elementor/Delete_Custom_Code.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Feature 067 — delete an Elementor Pro custom code snippet.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Delete_Custom_Code extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-delete-custom-code',
+			'args' => array(
+				'label'               => __( 'Delete Elementor Pro Custom Code', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Trash (default) or permanently delete an Elementor Pro Custom Code snippet. Requires Elementor Pro.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array(
+						'snippet_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+						'force'      => array( 'type' => 'boolean', 'default' => false ),
+					),
+					'required' => array( 'snippet_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'snippet_id' => array( 'type' => 'integer' ),
+						'action'     => array( 'type' => 'string' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$pro = Document_Repository::assert_elementor_pro_available();
+		if ( is_wp_error( $pro ) ) {
+			return array( 'success' => false, 'message' => (string) $pro->get_error_message(), 'error_code' => (string) $pro->get_error_code() );
+		}
+		$snippet_id = absint( $input['snippet_id'] ?? 0 );
+		$force      = ! empty( $input['force'] );
+		$post = get_post( $snippet_id );
+		if ( ! $post instanceof \WP_Post || List_Custom_Code::CPT !== $post->post_type ) {
+			return array( 'success' => false, 'message' => __( 'Snippet not found.', 'acrossai-abilities-manager' ), 'error_code' => 'post_not_found' );
+		}
+		$result = $force ? wp_delete_post( $snippet_id, true ) : wp_trash_post( $snippet_id );
+		if ( ! $result ) {
+			return array( 'success' => false, 'snippet_id' => $snippet_id, 'message' => __( 'Failed to delete snippet.', 'acrossai-abilities-manager' ), 'error_code' => 'delete_failed' );
+		}
+		return array(
+			'success'    => true,
+			'snippet_id' => $snippet_id,
+			'action'     => $force ? 'deleted' : 'trashed',
+			/* translators: 1: action, 2: id */
+			'message'    => sprintf( __( '%1$s Pro custom code snippet #%2$d.', 'acrossai-abilities-manager' ), $force ? 'Deleted' : 'Trashed', $snippet_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Delete_Form_Submission.php
+++ b/includes/Abilities/Elementor/Delete_Form_Submission.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Feature 067 — delete an Elementor Pro form submission.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Delete an Elementor Pro Form widget submission (plus its field-values
+ * rows). Requires confirm=true to prevent accidental deletion.
+ */
+class Delete_Form_Submission extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-delete-form-submission',
+			'args' => array(
+				'label'               => __( 'Delete Elementor Pro Form Submission', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Permanently delete an Elementor Pro Form widget submission plus its associated field values. Requires confirm=true. Requires Elementor Pro.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array(
+						'submission_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+						'confirm'       => array( 'type' => 'boolean' ),
+					),
+					'required' => array( 'submission_id', 'confirm' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'       => array( 'type' => 'boolean' ),
+						'submission_id' => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
+						'error_code'    => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$pro = Document_Repository::assert_elementor_pro_available();
+		if ( is_wp_error( $pro ) ) {
+			return array( 'success' => false, 'message' => (string) $pro->get_error_message(), 'error_code' => (string) $pro->get_error_code() );
+		}
+		$submission_id = absint( $input['submission_id'] ?? 0 );
+		if ( empty( $input['confirm'] ) ) {
+			return array( 'success' => false, 'submission_id' => $submission_id, 'message' => __( 'confirm=true is required.', 'acrossai-abilities-manager' ), 'error_code' => 'force_delete_required' );
+		}
+		global $wpdb;
+		$table = $wpdb->prefix . List_Form_Submissions::TABLE;
+		$vals  = $wpdb->prefix . 'e_submissions_values';
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $exists !== $table ) {
+			return array( 'success' => false, 'submission_id' => $submission_id, 'message' => __( 'Elementor Pro submissions storage not available.', 'acrossai-abilities-manager' ), 'error_code' => 'submission_storage_missing' );
+		}
+		$wpdb->delete( $vals, array( 'submission_id' => $submission_id ), array( '%d' ) );
+		$deleted = $wpdb->delete( $table, array( 'id' => $submission_id ), array( '%d' ) );
+		// phpcs:enable
+		if ( ! $deleted ) {
+			return array( 'success' => false, 'submission_id' => $submission_id, 'message' => __( 'Submission not found.', 'acrossai-abilities-manager' ), 'error_code' => 'submission_not_found' );
+		}
+		return array(
+			'success'       => true,
+			'submission_id' => $submission_id,
+			/* translators: %d: id */
+			'message'       => sprintf( __( 'Deleted submission #%d.', 'acrossai-abilities-manager' ), $submission_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Get_Custom_Code.php
+++ b/includes/Abilities/Elementor/Get_Custom_Code.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Feature 067 — read one Elementor Pro custom code snippet.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Get_Custom_Code extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-get-custom-code',
+			'args' => array(
+				'label'               => __( 'Get Elementor Pro Custom Code', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Read a single Elementor Pro Custom Code snippet including its code body. Requires Elementor Pro.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array( 'snippet_id' => array( 'type' => 'integer', 'minimum' => 1 ) ),
+					'required' => array( 'snippet_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'snippet'    => array( 'type' => 'object' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$pro = Document_Repository::assert_elementor_pro_available();
+		if ( is_wp_error( $pro ) ) {
+			return array( 'success' => false, 'message' => (string) $pro->get_error_message(), 'error_code' => (string) $pro->get_error_code() );
+		}
+		$snippet_id = absint( $input['snippet_id'] ?? 0 );
+		$post = get_post( $snippet_id );
+		if ( ! $post instanceof \WP_Post || List_Custom_Code::CPT !== $post->post_type ) {
+			return array( 'success' => false, 'message' => __( 'Snippet not found.', 'acrossai-abilities-manager' ), 'error_code' => 'post_not_found' );
+		}
+		$snippet = array_merge(
+			List_Custom_Code::to_summary( $post ),
+			array( 'code' => (string) $post->post_content )
+		);
+		return array(
+			'success' => true,
+			'snippet' => $snippet,
+			/* translators: %d: snippet id */
+			'message' => sprintf( __( 'Returned Pro custom code snippet #%d.', 'acrossai-abilities-manager' ), $snippet_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/Get_Form_Submission.php
+++ b/includes/Abilities/Elementor/Get_Form_Submission.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Feature 067 — read one Elementor Pro form submission.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Get_Form_Submission extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-get-form-submission',
+			'args' => array(
+				'label'               => __( 'Get Elementor Pro Form Submission', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Read one Elementor Pro Form widget submission by ID; optional include_values to fetch field values. Requires Elementor Pro.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array(
+						'submission_id'  => array( 'type' => 'integer', 'minimum' => 1 ),
+						'include_values' => array( 'type' => 'boolean', 'default' => true ),
+					),
+					'required' => array( 'submission_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'submission' => array( 'type' => 'object' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$pro = Document_Repository::assert_elementor_pro_available();
+		if ( is_wp_error( $pro ) ) {
+			return array( 'success' => false, 'message' => (string) $pro->get_error_message(), 'error_code' => (string) $pro->get_error_code() );
+		}
+		global $wpdb;
+		$submission_id  = absint( $input['submission_id'] ?? 0 );
+		$include_values = ! isset( $input['include_values'] ) || (bool) $input['include_values'];
+		$table          = $wpdb->prefix . List_Form_Submissions::TABLE;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $exists !== $table ) {
+			return array( 'success' => false, 'message' => __( 'Elementor Pro submissions storage not available.', 'acrossai-abilities-manager' ), 'error_code' => 'submission_storage_missing' );
+		}
+		$row = $wpdb->get_row( $wpdb->prepare( 'SELECT id, form_id, form_name, post_id, created_at FROM ' . $table . ' WHERE id = %d', $submission_id ), ARRAY_A );
+		// phpcs:enable
+		if ( ! $row ) {
+			return array( 'success' => false, 'message' => __( 'Submission not found.', 'acrossai-abilities-manager' ), 'error_code' => 'submission_not_found' );
+		}
+		$submission = array(
+			'id'         => (int) $row['id'],
+			'form_id'    => (string) $row['form_id'],
+			'form_name'  => (string) ( $row['form_name'] ?? '' ),
+			'post_id'    => (int) ( $row['post_id'] ?? 0 ),
+			'created_at' => (string) ( $row['created_at'] ?? '' ),
+		);
+		if ( $include_values ) {
+			$submission['values'] = List_Form_Submissions::fetch_values( $submission_id );
+		}
+		return array(
+			'success'    => true,
+			'submission' => $submission,
+			/* translators: %d: id */
+			'message'    => sprintf( __( 'Returned submission #%d.', 'acrossai-abilities-manager' ), $submission_id ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/List_Custom_Code.php
+++ b/includes/Abilities/Elementor/List_Custom_Code.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Feature 067 — list Elementor Pro custom code snippets.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use WP_Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List Elementor Pro custom code snippets (elementor_snippet CPT).
+ * Pro-gated: requires class_exists('\ElementorPro\Plugin') or ELEMENTOR_PRO_VERSION.
+ */
+class List_Custom_Code extends Ability_Definition {
+
+	/** The Elementor Pro custom-code CPT slug. */
+	public const CPT = 'elementor_snippet';
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-list-custom-code',
+			'args' => array(
+				'label'               => __( 'List Elementor Pro Custom Code', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List Elementor Pro Custom Code snippets. Filter by location and status. Requires Elementor Pro.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array(
+						'location' => array( 'type' => 'string', 'enum' => array( 'head', 'body_start', 'body_end', 'footer' ) ),
+						'status'   => array( 'type' => 'string', 'default' => 'any' ),
+					),
+					'required' => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'  => array( 'type' => 'boolean' ),
+						'snippets' => array( 'type' => 'array' ),
+						'count'    => array( 'type' => 'integer' ),
+						'message'  => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$pro = Document_Repository::assert_elementor_pro_available();
+		if ( is_wp_error( $pro ) ) {
+			return array( 'success' => false, 'message' => (string) $pro->get_error_message(), 'error_code' => (string) $pro->get_error_code() );
+		}
+		$location = isset( $input['location'] ) ? sanitize_key( (string) $input['location'] ) : '';
+		$status   = isset( $input['status'] ) ? sanitize_key( (string) $input['status'] ) : 'any';
+
+		$query_args = array(
+			'post_type'      => self::CPT,
+			'post_status'    => $status,
+			'posts_per_page' => -1,
+			'no_found_rows'  => true,
+		);
+		if ( '' !== $location ) {
+			$query_args['meta_query'] = array(
+				array( 'key' => '_elementor_snippet_location', 'value' => $location ),
+			);
+		}
+		$query    = new WP_Query( $query_args );
+		$snippets = array();
+		foreach ( $query->posts as $post ) {
+			$snippets[] = self::to_summary( $post );
+		}
+		return array(
+			'success'  => true,
+			'snippets' => $snippets,
+			'count'    => count( $snippets ),
+			/* translators: %d: count */
+			'message'  => sprintf( __( 'Returned %d Pro custom code snippets.', 'acrossai-abilities-manager' ), count( $snippets ) ),
+		);
+	}
+
+	/**
+	 * @param \WP_Post $post
+	 * @return array<string, mixed>
+	 */
+	public static function to_summary( \WP_Post $post ): array {
+		return array(
+			'id'       => (int) $post->ID,
+			'title'    => (string) $post->post_title,
+			'status'   => (string) $post->post_status,
+			'location' => (string) get_post_meta( $post->ID, '_elementor_snippet_location', true ),
+			'priority' => (int) get_post_meta( $post->ID, '_elementor_snippet_priority', true ),
+		);
+	}
+}

--- a/includes/Abilities/Elementor/List_Form_Submissions.php
+++ b/includes/Abilities/Elementor/List_Form_Submissions.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Feature 067 — list Elementor Pro form submissions.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List Elementor Pro Form widget submissions. Uses Elementor Pro's own
+ * Submissions module when available; degrades gracefully with an empty
+ * list + note when Pro is present but submissions storage is missing.
+ */
+class List_Form_Submissions extends Ability_Definition {
+
+	/** Custom DB table Elementor Pro uses for submissions. */
+	public const TABLE = 'e_submissions';
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-list-form-submissions',
+			'args' => array(
+				'label'               => __( 'List Elementor Pro Form Submissions', 'acrossai-abilities-manager' ),
+				'description'         => __( 'List Elementor Pro Form widget submissions with optional form_id filter and include_values flag. Requires Elementor Pro.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array(
+						'form_id'        => array( 'type' => 'string' ),
+						'limit'          => array( 'type' => 'integer', 'default' => 25 ),
+						'offset'         => array( 'type' => 'integer', 'default' => 0 ),
+						'include_values' => array( 'type' => 'boolean', 'default' => false ),
+					),
+					'required' => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'     => array( 'type' => 'boolean' ),
+						'submissions' => array( 'type' => 'array' ),
+						'count'       => array( 'type' => 'integer' ),
+						'message'     => array( 'type' => 'string' ),
+						'error_code'  => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$pro = Document_Repository::assert_elementor_pro_available();
+		if ( is_wp_error( $pro ) ) {
+			return array( 'success' => false, 'message' => (string) $pro->get_error_message(), 'error_code' => (string) $pro->get_error_code() );
+		}
+		global $wpdb;
+		$form_id        = isset( $input['form_id'] ) ? sanitize_text_field( (string) $input['form_id'] ) : '';
+		$limit          = max( 1, (int) ( $input['limit'] ?? 25 ) );
+		$offset         = max( 0, (int) ( $input['offset'] ?? 0 ) );
+		$include_values = ! empty( $input['include_values'] );
+
+		$table = $wpdb->prefix . self::TABLE;
+		// Guard: if the Pro submissions table doesn't exist, degrade gracefully.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $exists !== $table ) {
+			return array( 'success' => true, 'submissions' => array(), 'count' => 0, 'message' => __( 'Elementor Pro submissions storage not available.', 'acrossai-abilities-manager' ) );
+		}
+		$where  = '';
+		$params = array();
+		if ( '' !== $form_id ) {
+			$where    = ' WHERE form_id = %s';
+			$params[] = $form_id;
+		}
+		$params[]     = $limit;
+		$params[]     = $offset;
+		$query        = 'SELECT id, form_id, form_name, post_id, created_at FROM ' . $table . $where . ' ORDER BY id DESC LIMIT %d OFFSET %d';
+		$rows         = $wpdb->get_results( $wpdb->prepare( $query, $params ), ARRAY_A );
+		// phpcs:enable
+		$submissions  = array();
+		foreach ( (array) $rows as $row ) {
+			$entry = array(
+				'id'         => (int) $row['id'],
+				'form_id'    => (string) $row['form_id'],
+				'form_name'  => (string) ( $row['form_name'] ?? '' ),
+				'post_id'    => (int) ( $row['post_id'] ?? 0 ),
+				'created_at' => (string) ( $row['created_at'] ?? '' ),
+			);
+			if ( $include_values ) {
+				$entry['values'] = self::fetch_values( (int) $row['id'] );
+			}
+			$submissions[] = $entry;
+		}
+		return array(
+			'success'     => true,
+			'submissions' => $submissions,
+			'count'       => count( $submissions ),
+			/* translators: %d: count */
+			'message'     => sprintf( __( 'Returned %d form submissions.', 'acrossai-abilities-manager' ), count( $submissions ) ),
+		);
+	}
+
+	/**
+	 * Fetch field values from the submission-values table.
+	 *
+	 * @param int $submission_id
+	 * @return array<int, array<string, string>>
+	 */
+	public static function fetch_values( int $submission_id ): array {
+		global $wpdb;
+		$table = $wpdb->prefix . 'e_submissions_values';
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $exists !== $table ) {
+			return array();
+		}
+		$rows = $wpdb->get_results( $wpdb->prepare( 'SELECT `key`, `value` FROM ' . $table . ' WHERE submission_id = %d', $submission_id ), ARRAY_A );
+		// phpcs:enable
+		$values = array();
+		foreach ( (array) $rows as $row ) {
+			$values[] = array( 'field' => (string) $row['key'], 'value' => (string) $row['value'] );
+		}
+		return $values;
+	}
+}

--- a/includes/Abilities/Elementor/Update_Custom_Code.php
+++ b/includes/Abilities/Elementor/Update_Custom_Code.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Feature 067 — update an Elementor Pro custom code snippet.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Elementor
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Elementor;
+
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Elementor\Document_Repository;
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+class Update_Custom_Code extends Ability_Definition {
+
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/elementor-update-custom-code',
+			'args' => array(
+				'label'               => __( 'Update Elementor Pro Custom Code', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Update fields on an existing Elementor Pro Custom Code snippet. Requires Elementor Pro.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-elementor',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
+				'input_schema'        => array(
+					'type' => 'object',
+					'properties' => array(
+						'snippet_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+						'title'      => array( 'type' => 'string' ),
+						'code'       => array( 'type' => 'string' ),
+						'location'   => array( 'type' => 'string', 'enum' => array( 'head', 'body_start', 'body_end', 'footer' ) ),
+						'priority'   => array( 'type' => 'integer' ),
+						'status'     => array( 'type' => 'string', 'enum' => array( 'publish', 'draft' ) ),
+					),
+					'required' => array( 'snippet_id' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type' => 'object',
+					'properties' => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'snippet_id' => array( 'type' => 'integer' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required' => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta' => array(
+					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	public function execute( array $input = array() ): array {
+		$check = Document_Repository::assert_elementor_available();
+		if ( is_wp_error( $check ) ) {
+			return array( 'success' => false, 'message' => (string) $check->get_error_message(), 'error_code' => (string) $check->get_error_code() );
+		}
+		$pro = Document_Repository::assert_elementor_pro_available();
+		if ( is_wp_error( $pro ) ) {
+			return array( 'success' => false, 'message' => (string) $pro->get_error_message(), 'error_code' => (string) $pro->get_error_code() );
+		}
+		$snippet_id = absint( $input['snippet_id'] ?? 0 );
+		$post = get_post( $snippet_id );
+		if ( ! $post instanceof \WP_Post || List_Custom_Code::CPT !== $post->post_type ) {
+			return array( 'success' => false, 'message' => __( 'Snippet not found.', 'acrossai-abilities-manager' ), 'error_code' => 'post_not_found' );
+		}
+		$post_update = array( 'ID' => $snippet_id );
+		if ( isset( $input['title'] ) ) {
+			$post_update['post_title'] = sanitize_text_field( (string) $input['title'] );
+		}
+		if ( isset( $input['code'] ) ) {
+			$post_update['post_content'] = (string) $input['code'];
+		}
+		if ( isset( $input['status'] ) ) {
+			$post_update['post_status'] = sanitize_key( (string) $input['status'] );
+		}
+		if ( count( $post_update ) > 1 ) {
+			wp_update_post( $post_update );
+		}
+		if ( isset( $input['location'] ) ) {
+			update_post_meta( $snippet_id, '_elementor_snippet_location', sanitize_key( (string) $input['location'] ) );
+		}
+		if ( isset( $input['priority'] ) ) {
+			update_post_meta( $snippet_id, '_elementor_snippet_priority', (int) $input['priority'] );
+		}
+		return array(
+			'success'    => true,
+			'snippet_id' => $snippet_id,
+			/* translators: %d: id */
+			'message'    => sprintf( __( 'Updated Pro custom code snippet #%d.', 'acrossai-abilities-manager' ), $snippet_id ),
+		);
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -151,6 +151,14 @@
 			<file>tests/phpunit/abilities/Test_Elementor_List_Global_Widgets.php</file>
 			<file>tests/phpunit/abilities/Test_Elementor_List_Experiments.php</file>
 			<file>tests/phpunit/abilities/Test_Elementor_Update_Experiment.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_List_Custom_Code.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Get_Custom_Code.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Create_Custom_Code.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Update_Custom_Code.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Delete_Custom_Code.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_List_Form_Submissions.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Get_Form_Submission.php</file>
+			<file>tests/phpunit/abilities/Test_Elementor_Delete_Form_Submission.php</file>
 			<file>tests/phpunit/abilities/Test_Move_Block.php</file>
 			<file>tests/phpunit/abilities/Test_Duplicate_Block.php</file>
 			<file>tests/phpunit/abilities/Test_Insert_Pattern.php</file>

--- a/tests/phpunit/abilities/Test_Elementor_Create_Custom_Code.php
+++ b/tests/phpunit/abilities/Test_Elementor_Create_Custom_Code.php
@@ -1,0 +1,15 @@
+<?php
+/** Feature 067 — Create_Custom_Code tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Create_Custom_Code extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Create_Custom_Code.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-create-custom-code'", $this->src ); }
+	public function test_requires_title_code_location(): void { $this->assertStringContainsString( "'required' => array( 'title', 'code', 'location' )", $this->src ); }
+	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
+	public function test_inserts_snippet_cpt(): void { $this->assertStringContainsString( 'List_Custom_Code::CPT', $this->src ); }
+	public function test_writes_location_meta(): void { $this->assertStringContainsString( "'_elementor_snippet_location'", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Delete_Custom_Code.php
+++ b/tests/phpunit/abilities/Test_Elementor_Delete_Custom_Code.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Delete_Custom_Code tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Delete_Custom_Code extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Delete_Custom_Code.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-delete-custom-code'", $this->src ); }
+	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
+	public function test_supports_trash_and_force_delete(): void { $this->assertStringContainsString( 'wp_trash_post(', $this->src ); $this->assertStringContainsString( 'wp_delete_post( $snippet_id, true )', $this->src ); }
+	public function test_destructive(): void { $this->assertStringContainsString( "'destructive' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Delete_Form_Submission.php
+++ b/tests/phpunit/abilities/Test_Elementor_Delete_Form_Submission.php
@@ -1,0 +1,16 @@
+<?php
+/** Feature 067 — Delete_Form_Submission tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Delete_Form_Submission extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Delete_Form_Submission.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-delete-form-submission'", $this->src ); }
+	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
+	public function test_requires_confirm(): void { $this->assertStringContainsString( "'required' => array( 'submission_id', 'confirm' )", $this->src ); }
+	public function test_force_delete_error_when_no_confirm(): void { $this->assertStringContainsString( "'force_delete_required'", $this->src ); }
+	public function test_deletes_values_and_submission(): void { $this->assertStringContainsString( '$wpdb->delete( $vals,', $this->src ); $this->assertStringContainsString( '$wpdb->delete( $table,', $this->src ); }
+	public function test_destructive(): void { $this->assertStringContainsString( "'destructive' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Get_Custom_Code.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Custom_Code.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Get_Custom_Code tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Get_Custom_Code extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Get_Custom_Code.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-get-custom-code'", $this->src ); }
+	public function test_requires_snippet_id(): void { $this->assertStringContainsString( "'required' => array( 'snippet_id' )", $this->src ); }
+	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
+	public function test_returns_code(): void { $this->assertStringContainsString( "'code' => (string) \$post->post_content", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Get_Form_Submission.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Form_Submission.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Get_Form_Submission tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Get_Form_Submission extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Get_Form_Submission.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-get-form-submission'", $this->src ); }
+	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
+	public function test_requires_submission_id(): void { $this->assertStringContainsString( "'required' => array( 'submission_id' )", $this->src ); }
+	public function test_optionally_includes_values(): void { $this->assertStringContainsString( 'List_Form_Submissions::fetch_values(', $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_List_Custom_Code.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Custom_Code.php
@@ -1,0 +1,15 @@
+<?php
+/** Feature 067 — List_Custom_Code tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_List_Custom_Code extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Custom_Code.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-custom-code'", $this->src ); }
+	public function test_uses_elementor_snippet_cpt(): void { $this->assertStringContainsString( "public const CPT = 'elementor_snippet'", $this->src ); }
+	public function test_pro_gate(): void { $this->assertStringContainsString( 'Document_Repository::assert_elementor_pro_available()', $this->src ); }
+	public function test_location_enum(): void { $this->assertStringContainsString( "'head', 'body_start', 'body_end', 'footer'", $this->src ); }
+	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_List_Form_Submissions.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Form_Submissions.php
@@ -1,0 +1,15 @@
+<?php
+/** Feature 067 — List_Form_Submissions tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_List_Form_Submissions extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Form_Submissions.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-form-submissions'", $this->src ); }
+	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
+	public function test_uses_e_submissions_table(): void { $this->assertStringContainsString( "public const TABLE = 'e_submissions'", $this->src ); }
+	public function test_graceful_degradation_when_table_missing(): void { $this->assertStringContainsString( "'Elementor Pro submissions storage not available.'", $this->src ); }
+	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
+}

--- a/tests/phpunit/abilities/Test_Elementor_Update_Custom_Code.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Custom_Code.php
@@ -1,0 +1,14 @@
+<?php
+/** Feature 067 — Update_Custom_Code tests. */
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+use WP_UnitTestCase;
+
+class Test_Elementor_Update_Custom_Code extends WP_UnitTestCase {
+	private string $src = '';
+	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Update_Custom_Code.php' ); }
+	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-update-custom-code'", $this->src ); }
+	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
+	public function test_updates_post(): void { $this->assertStringContainsString( 'wp_update_post( $post_update )', $this->src ); }
+	public function test_updates_location_and_priority_meta(): void { $this->assertStringContainsString( "'_elementor_snippet_location'", $this->src ); $this->assertStringContainsString( "'_elementor_snippet_priority'", $this->src ); }
+}


### PR DESCRIPTION
## Summary

- Eighth batch of Feature 067 merged to main **without a plugin version bump**.
- All 8 abilities gated on **both** free Elementor AND Elementor Pro.
- Silently absent on non-Pro sites. Runtime deactivation returns `error_code: elementor_pro_missing`.

## Custom Code (5)

| Slug | Purpose |
|---|---|
| `elementor-list-custom-code` | List snippets from elementor_snippet CPT; optional location filter |
| `elementor-get-custom-code` | Read one snippet with code body |
| `elementor-create-custom-code` | Create with title, code, location, priority, status |
| `elementor-update-custom-code` | Update snippet fields |
| `elementor-delete-custom-code` | Trash (default) or permanently delete with force=true |

## Form Submissions (3) — Elementor Pro's `e_submissions` table

| Slug | Purpose |
|---|---|
| `elementor-list-form-submissions` | List with `form_id` filter + `include_values`; graceful degradation when table missing |
| `elementor-get-form-submission` | Read one submission with optional field values |
| `elementor-delete-form-submission` | Permanently delete submission + `e_submissions_values` rows; requires confirm=true |

## Total shipped Elementor abilities: 59 of 88

Only design audits (29) remain.

## Test plan

- [x] Full PHPUnit suite: **967 tests, 1890 assertions, 0 failures**
- [x] phpcs (WPCS strict): 0 errors · phpstan (level 8): 0 errors

## Not shipped

- No version bump (stays at 0.0.25) · No git tag · No GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)