### PR TITLE
fix(elementor): render Elementor abilities under own tab, not Core

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -137,6 +137,9 @@ No data is sent to any external server without an explicit administrator action.
 
 == Changelog ==
 
+= Unreleased (NOT YET RELEASED) =
+* **UI fix — Elementor abilities now render under their own "Elementor" tab in the Ability Library, not "Core".** Every Elementor ability (all 88 under `acrossai/elementor-*`) had its meta `tab_group` set to `'core'`, causing the group to appear in the Core tab with only a sub-heading identifying it as Elementor. Flipped every declaration to `tab_group => 'elementor'` (63 files including `Base_Audit_Ability`, which drives the 25 audit subclasses via inheritance). The Ability Library UI auto-derives tab names from distinct `tab_group` values, so a new "Elementor" tab appears without any frontend/asset rebuild.
+
 = 0.0.26 - 2026-08-14 =
 **Release rollup — 89 abilities total: 87 unreleased Elementor abilities (Feature 067 completion) + 2 native site maintenance-mode abilities.** Plugin version bumped 0.0.25 → 0.0.26. Elementor abilities gate on `class_exists('\Elementor\Plugin')` (with 8 additionally gated on Elementor Pro); site maintenance-mode toggle has no plugin dependency.
 

--- a/includes/Abilities/Elementor/Add_Button.php
+++ b/includes/Abilities/Elementor/Add_Button.php
@@ -69,7 +69,7 @@ class Add_Button extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Add_Container.php
+++ b/includes/Abilities/Elementor/Add_Container.php
@@ -62,7 +62,7 @@ class Add_Container extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Add_Heading.php
+++ b/includes/Abilities/Elementor/Add_Heading.php
@@ -63,7 +63,7 @@ class Add_Heading extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Add_Image.php
+++ b/includes/Abilities/Elementor/Add_Image.php
@@ -76,7 +76,7 @@ class Add_Image extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Add_Post_Tabs.php
+++ b/includes/Abilities/Elementor/Add_Post_Tabs.php
@@ -73,7 +73,7 @@ class Add_Post_Tabs extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Add_Text_Editor.php
+++ b/includes/Abilities/Elementor/Add_Text_Editor.php
@@ -60,7 +60,7 @@ class Add_Text_Editor extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Add_Widget.php
+++ b/includes/Abilities/Elementor/Add_Widget.php
@@ -68,7 +68,7 @@ class Add_Widget extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Base_Audit_Ability.php
+++ b/includes/Abilities/Elementor/Base_Audit_Ability.php
@@ -92,7 +92,7 @@ abstract class Base_Audit_Ability extends Ability_Definition { // phpcs:ignore
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => $readonly, 'destructive' => $destructive, 'idempotent' => $readonly ),

--- a/includes/Abilities/Elementor/Clear_Cache.php
+++ b/includes/Abilities/Elementor/Clear_Cache.php
@@ -60,7 +60,7 @@ class Clear_Cache extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Clone_Data.php
+++ b/includes/Abilities/Elementor/Clone_Data.php
@@ -62,7 +62,7 @@ class Clone_Data extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Create_Custom_Code.php
+++ b/includes/Abilities/Elementor/Create_Custom_Code.php
@@ -50,7 +50,7 @@ class Create_Custom_Code extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),

--- a/includes/Abilities/Elementor/Create_Page.php
+++ b/includes/Abilities/Elementor/Create_Page.php
@@ -61,7 +61,7 @@ class Create_Page extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Create_Template.php
+++ b/includes/Abilities/Elementor/Create_Template.php
@@ -55,7 +55,7 @@ class Create_Template extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),

--- a/includes/Abilities/Elementor/Delete_Custom_Code.php
+++ b/includes/Abilities/Elementor/Delete_Custom_Code.php
@@ -48,7 +48,7 @@ class Delete_Custom_Code extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),

--- a/includes/Abilities/Elementor/Delete_Element.php
+++ b/includes/Abilities/Elementor/Delete_Element.php
@@ -61,7 +61,7 @@ class Delete_Element extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Delete_Form_Submission.php
+++ b/includes/Abilities/Elementor/Delete_Form_Submission.php
@@ -51,7 +51,7 @@ class Delete_Form_Submission extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),

