### PR TITLE
feat: native site maintenance-mode toggle (set + unset abilities)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -138,6 +138,11 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased (NOT YET RELEASED) =
+* **Native site maintenance-mode toggle (2 abilities):**
+  * `acrossai/set-site-maintenance-mode` — activate WordPress core maintenance mode by writing the `ABSPATH/.maintenance` marker file (the same file WP core writes during plugin/theme/core updates). A wp-cron event refreshes the marker every 5 minutes so the site stays down for the requested `duration_minutes` (default 60, hard-cap 1440). Requires `confirm=true` — blocks wp-admin as well as the frontend.
+  * `acrossai/unset-site-maintenance-mode` — deactivate: delete the marker, clear the refresh cron, drop the expiry option. Idempotent — safe to call when maintenance mode is already inactive. Reports `was_active` in the response.
+  * Both live under the existing `acrossai-abilities-manager-site-health` category alongside `acrossai/get-maintenance-mode-status` (Feature 063 read). No Elementor / plugin dependency — works on every WP install.
+
 * **Feature 067 COMPLETE — 87 Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available on the `main` branch; no plugin release / tag / distribution package has been cut. Feature 067's 88-ability target reached (2 released in 0.0.25 + 87 unreleased on main). Design-audit ability logic is skeletal (`Base_Audit_Ability` skeleton returning empty findings) — real audit heuristics to be filled in follow-up work.
 
 **Batch 10 — full-document replacement (closes the parity gap):**

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -368,6 +368,9 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new SiteHealth\Get_Site_Maintenance_Report();
 		// Feature 063 — Maintenance-mode status read.
 		new SiteHealth\Get_Maintenance_Mode_Status();
+		// Site maintenance-mode toggle (write) — native WP-core .maintenance marker.
+		new SiteHealth\Set_Site_Maintenance_Mode();
+		new SiteHealth\Unset_Site_Maintenance_Mode();
 		new Plugins\Get_Plugin_Lifecycle_Context();
 		new Themes\Get_Theme_Lifecycle_Context();
 		// Feature 063 — Theme mods introspection.
@@ -411,6 +414,10 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		// Feature 041: Upload_Zip_Backup chunk sweeper — same shape as Upload_Media.
 		add_action( FileManager\Upload_Zip_Backup::CHUNK_SWEEP_HOOK, array( FileManager\Upload_Zip_Backup::class, 'sweep_chunk_sessions' ) );
 		FileManager\Upload_Zip_Backup::register_sweep_cron();
+
+		// Site maintenance-mode toggle — 5-min cron schedule + refresh callback.
+		add_filter( 'cron_schedules', array( SiteHealth\Set_Site_Maintenance_Mode::class, 'register_cron_schedule' ) );
+		add_action( SiteHealth\Set_Site_Maintenance_Mode::CRON_HOOK, array( SiteHealth\Set_Site_Maintenance_Mode::class, 'refresh_marker' ) );
 
 		// Feature 067 — Elementor ability suite (up to 88 abilities under
 		// acrossai/elementor-*). Gated on Elementor presence; the Pro-only

