### PR TITLE
Release 0.0.29 — Feature 065 safety envelope + payload enrichment

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.28
+Stable tag: 0.0.29
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -136,6 +136,21 @@ Several admin-only actions can cause external services to receive data — all a
 No data is sent to any external server without an explicit administrator action.
 
 == Changelog ==
+
+= 0.0.29 - 2026-08-18 =
+**Feature 065 — safety envelope + payload enrichment across 9 existing abilities.** No new abilities. Plugin version bumped 0.0.28 → 0.0.29. Two changes are breaking for programmatic callers: `acrossai/delete-media` and `acrossai/delete-file` now require an explicit `confirm: true`; `acrossai/update-post` silently strips protected meta keys (reported back in `dropped_meta_keys`). Every guardrail-triggered refusal now returns `success: false` + a machine-readable `blocked_reason` + a human `message`, with no state mutation on the refusal path.
+
+* **`acrossai/deactivate-plugin` — protected-plugin guard.** Refuses to deactivate `acrossai-mcp-manager`, `acrossai-abilities-manager`, or `acrossai-pro` — the three plugins that host either the ability surface itself or the MCP transport the AI is using to reach the site. Match runs against the *resolved* plugin file path, so slug / partial-name / file-path variants that fuzzy-resolve to a protected plugin are all refused (`blocked_reason: "protected_plugin"`).
+* **`acrossai/delete-media` — explicit confirmation + trash-aware.** Requires `confirm: true` (refuses with `blocked_reason: "confirmation_required"` otherwise). Honours the `MEDIA_TRASH` constant — trashes when defined truthy and `force` is absent; permanent-deletes otherwise. Response now carries `deleted: "deleted" | "trashed"`.
+* **`acrossai/delete-file` — confirmation + protected-write + backup + opcache invalidation.** Requires `confirm: true`. Refuses on `wp-config.php` / `.htaccess` at ABSPATH (`blocked_reason: "protected_write"`). Writes a `.bak.<timestamp>` copy next to the target before the delete and returns the backup path in `backup`. Calls `opcache_invalidate()` on the deleted path when OPcache is loaded.
+* **`acrossai/read-file` — protected-read + size cap + binary detection.** Refuses on `wp-config.php` / `.htaccess` at ABSPATH (`blocked_reason: "protected_read"`) — this closes the highest-value accidental disclosure path (database password + eight auth constants). Refuses files over 5 MB without loading them into memory (`blocked_reason: "file_too_large"`; response reports observed size + cap). Non-UTF-8 payloads return `{ binary: true, size, path, message }` instead of raw bytes.
+* **`acrossai/list-media` — alt-text search.** `search` now matches against `_wp_attachment_image_alt` postmeta in addition to WP_Query's default `s` fields (title / caption / description). Results are de-duplicated by attachment ID, so an image matched by both title and alt-text appears once.
+* **`acrossai/update-media` — updated-fields report.** Response now carries an `updated` array naming each field that was actually written (subset of `title` / `caption` / `description` / `alt_text`), in the order fields were processed. Empty array when no update fields were passed.
+* **`acrossai/update-post` — writability + protected-meta + publish / author gates.** Refuses on post types that are neither `public: true` nor `show_in_rest: true` (matches WP-REST writability). Filters caller-supplied `meta` to drop `_`-prefixed keys and any key that `is_protected_meta()` reports; the `acrossai_allowed_protected_meta` filter opts specific keys back in. Dropped keys are reported in the response as `dropped_meta_keys`. Refuses `status: "publish"` (or any status entering a public state) unless the caller holds `publish_posts` for the post type. Refuses `author: <different_user_id>` unless the caller holds `edit_others_posts`.
+* **`acrossai/get-post` — hydrated payload.** Response now includes `terms` (object keyed by taxonomy, each entry `{ term_id, name, slug }`), `meta` (non-protected keys only — same allow-list filter as `update-post`), `featured_image` (`{ id, url, alt }` or `null`), `permalink`, `edit_link`, and `author: { id, name }`. Callers no longer need 4–5 follow-up hydration calls per post.
+* **`acrossai/delete-post` — suggested-redirect hint.** When the target was `publish` and `force: true` is passed, the response includes `suggested_redirect: { from: <permalink>, to: <parent-or-archive-or-root-url> }`. Omitted for drafts and for trash operations (URL may return on restore).
+
+**Test coverage.** `Test_Feature_065_Safety_And_Payload` — 23 source-inspection tests covering all 23 FRs. Full suite green; PHPCS (WPCS strict) and PHPStan level 8 clean.
 
 = 0.0.28 - 2026-08-17 =
 **Feature 069 — Rank Math ability suite: 61 new abilities under a new "Rank Math" tab.** Gated on Rank Math SEO being active; absent entirely without it. Plugin version bumped 0.0.27 → 0.0.28.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.28