--- a/includes/Abilities/Elementor/Delete_Template.php
+++ b/includes/Abilities/Elementor/Delete_Template.php
@@ -49,7 +49,7 @@ class Delete_Template extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),

--- a/includes/Abilities/Elementor/Duplicate_Element.php
+++ b/includes/Abilities/Elementor/Duplicate_Element.php
@@ -60,7 +60,7 @@ class Duplicate_Element extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Duplicate_Template.php
+++ b/includes/Abilities/Elementor/Duplicate_Template.php
@@ -49,7 +49,7 @@ class Duplicate_Template extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),

--- a/includes/Abilities/Elementor/Empty_Trash.php
+++ b/includes/Abilities/Elementor/Empty_Trash.php
@@ -47,7 +47,7 @@ class Empty_Trash extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),

--- a/includes/Abilities/Elementor/Evaluate_Design.php
+++ b/includes/Abilities/Elementor/Evaluate_Design.php
@@ -58,7 +58,7 @@ class Evaluate_Design extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Evaluate_Render_Context.php
+++ b/includes/Abilities/Elementor/Evaluate_Render_Context.php
@@ -61,7 +61,7 @@ class Evaluate_Render_Context extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Export_Template.php
+++ b/includes/Abilities/Elementor/Export_Template.php
@@ -48,7 +48,7 @@ class Export_Template extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Find_Elements.php
+++ b/includes/Abilities/Elementor/Find_Elements.php
@@ -62,7 +62,7 @@ class Find_Elements extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Find_Template_For_Pattern.php
+++ b/includes/Abilities/Elementor/Find_Template_For_Pattern.php
@@ -50,7 +50,7 @@ class Find_Template_For_Pattern extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Get_Custom_Code.php
+++ b/includes/Abilities/Elementor/Get_Custom_Code.php
@@ -44,7 +44,7 @@ class Get_Custom_Code extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Get_Data.php
+++ b/includes/Abilities/Elementor/Get_Data.php
@@ -62,7 +62,7 @@ class Get_Data extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Get_Element.php
+++ b/includes/Abilities/Elementor/Get_Element.php
@@ -60,7 +60,7 @@ class Get_Element extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Get_Form_Submission.php
+++ b/includes/Abilities/Elementor/Get_Form_Submission.php
@@ -47,7 +47,7 @@ class Get_Form_Submission extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Get_Kit_Settings.php
+++ b/includes/Abilities/Elementor/Get_Kit_Settings.php
@@ -45,7 +45,7 @@ class Get_Kit_Settings extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Get_Maintenance_Mode.php
+++ b/includes/Abilities/Elementor/Get_Maintenance_Mode.php
@@ -58,7 +58,7 @@ class Get_Maintenance_Mode extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Get_Official_Pattern_Guidance.php
+++ b/includes/Abilities/Elementor/Get_Official_Pattern_Guidance.php
@@ -58,7 +58,7 @@ class Get_Official_Pattern_Guidance extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Get_Official_Widget_Catalog.php
+++ b/includes/Abilities/Elementor/Get_Official_Widget_Catalog.php
@@ -58,7 +58,7 @@ class Get_Official_Widget_Catalog extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Get_Style_Guide.php
+++ b/includes/Abilities/Elementor/Get_Style_Guide.php
@@ -63,7 +63,7 @@ class Get_Style_Guide extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Get_Template.php
+++ b/includes/Abilities/Elementor/Get_Template.php
@@ -48,7 +48,7 @@ class Get_Template extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Get_Theme_Builder_Conditions.php
+++ b/includes/Abilities/Elementor/Get_Theme_Builder_Conditions.php
@@ -57,7 +57,7 @@ class Get_Theme_Builder_Conditions extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Get_Theme_Context.php
+++ b/includes/Abilities/Elementor/Get_Theme_Context.php
@@ -57,7 +57,7 @@ class Get_Theme_Context extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Get_Widget_Controls.php
+++ b/includes/Abilities/Elementor/Get_Widget_Controls.php
@@ -74,7 +74,7 @@ class Get_Widget_Controls extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Import_Template.php
+++ b/includes/Abilities/Elementor/Import_Template.php
@@ -49,7 +49,7 @@ class Import_Template extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => false ),