--- a/includes/Abilities/SiteHealth/Set_Site_Maintenance_Mode.php
+++ b/includes/Abilities/SiteHealth/Set_Site_Maintenance_Mode.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Site maintenance mode — write the .maintenance marker used by WP core.
+ *
+ * Writes ABSPATH/.maintenance so wp_maintenance() (wp-includes/load.php)
+ * short-circuits every request with a 503. Because core treats the marker
+ * as stale after 10 minutes, a wp-cron event refreshes the timestamp
+ * every 5 minutes until the requested duration elapses.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\SiteHealth
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\SiteHealth;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Set_Site_Maintenance_Mode — activate the WP-core .maintenance marker
+ * for a bounded duration, keeping the timestamp fresh via wp-cron.
+ */
+class Set_Site_Maintenance_Mode extends Ability_Definition {
+
+	public const CRON_HOOK        = 'acrossai_refresh_maintenance_marker';
+	public const EXPIRY_OPTION    = 'acrossai_maintenance_expires_at';
+	public const REFRESH_INTERVAL = 300; // 5 minutes.
+	public const DEFAULT_MINUTES  = 60;
+	public const MAX_MINUTES      = 1440;
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/set-site-maintenance-mode',
+			'args' => array(
+				'label'               => __( 'Set Site Maintenance Mode', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Activate WordPress core maintenance mode by writing the ABSPATH/.maintenance marker. A wp-cron event refreshes the marker every 5 minutes so the site stays down for the requested duration. WARNING: this blocks wp-admin as well as the frontend.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-site-health',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'duration_minutes' => array(
+							'type'    => 'integer',
+							'minimum' => 1,
+							'maximum' => self::MAX_MINUTES,
+							'default' => self::DEFAULT_MINUTES,
+						),
+						'confirm'          => array( 'type' => 'boolean' ),
+					),
+					'required'             => array( 'confirm' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'          => array( 'type' => 'boolean' ),
+						'active'           => array( 'type' => 'boolean' ),
+						'expires_at'       => array( 'type' => 'integer' ),
+						'duration_minutes' => array( 'type' => 'integer' ),
+						'refresh_scheduled'=> array( 'type' => 'boolean' ),
+						'message'          => array( 'type' => 'string' ),
+						'error_code'       => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'site-health',
+						'sub_group'       => 'maintenance',
+						'sub_group_label' => __( 'Maintenance', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		if ( empty( $input['confirm'] ) ) {
+			return array(
+				'success'    => false,
+				'message'    => __( 'Refused: set confirm=true to acknowledge that maintenance mode blocks wp-admin as well as the frontend.', 'acrossai-abilities-manager' ),
+				'error_code' => 'confirmation_required',
+			);
+		}
+
+		$minutes = isset( $input['duration_minutes'] ) ? (int) $input['duration_minutes'] : self::DEFAULT_MINUTES;
+		if ( $minutes < 1 ) {
+			$minutes = self::DEFAULT_MINUTES;
+		}
+		if ( $minutes > self::MAX_MINUTES ) {
+			$minutes = self::MAX_MINUTES;
+		}
+
+		$now        = time();
+		$expires_at = $now + ( $minutes * MINUTE_IN_SECONDS );
+		$marker     = ABSPATH . '.maintenance';
+
+		$written = self::write_marker( $marker, $now );
+		if ( ! $written ) {
+			return array(
+				'success'    => false,
+				'message'    => __( 'Could not write the .maintenance marker file at ABSPATH. Check filesystem permissions.', 'acrossai-abilities-manager' ),
+				'error_code' => 'marker_write_failed',
+			);
+		}
+
+		update_option( self::EXPIRY_OPTION, $expires_at, false );
+
+		$scheduled = true;
+		wp_clear_scheduled_hook( self::CRON_HOOK );
+		$result = wp_schedule_event( $now + self::REFRESH_INTERVAL, 'acrossai_five_minutes', self::CRON_HOOK );
+		if ( false === $result || is_wp_error( $result ) ) {
+			$scheduled = false;
+		}
+
+		return array(
+			'success'          => true,
+			'active'           => true,
+			'expires_at'       => $expires_at,
+			'duration_minutes' => $minutes,
+			'refresh_scheduled'=> $scheduled,
+			/* translators: 1: duration in minutes, 2: expiry unix timestamp */
+			'message'          => sprintf( __( 'Maintenance mode activated for %1$d minutes (expires at %2$d).', 'acrossai-abilities-manager' ), $minutes, $expires_at ),
+		);
+	}
+
+	/**
+	 * Write the .maintenance marker with the given $upgrading timestamp.
+	 *
+	 * @param string $marker Absolute path.
+	 * @param int    $timestamp Unix time to assign to $upgrading.
+	 * @return bool True on success.
+	 */
+	public static function write_marker( string $marker, int $timestamp ): bool {
+		$contents = '<?php $upgrading = ' . $timestamp . '; ?>';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- writing the exact file WP core writes; WP_Filesystem is unavailable in ability execution context.
+		$bytes = @file_put_contents( $marker, $contents, LOCK_EX );
+		return false !== $bytes;
+	}
+
+	/**
+	 * WP-cron callback — refresh the marker until the recorded expiry.
+	 * Deletes the marker and clears itself once expiry passes.
+	 */
+	public static function refresh_marker(): void {
+		$expires_at = (int) get_option( self::EXPIRY_OPTION, 0 );
+		$marker     = ABSPATH . '.maintenance';
+		$now        = time();
+
+		if ( $expires_at <= 0 || $now >= $expires_at ) {
+			if ( file_exists( $marker ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- symmetric with write_marker() which uses file_put_contents.
+				@unlink( $marker );
+			}
+			delete_option( self::EXPIRY_OPTION );
+			wp_clear_scheduled_hook( self::CRON_HOOK );
+			return;
+		}
+
+		self::write_marker( $marker, $now );
+	}
+
+	/**
+	 * Register the 5-minute cron schedule used by refresh_marker().
+	 *
+	 * @param array<string,array<string,mixed>> $schedules
+	 * @return array<string,array<string,mixed>>
+	 */
+	public static function register_cron_schedule( array $schedules ): array {
+		if ( ! isset( $schedules['acrossai_five_minutes'] ) ) {
+			$schedules['acrossai_five_minutes'] = array(
+				'interval' => self::REFRESH_INTERVAL,
+				'display'  => __( 'Every 5 minutes (AcrossAI maintenance-mode refresh)', 'acrossai-abilities-manager' ),
+			);
+		}
+		return $schedules;
+	}
+}

--- a/includes/Abilities/SiteHealth/Unset_Site_Maintenance_Mode.php
+++ b/includes/Abilities/SiteHealth/Unset_Site_Maintenance_Mode.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Site maintenance mode — remove the .maintenance marker and clear
+ * the refresh cron scheduled by Set_Site_Maintenance_Mode.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\SiteHealth
+ * @since      0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\SiteHealth;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Deactivate WordPress core maintenance mode. Idempotent — safe to call
+ * whether or not the marker is currently present.
+ */
+class Unset_Site_Maintenance_Mode extends Ability_Definition {
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'acrossai/unset-site-maintenance-mode',
+			'args' => array(
+				'label'               => __( 'Unset Site Maintenance Mode', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Deactivate WordPress core maintenance mode: delete the ABSPATH/.maintenance marker and clear the refresh cron. Idempotent — safe to call when maintenance mode is already inactive.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-site-health',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'    => array( 'type' => 'boolean' ),
+						'was_active' => array( 'type' => 'boolean' ),
+						'active'     => array( 'type' => 'boolean' ),
+						'message'    => array( 'type' => 'string' ),
+						'error_code' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'site-health',
+						'sub_group'       => 'maintenance',
+						'sub_group_label' => __( 'Maintenance', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
+					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input = array() ): array {
+		$marker     = ABSPATH . '.maintenance';
+		$was_active = file_exists( $marker );
+
+		if ( $was_active ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- symmetric with Set_Site_Maintenance_Mode::write_marker().
+			$removed = @unlink( $marker );
+			if ( ! $removed && file_exists( $marker ) ) {
+				return array(
+					'success'    => false,
+					'was_active' => true,
+					'active'     => true,
+					'message'    => __( 'Could not remove the .maintenance marker file. Check filesystem permissions.', 'acrossai-abilities-manager' ),
+					'error_code' => 'marker_delete_failed',
+				);
+			}
+		}
+
+		delete_option( Set_Site_Maintenance_Mode::EXPIRY_OPTION );
+		wp_clear_scheduled_hook( Set_Site_Maintenance_Mode::CRON_HOOK );
+
+		return array(
+			'success'    => true,
+			'was_active' => $was_active,
+			'active'     => false,
+			'message'    => $was_active
+				? __( 'Maintenance mode deactivated; marker removed and refresh cron cleared.', 'acrossai-abilities-manager' )
+				: __( 'Maintenance mode was already inactive.', 'acrossai-abilities-manager' ),
+		);
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -72,6 +72,8 @@
 			<file>tests/phpunit/abilities/Test_List_Image_Sizes.php</file>
 			<file>tests/phpunit/abilities/Test_Get_Comment_Count.php</file>
 			<file>tests/phpunit/abilities/Test_Get_Maintenance_Mode_Status.php</file>
+			<file>tests/phpunit/abilities/Test_Set_Site_Maintenance_Mode.php</file>
+			<file>tests/phpunit/abilities/Test_Unset_Site_Maintenance_Mode.php</file>
 			<file>tests/phpunit/abilities/Test_Test_Wp_Cron.php</file>
 			<file>tests/phpunit/abilities/Test_List_Widgets.php</file>
 			<file>tests/phpunit/abilities/Test_List_Sidebars.php</file>

--- a/tests/phpunit/abilities/Test_Set_Site_Maintenance_Mode.php
+++ b/tests/phpunit/abilities/Test_Set_Site_Maintenance_Mode.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Source-inspection tests for Set_Site_Maintenance_Mode.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Set_Site_Maintenance_Mode extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/SiteHealth/Set_Site_Maintenance_Mode.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/set-site-maintenance-mode'", $this->src );
+	}
+
+	public function test_lives_in_site_health_category(): void {
+		$this->assertStringContainsString( "'acrossai-abilities-manager-site-health'", $this->src );
+	}
+
+	public function test_requires_confirm_flag(): void {
+		$this->assertStringContainsString( "'required'             => array( 'confirm' )", $this->src );
+		$this->assertStringContainsString( "'confirmation_required'", $this->src );
+	}
+
+	public function test_destructive_annotation(): void {
+		$this->assertStringContainsString( "'destructive' => true", $this->src );
+		$this->assertStringContainsString( "'idempotent' => false", $this->src );
+	}
+
+	public function test_duration_bounds(): void {
+		$this->assertStringContainsString( "'minimum' => 1", $this->src );
+		$this->assertStringContainsString( 'MAX_MINUTES      = 1440', $this->src );
+		$this->assertStringContainsString( 'DEFAULT_MINUTES  = 60', $this->src );
+	}
+
+	public function test_writes_wp_core_marker(): void {
+		$this->assertStringContainsString( "ABSPATH . '.maintenance'", $this->src );
+		$this->assertStringContainsString( "'<?php \$upgrading = '", $this->src );
+	}
+
+	public function test_registers_5_minute_refresh_schedule(): void {
+		$this->assertStringContainsString( 'REFRESH_INTERVAL = 300', $this->src );
+		$this->assertStringContainsString( "'acrossai_five_minutes'", $this->src );
+		$this->assertStringContainsString( 'register_cron_schedule', $this->src );
+	}
+
+	public function test_refresh_marker_self_cleans_after_expiry(): void {
+		$this->assertStringContainsString( 'public static function refresh_marker(): void', $this->src );
+		$this->assertStringContainsString( '$now >= $expires_at', $this->src );
+		$this->assertStringContainsString( '@unlink( $marker )', $this->src );
+		$this->assertStringContainsString( 'wp_clear_scheduled_hook( self::CRON_HOOK )', $this->src );
+	}
+
+	public function test_requires_manage_options(): void {
+		$this->assertStringContainsString( "current_user_can( 'manage_options' )", $this->src );
+	}
+
+	public function test_persists_expiry_to_option(): void {
+		$this->assertStringContainsString( "EXPIRY_OPTION    = 'acrossai_maintenance_expires_at'", $this->src );
+		$this->assertStringContainsString( 'update_option( self::EXPIRY_OPTION', $this->src );
+	}
+}

--- a/tests/phpunit/abilities/Test_Unset_Site_Maintenance_Mode.php
+++ b/tests/phpunit/abilities/Test_Unset_Site_Maintenance_Mode.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Source-inspection tests for Unset_Site_Maintenance_Mode.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.0.25
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+class Test_Unset_Site_Maintenance_Mode extends WP_UnitTestCase {
+
+	private string $src = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->src = (string) file_get_contents(
+			dirname( __DIR__, 3 ) . '/includes/Abilities/SiteHealth/Unset_Site_Maintenance_Mode.php'
+		);
+	}
+
+	public function test_extends_ability_definition(): void {
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->src );
+	}
+
+	public function test_registers_correct_slug(): void {
+		$this->assertStringContainsString( "'acrossai/unset-site-maintenance-mode'", $this->src );
+	}
+
+	public function test_lives_in_site_health_category(): void {
+		$this->assertStringContainsString( "'acrossai-abilities-manager-site-health'", $this->src );
+	}
+
+	public function test_takes_no_input(): void {
+		$this->assertStringContainsString( "'properties'           => array()", $this->src );
+	}
+
+	public function test_idempotent_annotation(): void {
+		$this->assertStringContainsString( "'idempotent' => true", $this->src );
+		$this->assertStringContainsString( "'destructive' => false", $this->src );
+	}
+
+	public function test_removes_wp_core_marker(): void {
+		$this->assertStringContainsString( "ABSPATH . '.maintenance'", $this->src );
+		$this->assertStringContainsString( '@unlink( $marker )', $this->src );
+	}
+
+	public function test_reports_was_active(): void {
+		$this->assertStringContainsString( "'was_active'", $this->src );
+		$this->assertStringContainsString( '$was_active = file_exists( $marker )', $this->src );
+	}
+
+	public function test_clears_expiry_option_and_cron(): void {
+		$this->assertStringContainsString( 'delete_option( Set_Site_Maintenance_Mode::EXPIRY_OPTION )', $this->src );
+		$this->assertStringContainsString( 'wp_clear_scheduled_hook( Set_Site_Maintenance_Mode::CRON_HOOK )', $this->src );
+	}
+
+	public function test_requires_manage_options(): void {
+		$this->assertStringContainsString( "current_user_can( 'manage_options' )", $this->src );
+	}
+
+	public function test_handles_delete_failure(): void {
+		$this->assertStringContainsString( "'marker_delete_failed'", $this->src );
+	}
+}


### PR DESCRIPTION
## Summary

Adds two native abilities that let a caller put a WordPress site into and take it out of maintenance mode, using the **same `.maintenance` marker mechanism WP core uses during plugin/theme/core updates**. No Elementor / plugin dependency — works on every WP install.

Companion to the existing read-only `acrossai/get-maintenance-mode-status` (Feature 063), completing the read/write pair under the `acrossai-abilities-manager-site-health` category.

## Abilities

**`acrossai/set-site-maintenance-mode`** — activate
- Writes `ABSPATH/.maintenance` with `<?php $upgrading = <time>; ?>` — same file WP core writes via `WP_Upgrader::maintenance_mode(true)`. Every subsequent request is short-circuited by `wp_maintenance()` in `wp-includes/load.php` with a 503.
- Because WP core treats the marker as stale after **10 minutes**, a wp-cron event on the `acrossai_refresh_maintenance_marker` hook fires every 5 minutes (`acrossai_five_minutes` interval) and rewrites the timestamp until the caller's requested `duration_minutes` elapses. On expiry, the cron self-deletes the marker + clears itself + drops the expiry option.
- **Input**: `{ duration_minutes?: int (default 60, max 1440), confirm: bool (required true) }`
- **Output**: `{ success, active, expires_at, duration_minutes, refresh_scheduled, message }`
- Requires `manage_options` + `confirm=true` — the `confirm` flag exists because this ability also blocks wp-admin, not just the frontend.
- **Annotations**: `readonly: false · destructive: true · idempotent: false`

**`acrossai/unset-site-maintenance-mode`** — deactivate
- Deletes the marker, clears the refresh cron, drops the expiry option.
- **Idempotent** — safe to call whether or not maintenance mode was active.
- Reports `was_active` in the response so callers can tell whether they actually toggled anything.
- **Input**: `{}`  
- **Output**: `{ success, was_active, active: false, message }`
- **Annotations**: `readonly: false · destructive: false · idempotent: true`

## Bootstrap wiring

Two additions in `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php::register_abilities()`:
1. `add_filter('cron_schedules', [Set_Site_Maintenance_Mode::class, 'register_cron_schedule'])` — declares the 5-minute schedule.
2. `add_action(Set_Site_Maintenance_Mode::CRON_HOOK, [Set_Site_Maintenance_Mode::class, 'refresh_marker'])` — wires the refresh callback.

Registered next to the other companion-cron extras (Upload_Media chunk sweep, Upload_Zip_Backup chunk sweep).

## Guardrails

- `confirm=true` required on the activate call — locking yourself out of wp-admin without confirming is a footgun this ability refuses to arm silently.
- Hard cap of 1440 minutes (24h) on `duration_minutes`.
- `manage_options` capability check on both abilities.
- Deactivate returns `marker_delete_failed` if the filesystem rejects the unlink so callers can escalate rather than silently succeeding.
- **Escape hatch documented**: if a caller ever locks themselves out and can't reach the ability, the recovery is `rm -f wp-root/.maintenance` (unchanged from stock WP behavior — that's how WP has always worked).

## No version bump

Per standing directive. Merged to `main`, changelog appended to the `= Unreleased (NOT YET RELEASED) =` block; plugin `Version:` header stays at `0.0.25`. No git tag, no GitHub release.

## Test plan

- [x] `composer test -- --filter Site_Maintenance_Mode` — 21 tests, 36 assertions, all pass
- [x] `composer test` — 996 tests, 2027 assertions, all pass (same 6 pre-existing warnings)
- [ ] Live-site smoke: call `set-site-maintenance-mode` with `confirm=true, duration_minutes=5`; verify site returns the "Briefly unavailable for scheduled maintenance" 503 in a browser
- [ ] Live-site smoke: while active, verify wp-admin also returns the 503 (that's the intended behavior)
- [ ] Live-site smoke: call `unset-site-maintenance-mode`; verify frontend + wp-admin recover; `was_active: true` in response
- [ ] Live-site smoke: call `unset-site-maintenance-mode` again while inactive; `was_active: false`, no error
- [ ] Cron smoke: set with `duration_minutes=15`, verify `.maintenance` timestamp increments across the 5-min refresh boundary (would otherwise go stale at t+10m)
- [ ] Cron smoke: set with `duration_minutes=1`, wait past expiry, verify next cron tick removes the marker + clears itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)