+ * Version:           0.0.29
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.28' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.29' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Version bump **0.0.28 → 0.0.29**. No new abilities — this release ships Feature 065 (PR #114, already merged to `main`), which modified nine existing abilities to add safety guardrails and enrich payloads.

## What ships

* **Protected-plugin guard** on `acrossai/deactivate-plugin` — refuses the three AcrossAI plugins (`acrossai-mcp-manager`, `acrossai-abilities-manager`, `acrossai-pro`), matched against the resolved plugin file path so fuzzy inputs cannot bypass it.
* **Confirmation gate** on `acrossai/delete-media` and `acrossai/delete-file` (both now require `confirm: true`).
* **Protected-read / protected-write** on `acrossai/read-file` and `acrossai/delete-file` — `wp-config.php` and `.htaccess` at ABSPATH are refused. `read-file` also caps at 5 MB and returns a distinct binary shape for non-UTF-8 payloads.
* **Payload enrichment** on `acrossai/get-post` (terms / meta / featured_image / permalink / edit_link / author), `acrossai/list-media` (alt-text search), `acrossai/update-media` (`updated` field report), and `acrossai/delete-post` (`suggested_redirect` for public deletions).
* **Correctness gates** on `acrossai/update-post` — refuses non-writable post types, strips protected meta keys (reported in `dropped_meta_keys`), enforces `publish_posts` for public status transitions and `edit_others_posts` for author changes.
* Every guardrail-triggered refusal returns `success: false` + machine-readable `blocked_reason` + human `message`, with no state mutation on the refusal path.

## Breaking changes (documented)

* `acrossai/delete-media` and `acrossai/delete-file` now **require** `confirm: true`. Callers that omit it will get `blocked_reason: "confirmation_required"` instead of the previous silent execution.
* `acrossai/update-post` **silently strips** `_`-prefixed and `is_protected_meta()` keys from caller-supplied `meta`. Stripped keys are reported in `dropped_meta_keys` so callers can adapt. The `acrossai_allowed_protected_meta` filter opts specific keys back in.

## Verification

* Full test suite green including `Test_Feature_065_Safety_And_Payload` (23 source-inspection tests, one per FR).
* PHPCS (WPCS strict) + PHPStan level 8 clean.
* Ships alongside the 0.0.28 Rank Math suite which is already on `main`.

## Test plan

- [ ] Merge and confirm CI green across PHP 8.1 / 8.2 / 8.3 / 8.4 / 8.5.
- [ ] Smoke: `acrossai/delete-file` without `confirm` returns `blocked_reason: "confirmation_required"`; with `confirm: true` writes a `.bak.<timestamp>` next to the target and returns the backup path.
- [ ] Smoke: `acrossai/read-file` on `wp-config.php` returns `blocked_reason: "protected_read"` and does not disclose contents.
- [ ] Smoke: `acrossai/deactivate-plugin` targeting `acrossai-mcp-manager` refuses without mutating state.
- [ ] Smoke: `acrossai/get-post` on a post with a featured image + taxonomies returns hydrated `featured_image`, `terms`, `permalink`, and `author` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)