--- a/includes/Abilities/Elementor/List_Custom_Code.php
+++ b/includes/Abilities/Elementor/List_Custom_Code.php
@@ -56,7 +56,7 @@ class List_Custom_Code extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/List_Experiments.php
+++ b/includes/Abilities/Elementor/List_Experiments.php
@@ -43,7 +43,7 @@ class List_Experiments extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/List_Form_Submissions.php
+++ b/includes/Abilities/Elementor/List_Form_Submissions.php
@@ -58,7 +58,7 @@ class List_Form_Submissions extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/List_Global_Widgets.php
+++ b/includes/Abilities/Elementor/List_Global_Widgets.php
@@ -45,7 +45,7 @@ class List_Global_Widgets extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/List_Kits.php
+++ b/includes/Abilities/Elementor/List_Kits.php
@@ -41,7 +41,7 @@ class List_Kits extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/List_Templates.php
+++ b/includes/Abilities/Elementor/List_Templates.php
@@ -51,7 +51,7 @@ class List_Templates extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Merge_Element_Settings.php
+++ b/includes/Abilities/Elementor/Merge_Element_Settings.php
@@ -66,7 +66,7 @@ class Merge_Element_Settings extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Move_Element.php
+++ b/includes/Abilities/Elementor/Move_Element.php
@@ -67,7 +67,7 @@ class Move_Element extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Patch_Data.php
+++ b/includes/Abilities/Elementor/Patch_Data.php
@@ -60,7 +60,7 @@ class Patch_Data extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Remove_Element.php
+++ b/includes/Abilities/Elementor/Remove_Element.php
@@ -61,7 +61,7 @@ class Remove_Element extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Reorder_Elements.php
+++ b/includes/Abilities/Elementor/Reorder_Elements.php
@@ -61,7 +61,7 @@ class Reorder_Elements extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Replace_Urls.php
+++ b/includes/Abilities/Elementor/Replace_Urls.php
@@ -63,7 +63,7 @@ class Replace_Urls extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Restore_Template.php
+++ b/includes/Abilities/Elementor/Restore_Template.php
@@ -47,7 +47,7 @@ class Restore_Template extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Set_Active_Kit.php
+++ b/includes/Abilities/Elementor/Set_Active_Kit.php
@@ -46,7 +46,7 @@ class Set_Active_Kit extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Suggest_Design_Fixes.php
+++ b/includes/Abilities/Elementor/Suggest_Design_Fixes.php
@@ -29,7 +29,7 @@ class Suggest_Design_Fixes extends Ability_Definition {
 				'permission_callback' => static function (): bool { return current_user_can( 'manage_options' ) && current_user_can( 'edit_posts' ); },
 				'input_schema'        => array( 'type' => 'object', 'properties' => array( 'post_id' => array( 'type' => 'integer', 'minimum' => 1 ), 'subtree_id' => array( 'type' => 'string' ) ), 'required' => array( 'post_id' ), 'additionalProperties' => false ),
 				'output_schema' => array( 'type' => 'object', 'properties' => array( 'success' => array( 'type' => 'boolean' ), 'post_id' => array( 'type' => 'integer' ), 'recommendations' => array( 'type' => 'array' ), 'source_policy' => array( 'type' => 'string' ), 'message' => array( 'type' => 'string' ), 'error_code' => array( 'type' => 'string' ) ), 'required' => array( 'success' ), 'additionalProperties' => false ),
-				'meta' => array( 'acrossai' => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ), 'show_in_rest' => true, 'mcp' => array( 'public' => false, 'type' => 'tool' ), 'annotations' => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ) ),
+				'meta' => array( 'acrossai' => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ), 'show_in_rest' => true, 'mcp' => array( 'public' => false, 'type' => 'tool' ), 'annotations' => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ) ),
 			),
 		);
 	}

--- a/includes/Abilities/Elementor/Update_Custom_Code.php
+++ b/includes/Abilities/Elementor/Update_Custom_Code.php
@@ -51,7 +51,7 @@ class Update_Custom_Code extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Update_Data.php
+++ b/includes/Abilities/Elementor/Update_Data.php
@@ -68,7 +68,7 @@ class Update_Data extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Update_Element.php
+++ b/includes/Abilities/Elementor/Update_Element.php
@@ -63,7 +63,7 @@ class Update_Element extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Update_Experiment.php
+++ b/includes/Abilities/Elementor/Update_Experiment.php
@@ -52,7 +52,7 @@ class Update_Experiment extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Update_Kit_Settings.php
+++ b/includes/Abilities/Elementor/Update_Kit_Settings.php
@@ -49,7 +49,7 @@ class Update_Kit_Settings extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),

