### PR TITLE
Release 0.0.27 — Ability Integrations rename + Elementor tab UI fix

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.26
+Stable tag: 0.0.27
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -137,7 +137,9 @@ No data is sent to any external server without an explicit administrator action.
 
 == Changelog ==
 
-= Unreleased (NOT YET RELEASED) =
+= 0.0.27 - 2026-08-14 =
+**Patch release — UI polish + admin-surface rename following the 0.0.26 Feature 067 rollup.** No new abilities; both entries below are UX-affecting changes to the admin surface. Plugin version bumped 0.0.26 → 0.0.27.
+
 * **Rename — "Ability Library" admin page is now "Ability Integrations".** The submenu label ("Library" → "Integrations"), page title ("Ability Library" → "Ability Integrations"), main heading, and URL slug (`page=acrossai-abilities-library` → `page=acrossai-abilities-integrations`) all updated. Bookmarks / external links to the old slug will 404 in wp-admin — update saved links to the new URL. Internal class names, hook names, REST endpoint namespace (`/wp-json/acrossai-abilities-library/v1/`), and the DOM mount id are unchanged (deliberately scoped rename — extending to the REST namespace would break external MCP callers).
 * **UI fix — Elementor abilities now render under their own "Elementor" tab in the Ability Integrations screen, not "Core".** Every Elementor ability (all 88 under `acrossai/elementor-*`) had its meta `tab_group` set to `'core'`, causing the group to appear in the Core tab with only a sub-heading identifying it as Elementor. Flipped every declaration to `tab_group => 'elementor'` (63 files including `Base_Audit_Ability`, which drives the 25 audit subclasses via inheritance). The Ability Integrations UI auto-derives tab names from distinct `tab_group` values, so a new "Elementor" tab appears without any frontend/asset rebuild.
 

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.26
+ * Version:           0.0.27
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0


### PR DESCRIPTION
## Summary

Cuts release 0.0.27. Bumps `Version:` header + `Stable tag:` from 0.0.26 → 0.0.27, and renames the accumulated `= Unreleased =` changelog section to `= 0.0.27 - 2026-08-14 =`.

## What's in 0.0.27

**No new abilities.** Two admin-surface UX changes that landed on `main` after the 0.0.26 release:

- **Rename: "Ability Library" admin page → "Ability Integrations"** (PR #129, `db00a64`)
  - Submenu label, page title, h1 heading, URL slug all updated.
  - Old URL `?page=acrossai-abilities-library` → new URL `?page=acrossai-abilities-integrations`.
  - **Breaking**: bookmarks / external links to the old slug will 404 in wp-admin. Documented explicitly in the changelog.
  - **Deliberately not renamed**: REST endpoint namespace `/wp-json/acrossai-abilities-library/v1/`, PHP class names, hook names, DOM mount id (`acrossai-library-root`). External MCP callers keep working.

- **Fix: Elementor abilities render under their own "Elementor" tab** (PR #128, `a87a4ac`)
  - Every one of the 88 Elementor abilities had its meta `tab_group` declared as `'core'`, so the entire suite silently landed under the Core tab with only a sub-heading identifying it as Elementor.
  - Fixed by flipping 63 files (62 direct declarations + `Base_Audit_Ability` covering 25 audit subclasses via inheritance) to `tab_group => 'elementor'`.
  - The Ability Integrations UI auto-derives its tab strip from the set of distinct `tab_group` values — no PHP-side tab registration exists — so the new "Elementor" tab appears automatically.

## Diff scope

Only 2 files change in this PR:
- `acrossai-abilities-manager.php` — `Version: 0.0.26` → `0.0.27`
- `README.txt` — `Stable tag: 0.0.26` → `0.0.27`; `= Unreleased (NOT YET RELEASED) =` → `= 0.0.27 - 2026-08-14 =`; header paragraph added summarizing the patch scope.

The actual functional changes are already on `main` from PRs #128 + #129.

## Also on main since 0.0.26 (documentation, not shipped-code)

- `specs/068-rename-library-to-integrations/` — retroactive spec-kit artifacts (spec.md, plan.md, tasks.md, checklists/requirements.md) for the rename.
- `docs/memory/` — 2 durable-memory entries captured via `/speckit-memory-md-capture`:
  - `BUG-WP-MAINTENANCE-MARKER-STALE-AT-10MIN` (BUGS.md)
  - `PATTERN-ABILITY-LIBRARY-TAB-AUTO-DERIVE` (ARCHITECTURE.md)

Neither ships in the plugin ZIP — they're repo-only documentation.

## Test plan

- [x] `composer test` — 1006 tests, 2040 assertions, all pass (same 6 pre-existing warnings)
- [ ] After merge: tag `v0.0.27`, push tag, `gh release create v0.0.27` with the change summary
- [ ] Post-release smoke: install 0.0.27 on a fresh WP install; verify the admin sidebar item reads **Integrations**, URL is `?page=acrossai-abilities-integrations`, page h1 reads **Ability Integrations**
- [ ] Post-release smoke: on a site with Elementor active, verify a distinct **Elementor** tab appears in the Ability Integrations tab strip alongside Core / Database / etc.
- [ ] Post-release smoke: visit the old URL `?page=acrossai-abilities-library` — verify WP core's "you do not have sufficient permissions" screen (expected 404-style failure, not silent misdirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)