### PR TITLE
Release 0.0.26 — Feature 067 complete + native site maintenance-mode toggle

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.25
+Stable tag: 0.0.26
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -137,13 +137,15 @@ No data is sent to any external server without an explicit administrator action.
 
 == Changelog ==
 
-= Unreleased (NOT YET RELEASED) =
+= 0.0.26 - 2026-08-14 =
+**Release rollup — 89 abilities total: 87 unreleased Elementor abilities (Feature 067 completion) + 2 native site maintenance-mode abilities.** Plugin version bumped 0.0.25 → 0.0.26. Elementor abilities gate on `class_exists('\Elementor\Plugin')` (with 8 additionally gated on Elementor Pro); site maintenance-mode toggle has no plugin dependency.
+
 * **Native site maintenance-mode toggle (2 abilities):**
   * `acrossai/set-site-maintenance-mode` — activate WordPress core maintenance mode by writing the `ABSPATH/.maintenance` marker file (the same file WP core writes during plugin/theme/core updates). A wp-cron event refreshes the marker every 5 minutes so the site stays down for the requested `duration_minutes` (default 60, hard-cap 1440). Requires `confirm=true` — blocks wp-admin as well as the frontend.
   * `acrossai/unset-site-maintenance-mode` — deactivate: delete the marker, clear the refresh cron, drop the expiry option. Idempotent — safe to call when maintenance mode is already inactive. Reports `was_active` in the response.
   * Both live under the existing `acrossai-abilities-manager-site-health` category alongside `acrossai/get-maintenance-mode-status` (Feature 063 read). No Elementor / plugin dependency — works on every WP install.
 
-* **Feature 067 COMPLETE — 87 Elementor abilities merged to main without a version bump.** Plugin version remains 0.0.25. These abilities are available on the `main` branch; no plugin release / tag / distribution package has been cut. Feature 067's 88-ability target reached (2 released in 0.0.25 + 87 unreleased on main). Design-audit ability logic is skeletal (`Base_Audit_Ability` skeleton returning empty findings) — real audit heuristics to be filled in follow-up work.
+* **Feature 067 COMPLETE — 87 additional Elementor abilities ship in this release.** Combined with the 2 foundation abilities from 0.0.25, the full 88 planned abilities are now available under the `acrossai/elementor-*` namespace. Design-audit ability logic is skeletal (`Base_Audit_Ability` skeleton returning empty findings) — real audit heuristics to be filled in follow-up work.
 
 **Batch 10 — full-document replacement (closes the parity gap):**
   * `acrossai/elementor-update-data` — overwrite the entire `_elementor_data` tree for a post with a caller-supplied element array; optional `page_settings` merge; `force_replace=true` required when the new payload is materially smaller than the existing document. Returns `element_count` + cache scope report.
@@ -244,7 +246,7 @@ All 8 Pro abilities gated on **both** `class_exists( '\Elementor\Plugin' )` **an
 
 **Test coverage:** 43 (b2) + 40 (b3) + 53 (b4) + 64 (b5) + 53 (b6) + 33 (b7) + 45 (b8) + 8 (b9 manifest) = 339 new source-inspection tests across 58 test files. Full suite: 975 tests, 1991 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
 
-**Feature 067 ability surface complete: 88 of 88 abilities.** Foundation + 2 released in 0.0.25 + 86 unreleased on main. Every planned ability shipped. Design-audit analysis logic is skeletal (returns empty findings + recommendations); the audit surface is registered and composable via `Design_Audit_Runner`, real heuristics to be filled in follow-up work.
+**Feature 067 ability surface complete: 88 of 88 abilities.** Foundation + 2 shipped in 0.0.25 + 86 in this release. Every planned ability shipped. Design-audit analysis logic is skeletal (returns empty findings + recommendations); the audit surface is registered and composable via `Design_Audit_Runner`, real heuristics to be filled in follow-up work.
 
 = 0.0.25 =
 * **New — Feature 067 Elementor Ability Suite (interim ship: foundation + 2 abilities).** First release of the planned 88-ability Elementor integration. This interim release delivers the full foundational infrastructure plus two highest-value abilities. Follow-up features (068+) will incrementally add the remaining 86 abilities.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.25
+ * Version:           0.0.26
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0


### PR DESCRIPTION
## Summary

Cuts release 0.0.26. Bumps `Version:` header + `Stable tag:` from 0.0.25 → 0.0.26, and renames the accumulated `= Unreleased =` changelog section to `= 0.0.26 - 2026-08-14 =`.

## What's in 0.0.26 (89 new abilities)

**Feature 067 completion — 87 new Elementor abilities** (PRs #116 through #125, previously merged unreleased):
- 15 document / element operations (get-data, update-data, patch-data, clone-data, get-element, find-elements, update-element, merge-element-settings, delete-element, remove-element, move-element, duplicate-element, reorder-elements, add-container, add-widget)
- 5 widget shortcuts (add-heading, add-text-editor, add-image, add-button, add-post-tabs)
- 5 discovery/guidance (get-official-widget-catalog, get-official-pattern-guidance, get-theme-context, get-style-guide, evaluate-render-context)
- 11 template CRUD (list/get/create/update/delete/restore/duplicate/empty-trash/export/import + find-template-for-pattern)
- 7 kits & site settings (list-kits, get/update-kit-settings, set-active-kit, list-global-widgets, list-experiments, update-experiment)
- 2 theme builder (get/update-theme-builder-conditions)
- 4 system/maintenance (clear-cache, replace-urls, get/update-maintenance-mode)
- 29 design audits (evaluate-design, suggest-design-fixes, score-distinctiveness, extract-design-tokens, 14 audit-* checks, 7 destructive subtree ops, 4 copy/sync helpers — logic skeletal, real heuristics deferred)
- 8 Elementor Pro–gated (5 custom-code CRUD + 3 form-submissions)
- 1 full-document overwrite (update-data — closed the 87→88 parity gap in PR #125)

Combined with the 2 foundation abilities from 0.0.25, this hits the **full 88 planned Feature 067 abilities**.

**Native site maintenance-mode toggle — 2 new abilities** (PR #126):
- `acrossai/set-site-maintenance-mode` — writes `ABSPATH/.maintenance` (same file WP core writes during plugin/theme/core updates); a 5-minute wp-cron keeps the timestamp fresh for the requested `duration_minutes` (default 60, max 1440). Requires `confirm=true` — blocks wp-admin as well as the frontend.
- `acrossai/unset-site-maintenance-mode` — deletes the marker, clears the cron, drops the expiry option. Idempotent, reports `was_active`.

## Diff scope

Only 2 files change in this PR:
- `acrossai-abilities-manager.php` — `Version: 0.0.25` → `0.0.26`
- `README.txt` — `Stable tag: 0.0.25` → `0.0.26`; `= Unreleased (NOT YET RELEASED) =` → `= 0.0.26 - 2026-08-14 =`; a couple of stale-in-context wording fixes inside the section (e.g. "unreleased on main" → "in this release").

The actual ability code is already on `main` from PRs #116–#126.

## Test plan

- [x] `composer test` — 1006 tests, 2040 assertions, all pass (same 6 pre-existing warnings)
- [ ] After merge: tag `v0.0.26`, push tag, `gh release create v0.0.26` with the batch summary
- [ ] Post-release smoke: install the plugin at 0.0.26 on a WP install with Elementor active — verify `acrossai/elementor-get-data`, `acrossai/set-site-maintenance-mode`, `acrossai/unset-site-maintenance-mode` all appear in `wp ability list`
- [ ] Post-release smoke: same install with Elementor deactivated — verify Elementor category is silently absent, maintenance-mode abilities still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)