--- a/includes/Abilities/Elementor/Update_Maintenance_Mode.php
+++ b/includes/Abilities/Elementor/Update_Maintenance_Mode.php
@@ -61,7 +61,7 @@ class Update_Maintenance_Mode extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Update_Page_Settings.php
+++ b/includes/Abilities/Elementor/Update_Page_Settings.php
@@ -59,7 +59,7 @@ class Update_Page_Settings extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),

--- a/includes/Abilities/Elementor/Update_Template.php
+++ b/includes/Abilities/Elementor/Update_Template.php
@@ -51,7 +51,7 @@ class Update_Template extends Ability_Definition {
 					'additionalProperties' => false,
 				),
 				'meta' => array(
-					'acrossai'     => array( 'tab_group' => 'core', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
+					'acrossai'     => array( 'tab_group' => 'elementor', 'sub_group' => 'elementor', 'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ) ),
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => false, 'type' => 'tool' ),
 					'annotations'  => array( 'readonly' => false, 'destructive' => true, 'idempotent' => false ),

--- a/includes/Abilities/Elementor/Update_Theme_Builder_Conditions.php
+++ b/includes/Abilities/Elementor/Update_Theme_Builder_Conditions.php
@@ -69,7 +69,7 @@ class Update_Theme_Builder_Conditions extends Ability_Definition {
 				),
 				'meta'                => array(
 					'acrossai'     => array(
-						'tab_group'       => 'core',
+						'tab_group'       => 'elementor',
 						'sub_group'       => 'elementor',
 						'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
 					),


### PR DESCRIPTION
## Bug

The Ability Library UI rendered every Elementor ability inside the **Core** tab with only a sub-heading labeling the group as \"Elementor\" — visible in the settings screen as the \"Core\" pill next to \"Acrossai Abilities Manager Elementor\":

> **Acrossai Abilities Manager Elementor** \`Core\`

## Root cause

Every one of the 88 Elementor abilities had its meta declared like this:

\`\`\`php
'acrossai' => array(
    'tab_group'       => 'core',        // <— wrong
    'sub_group'       => 'elementor',
    'sub_group_label' => __( 'Elementor', 'acrossai-abilities-manager' ),
),
\`\`\`

The Ability Library UI (\`src/js/ability-library/components/LibraryPage.js\`) auto-derives tab names from the set of distinct \`tab_group\` values across all abilities and applies \`titleCaseTabLabel(value)\` for the display label. So all 88 abilities landed in the \"Core\" tab, with \"Elementor\" only appearing as an inner sub-group header.

## Fix

Flipped every declaration to \`tab_group => 'elementor'\`. Covers **63 files**:
- 62 ability classes that declare tab_group inline
- 1 \`Base_Audit_Ability\` — its \`ability()\` method drives the 25 audit subclasses via inheritance

Because the JS auto-derives tabs from whatever \`tab_group\` values arrive at runtime, and \`titleCaseTabLabel('elementor')\` yields \`'Elementor'\`, a new **Elementor** tab appears automatically. **No JS, CSS, or asset rebuild needed** — this is a pure PHP data change.

## No version bump

Per standing directive — changelog appended to a new \`= Unreleased (NOT YET RELEASED) =\` section above the just-released \`0.0.26\` entry. Plugin \`Version:\` header stays at \`0.0.26\`.

## Test plan

- [x] \`composer test\` — 1006 tests, 2040 assertions, all pass
- [x] \`grep -rE \"'tab_group' *=> *'core'\" includes/Abilities/Elementor/\` returns 0
- [x] \`grep -rE \"'tab_group' *=> *'elementor'\" includes/Abilities/Elementor/\` returns 63
- [ ] Load /wp-admin ability library on a site with Elementor active — verify a new **Elementor** tab appears at the top of the tab strip alongside Core / Database / etc.
- [ ] Toggle to the Elementor tab — verify all 88 abilities render and the \"Acrossai Abilities Manager Elementor\" group no longer shows the \"Core\" pill
- [ ] On a site without Elementor active — verify the Elementor tab is absent (since no abilities register)

🤖 Generated with [Claude Code](https://claude.com/claude-code)