### PR TITLE
refactor(elementor): move Elementor abilities to elementor/ namespace

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -181,7 +181,7 @@ Coverage baseline was deliberately narrow: Rank Math core ships **13** abilities
 **Patch release — UI polish + admin-surface rename following the 0.0.26 Feature 067 rollup.** No new abilities; both entries below are UX-affecting changes to the admin surface. Plugin version bumped 0.0.26 → 0.0.27.
 
 * **Rename — "Ability Library" admin page is now "Ability Integrations".** The submenu label ("Library" → "Integrations"), page title ("Ability Library" → "Ability Integrations"), main heading, and URL slug (`page=acrossai-abilities-library` → `page=acrossai-abilities-integrations`) all updated. Bookmarks / external links to the old slug will 404 in wp-admin — update saved links to the new URL. Internal class names, hook names, REST endpoint namespace (`/wp-json/acrossai-abilities-library/v1/`), and the DOM mount id are unchanged (deliberately scoped rename — extending to the REST namespace would break external MCP callers).
-* **UI fix — Elementor abilities now render under their own "Elementor" tab in the Ability Integrations screen, not "Core".** Every Elementor ability (all 88 under `acrossai/elementor-*`) had its meta `tab_group` set to `'core'`, causing the group to appear in the Core tab with only a sub-heading identifying it as Elementor. Flipped every declaration to `tab_group => 'elementor'` (63 files including `Base_Audit_Ability`, which drives the 25 audit subclasses via inheritance). The Ability Integrations UI auto-derives tab names from distinct `tab_group` values, so a new "Elementor" tab appears without any frontend/asset rebuild.
+* **UI fix — Elementor abilities now render under their own "Elementor" tab in the Ability Integrations screen, not "Core".** Every Elementor ability (all 88 under `elementor/*`) had its meta `tab_group` set to `'core'`, causing the group to appear in the Core tab with only a sub-heading identifying it as Elementor. Flipped every declaration to `tab_group => 'elementor'` (63 files including `Base_Audit_Ability`, which drives the 25 audit subclasses via inheritance). The Ability Integrations UI auto-derives tab names from distinct `tab_group` values, so a new "Elementor" tab appears without any frontend/asset rebuild.
 
 = 0.0.26 - 2026-08-14 =
 **Release rollup — 89 abilities total: 87 unreleased Elementor abilities (Feature 067 completion) + 2 native site maintenance-mode abilities.** Plugin version bumped 0.0.25 → 0.0.26. Elementor abilities gate on `class_exists('\Elementor\Plugin')` (with 8 additionally gated on Elementor Pro); site maintenance-mode toggle has no plugin dependency.
@@ -191,18 +191,18 @@ Coverage baseline was deliberately narrow: Rank Math core ships **13** abilities
   * `acrossai/unset-site-maintenance-mode` — deactivate: delete the marker, clear the refresh cron, drop the expiry option. Idempotent — safe to call when maintenance mode is already inactive. Reports `was_active` in the response.
   * Both live under the existing `acrossai-abilities-manager-site-health` category alongside `acrossai/get-maintenance-mode-status` (Feature 063 read). No Elementor / plugin dependency — works on every WP install.
 
-* **Feature 067 COMPLETE — 87 additional Elementor abilities ship in this release.** Combined with the 2 foundation abilities from 0.0.25, the full 88 planned abilities are now available under the `acrossai/elementor-*` namespace. Design-audit ability logic is skeletal (`Base_Audit_Ability` skeleton returning empty findings) — real audit heuristics to be filled in follow-up work.
+* **Feature 067 COMPLETE — 87 additional Elementor abilities ship in this release.** Combined with the 2 foundation abilities from 0.0.25, the full 88 planned abilities are now available under the `elementor/*` namespace. Design-audit ability logic is skeletal (`Base_Audit_Ability` skeleton returning empty findings) — real audit heuristics to be filled in follow-up work.
 
 **Batch 10 — full-document replacement (closes the parity gap):**
-  * `acrossai/elementor-update-data` — overwrite the entire `_elementor_data` tree for a post with a caller-supplied element array; optional `page_settings` merge; `force_replace=true` required when the new payload is materially smaller than the existing document. Returns `element_count` + cache scope report.
+  * `elementor/update-data` — overwrite the entire `_elementor_data` tree for a post with a caller-supplied element array; optional `page_settings` merge; `force_replace=true` required when the new payload is materially smaller than the existing document. Returns `element_count` + cache scope report.
 
 **Batch 9 — 29 design-audit abilities (this commit):**
 
 Aggregators + scorers (4):
-  * `acrossai/elementor-evaluate-design` — aggregate report from every registered design audit (score + findings + recommendations).
-  * `acrossai/elementor-suggest-design-fixes` — turn aggregated findings into concrete fix recommendations.
-  * `acrossai/elementor-score-distinctiveness` — neutral distinctiveness score for structural repetition.
-  * `acrossai/elementor-extract-design-tokens` — extract recurring colors / typography / spacing / dimensional tokens.
+  * `elementor/evaluate-design` — aggregate report from every registered design audit (score + findings + recommendations).
+  * `elementor/suggest-design-fixes` — turn aggregated findings into concrete fix recommendations.
+  * `elementor/score-distinctiveness` — neutral distinctiveness score for structural repetition.
+  * `elementor/extract-design-tokens` — extract recurring colors / typography / spacing / dimensional tokens.
 
 Individual audits (14):
   * Column: `audit-column-alignment-rhythm`, `audit-column-balance`, `audit-column-dominance`, `audit-column-necessity`, `audit-column-patterns`
@@ -218,77 +218,77 @@ Copy / sync / convert helpers — destructive (4):
 New utility class `includes/Abilities/Elementor/Base_Audit_Ability.php` provides the shared skeleton for 27 of the 29 audit abilities — subclasses supply `audit_slug`, `audit_label`, `audit_description`, and `analyze()`. `Evaluate_Design` and `Suggest_Design_Fixes` are self-contained aggregators.
 
 **Batch 8 — 8 Elementor Pro-gated abilities:**
-  * `acrossai/elementor-list-custom-code` — list Custom Code snippets from `elementor_snippet` CPT; optional location filter.
-  * `acrossai/elementor-get-custom-code` — read one snippet including its code body.
-  * `acrossai/elementor-create-custom-code` — create snippet with title, code, location (head / body_start / body_end / footer), priority, status.
-  * `acrossai/elementor-update-custom-code` — update snippet fields.
-  * `acrossai/elementor-delete-custom-code` — trash (default) or permanently delete with `force=true`.
-  * `acrossai/elementor-list-form-submissions` — list Form widget submissions from the `e_submissions` table; optional `form_id` filter + `include_values` flag. Graceful degradation when the Pro submissions table is missing.
-  * `acrossai/elementor-get-form-submission` — read one submission by ID; optional field values.
-  * `acrossai/elementor-delete-form-submission` — permanently delete submission + its `e_submissions_values` rows; requires `confirm=true`.
+  * `elementor/list-custom-code` — list Custom Code snippets from `elementor_snippet` CPT; optional location filter.
+  * `elementor/get-custom-code` — read one snippet including its code body.
+  * `elementor/create-custom-code` — create snippet with title, code, location (head / body_start / body_end / footer), priority, status.
+  * `elementor/update-custom-code` — update snippet fields.
+  * `elementor/delete-custom-code` — trash (default) or permanently delete with `force=true`.
+  * `elementor/list-form-submissions` — list Form widget submissions from the `e_submissions` table; optional `form_id` filter + `include_values` flag. Graceful degradation when the Pro submissions table is missing.
+  * `elementor/get-form-submission` — read one submission by ID; optional field values.
+  * `elementor/delete-form-submission` — permanently delete submission + its `e_submissions_values` rows; requires `confirm=true`.
 
 All 8 Pro abilities gated on **both** `class_exists( '\Elementor\Plugin' )` **and** `class_exists( '\ElementorPro\Plugin' ) || defined( 'ELEMENTOR_PRO_VERSION' )` — silently absent on sites without Elementor Pro. Runtime deactivation returns `error_code: elementor_pro_missing`.
 
 **Batch 7 — 7 kits & site-settings abilities:**
-  * `acrossai/elementor-list-kits` — list all Elementor kits; marks active kit.
-  * `acrossai/elementor-get-kit-settings` — read kit settings (defaults to active kit).
-  * `acrossai/elementor-update-kit-settings` — merge new settings; `force_replace` for full overwrite; site-wide cache invalidation.
-  * `acrossai/elementor-set-active-kit` — switch site-wide active kit; invalidates cache.
-  * `acrossai/elementor-list-global-widgets` — list global (reusable) widgets from elementor_library CPT.
-  * `acrossai/elementor-list-experiments` — list feature flags with current + default state.
-  * `acrossai/elementor-update-experiment` — toggle experiment state (active | inactive | default).
+  * `elementor/list-kits` — list all Elementor kits; marks active kit.
+  * `elementor/get-kit-settings` — read kit settings (defaults to active kit).
+  * `elementor/update-kit-settings` — merge new settings; `force_replace` for full overwrite; site-wide cache invalidation.
+  * `elementor/set-active-kit` — switch site-wide active kit; invalidates cache.
+  * `elementor/list-global-widgets` — list global (reusable) widgets from elementor_library CPT.
+  * `elementor/list-experiments` — list feature flags with current + default state.
+  * `elementor/update-experiment` — toggle experiment state (active | inactive | default).
 
 **Batch 6 — 11 template abilities:**
-  * `acrossai/elementor-list-templates` — list saved templates with filters on `template_type` + `status` + pagination.
-  * `acrossai/elementor-get-template` — return one template's metadata + conditions + optional `_elementor_data`.
-  * `acrossai/elementor-create-template` — create a new template of type page / section / popup / header / footer / single / archive; sets taxonomy term + Elementor meta.
-  * `acrossai/elementor-update-template` — update title / page_settings / full data with `force_replace` guard.
-  * `acrossai/elementor-delete-template` — trash (default) or permanently delete with `force=true`.
-  * `acrossai/elementor-restore-template` — restore a trashed template.
-  * `acrossai/elementor-duplicate-template` — clone template preserving type + conditions + sub_type; regenerates element IDs.
-  * `acrossai/elementor-empty-trash` — permanently delete every trashed template; requires `confirm=true`.
-  * `acrossai/elementor-export-template` — export template as JSON-encodable object (title, template_type, sub_type, page_settings, content, conditions).
-  * `acrossai/elementor-import-template` — import from JSON export; regenerates element IDs; optional `overwrite_id` to replace an existing template.
-  * `acrossai/elementor-find-template-for-pattern` — rank saved templates by keyword match (title + tax term + widget-types in content); returns top N with scores.
+  * `elementor/list-templates` — list saved templates with filters on `template_type` + `status` + pagination.
+  * `elementor/get-template` — return one template's metadata + conditions + optional `_elementor_data`.
+  * `elementor/create-template` — create a new template of type page / section / popup / header / footer / single / archive; sets taxonomy term + Elementor meta.
+  * `elementor/update-template` — update title / page_settings / full data with `force_replace` guard.
+  * `elementor/delete-template` — trash (default) or permanently delete with `force=true`.
+  * `elementor/restore-template` — restore a trashed template.
+  * `elementor/duplicate-template` — clone template preserving type + conditions + sub_type; regenerates element IDs.
+  * `elementor/empty-trash` — permanently delete every trashed template; requires `confirm=true`.
+  * `elementor/export-template` — export template as JSON-encodable object (title, template_type, sub_type, page_settings, content, conditions).
+  * `elementor/import-template` — import from JSON export; regenerates element IDs; optional `overwrite_id` to replace an existing template.
+  * `elementor/find-template-for-pattern` — rank saved templates by keyword match (title + tax term + widget-types in content); returns top N with scores.
 
 **Batch 5 — 11 site-management abilities:**
-  * `acrossai/elementor-clear-cache` — clear Elementor cache at post / site / all scope; optional `regenerate_css=true` for a specific post.
-  * `acrossai/elementor-replace-urls` — bulk find/replace URLs across every Elementor document on the site with `dry_run=true` default preview.
-  * `acrossai/elementor-get-maintenance-mode` — read current maintenance mode settings (mode, template, exclude rules).
-  * `acrossai/elementor-update-maintenance-mode` — enable/disable maintenance mode with mode selection (maintenance | coming_soon).
-  * `acrossai/elementor-get-theme-builder-conditions` — read display conditions attached to an Elementor template.
-  * `acrossai/elementor-update-theme-builder-conditions` — replace display conditions; pass empty array to clear. Invalidates Elementor's condition cache.
-  * `acrossai/elementor-get-official-widget-catalog` — canonical widget catalog (Basic / Pro / Theme / WooCommerce) with 12-hour transient.
-  * `acrossai/elementor-get-official-pattern-guidance` — pattern & layout guidance (widgets / patterns / layouts topics) grounded in Elementor documentation.
-  * `acrossai/elementor-get-theme-context` — active theme + Elementor version + active kit + viewport settings snapshot.
-  * `acrossai/elementor-get-style-guide` — style-guide summary from active kit (colors, typography, buttons, forms, layout, custom CSS).
-  * `acrossai/elementor-evaluate-render-context` — inspect frontend template + canvas type + edit-mode flag for a post.
+  * `elementor/clear-cache` — clear Elementor cache at post / site / all scope; optional `regenerate_css=true` for a specific post.
+  * `elementor/replace-urls` — bulk find/replace URLs across every Elementor document on the site with `dry_run=true` default preview.
+  * `elementor/get-maintenance-mode` — read current maintenance mode settings (mode, template, exclude rules).
+  * `elementor/update-maintenance-mode` — enable/disable maintenance mode with mode selection (maintenance | coming_soon).
+  * `elementor/get-theme-builder-conditions` — read display conditions attached to an Elementor template.
+  * `elementor/update-theme-builder-conditions` — replace display conditions; pass empty array to clear. Invalidates Elementor's condition cache.
+  * `elementor/get-official-widget-catalog` — canonical widget catalog (Basic / Pro / Theme / WooCommerce) with 12-hour transient.
+  * `elementor/get-official-pattern-guidance` — pattern & layout guidance (widgets / patterns / layouts topics) grounded in Elementor documentation.
+  * `elementor/get-theme-context` — active theme + Elementor version + active kit + viewport settings snapshot.
+  * `elementor/get-style-guide` — style-guide summary from active kit (colors, typography, buttons, forms, layout, custom CSS).
+  * `elementor/evaluate-render-context` — inspect frontend template + canvas type + edit-mode flag for a post.
 
 **Batch 4 — 9 page-composition abilities:**
-  * `acrossai/elementor-create-page` — insert a new post/page pre-configured for Elementor (sets `_elementor_edit_mode`, `_elementor_template_type`, `_elementor_version`; seeds empty `_elementor_data`). Returns edit URL.
-  * `acrossai/elementor-update-page-settings` — merge new page-level settings into `_elementor_page_settings`. `force_replace` guard on materially-smaller payloads.
-  * `acrossai/elementor-patch-data` — find/replace text within the raw Elementor JSON string; updates every widget containing the match in one pass.
-  * `acrossai/elementor-clone-data` — copy the full Elementor tree from one post to another with fresh element IDs throughout. Optionally include page settings. `force_replace` guard on populated targets.
-  * `acrossai/elementor-add-heading` — widget shortcut (title, header_size h1-h6, align, title_color).
-  * `acrossai/elementor-add-text-editor` — widget shortcut (editor HTML, align).
-  * `acrossai/elementor-add-image` — widget shortcut (image ID or URL, size, align, caption, link).
-  * `acrossai/elementor-add-button` — widget shortcut (text, link, size xs-xl, align).
-  * `acrossai/elementor-add-post-tabs` — higher-order shortcut: Nested Tabs widget where each tab contains a native Posts widget (optionally filtered by taxonomy term or query args).
+  * `elementor/create-page` — insert a new post/page pre-configured for Elementor (sets `_elementor_edit_mode`, `_elementor_template_type`, `_elementor_version`; seeds empty `_elementor_data`). Returns edit URL.
+  * `elementor/update-page-settings` — merge new page-level settings into `_elementor_page_settings`. `force_replace` guard on materially-smaller payloads.
+  * `elementor/patch-data` — find/replace text within the raw Elementor JSON string; updates every widget containing the match in one pass.
+  * `elementor/clone-data` — copy the full Elementor tree from one post to another with fresh element IDs throughout. Optionally include page settings. `force_replace` guard on populated targets.
+  * `elementor/add-heading` — widget shortcut (title, header_size h1-h6, align, title_color).
+  * `elementor/add-text-editor` — widget shortcut (editor HTML, align).
+  * `elementor/add-image` — widget shortcut (image ID or URL, size, align, caption, link).
+  * `elementor/add-button` — widget shortcut (text, link, size xs-xl, align).
+  * `elementor/add-post-tabs` — higher-order shortcut: Nested Tabs widget where each tab contains a native Posts widget (optionally filtered by taxonomy term or query args).
 
 **Batch 3 — 6 element-lifecycle abilities (previously in this section):**
-  * `acrossai/elementor-merge-element-settings` — deep-merge new settings into an element by ID. Additive (no force_replace guard needed); reports `changed_keys` in the response.
-  * `acrossai/elementor-delete-element` — remove an element by ID. Guarded by `force_delete=true` for top-level or populated (with-children) elements.
-  * `acrossai/elementor-remove-element` — safer alias for `delete-element` with identical semantics.
-  * `acrossai/elementor-move-element` — atomic move to a new parent/position with descendant-guard preventing cycle-creating moves into own subtree.
-  * `acrossai/elementor-duplicate-element` — deep-clone an element (all nested children included) with fresh IDs generated throughout the cloned subtree; inserted as the next sibling.
-  * `acrossai/elementor-reorder-elements` — reorder direct children of a parent (or root); children omitted from `ordered_element_ids` retain their prior relative order and are appended after.
+  * `elementor/merge-element-settings` — deep-merge new settings into an element by ID. Additive (no force_replace guard needed); reports `changed_keys` in the response.
+  * `elementor/delete-element` — remove an element by ID. Guarded by `force_delete=true` for top-level or populated (with-children) elements.
+  * `elementor/remove-element` — safer alias for `delete-element` with identical semantics.
+  * `elementor/move-element` — atomic move to a new parent/position with descendant-guard preventing cycle-creating moves into own subtree.
+  * `elementor/duplicate-element` — deep-clone an element (all nested children included) with fresh IDs generated throughout the cloned subtree; inserted as the next sibling.
+  * `elementor/reorder-elements` — reorder direct children of a parent (or root); children omitted from `ordered_element_ids` retain their prior relative order and are appended after.
 
 **Batch 2 — 5 abilities merged earlier:**
-  * `acrossai/elementor-get-element` — read a single element by 7-char hex ID.
-  * `acrossai/elementor-find-elements` — search by `element_type` / `widget_type` / contains-text.
-  * `acrossai/elementor-update-element` — replace by ID with `force_replace` guard.
-  * `acrossai/elementor-add-container` — insert Elementor v3+ container.
-  * `acrossai/elementor-add-widget` — insert any registered widget (validated via `Widget_Controls`).
+  * `elementor/get-element` — read a single element by 7-char hex ID.
+  * `elementor/find-elements` — search by `element_type` / `widget_type` / contains-text.
+  * `elementor/update-element` — replace by ID with `force_replace` guard.
+  * `elementor/add-container` — insert Elementor v3+ container.
+  * `elementor/add-widget` — insert any registered widget (validated via `Widget_Controls`).
 
 **Test coverage:** 43 (b2) + 40 (b3) + 53 (b4) + 64 (b5) + 53 (b6) + 33 (b7) + 45 (b8) + 8 (b9 manifest) = 339 new source-inspection tests across 58 test files. Full suite: 975 tests, 1991 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
 
@@ -310,9 +310,9 @@ All 8 Pro abilities gated on **both** `class_exists( '\Elementor\Plugin' )` **an
   * Inner Pro gate: `class_exists( '\ElementorPro\Plugin' ) || defined( 'ELEMENTOR_PRO_VERSION' )` for the future Custom Code + Form Submissions abilities.
   * Split into two private methods `register_elementor_free_abilities()` + `register_elementor_pro_abilities()` — new `new Elementor\<Class>()` lines added as each ability class lands.
 
-**Two shipped abilities under `acrossai/elementor-*` namespace:**
-  * `acrossai/elementor-get-widget-controls` — schema-lookup primitive. Returns the schema-safe control summary for any registered Elementor widget on the current site (free + Pro + third-party). Enables clients to author valid add-widget / update-element payloads without hard-coded per-widget wrappers. Optional case-insensitive search filter.
-  * `acrossai/elementor-get-data` — the read primitive. Returns the parsed Elementor document tree + page settings for a post, plus recursive element count.
+**Two shipped abilities under `elementor/*` namespace:**
+  * `elementor/get-widget-controls` — schema-lookup primitive. Returns the schema-safe control summary for any registered Elementor widget on the current site (free + Pro + third-party). Enables clients to author valid add-widget / update-element payloads without hard-coded per-widget wrappers. Optional case-insensitive search filter.
+  * `elementor/get-data` — the read primitive. Returns the parsed Elementor document tree + page settings for a post, plus recursive element count.
 
 **Test coverage:** 44 new utility tests + 15 new ability tests = 59 additional PHPUnit assertions. Full suite: 636 tests, 1530 assertions, 0 failures. phpcs (WPCS strict) and phpstan (level 8) both clean.
 

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -422,7 +422,7 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		add_action( SiteHealth\Set_Site_Maintenance_Mode::CRON_HOOK, array( SiteHealth\Set_Site_Maintenance_Mode::class, 'refresh_marker' ) );
 
 		// Feature 067 — Elementor ability suite (up to 88 abilities under
-		// acrossai/elementor-*). Gated on Elementor presence; the Pro-only
+		// elementor/*). Gated on Elementor presence; the Pro-only
 		// subset (Custom Code CRUD + Form Submissions) is additionally gated
 		// on Elementor Pro. See specs/067-elementor-abilities/plan.md.
 		if ( class_exists( '\Elementor\Plugin' ) ) {

--- a/includes/Abilities/Elementor/Add_Button.php
+++ b/includes/Abilities/Elementor/Add_Button.php
@@ -24,7 +24,7 @@ class Add_Button extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-add-button',
+			'name' => 'elementor/add-button',
 			'args' => array(
 				'label'               => __( 'Add Elementor Button', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Insert an Elementor button widget with text, link, size, and alignment.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Add_Container.php
+++ b/includes/Abilities/Elementor/Add_Container.php
@@ -25,7 +25,7 @@ class Add_Container extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-add-container',
+			'name' => 'elementor/add-container',
 			'args' => array(
 				'label'               => __( 'Add Elementor Container', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Insert a new Elementor v3+ container element at root or nested inside another element. Returns the new element with its generated ID.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Add_Heading.php
+++ b/includes/Abilities/Elementor/Add_Heading.php
@@ -25,7 +25,7 @@ class Add_Heading extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-add-heading',
+			'name' => 'elementor/add-heading',
 			'args' => array(
 				'label'               => __( 'Add Elementor Heading', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Insert an Elementor heading widget with title, header size (h1-h6), alignment, and colour.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Add_Image.php
+++ b/includes/Abilities/Elementor/Add_Image.php
@@ -24,7 +24,7 @@ class Add_Image extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-add-image',
+			'name' => 'elementor/add-image',
 			'args' => array(
 				'label'               => __( 'Add Elementor Image', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Insert an Elementor image widget from an attachment ID or URL, with optional size, alignment, caption, and link.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Add_Post_Tabs.php
+++ b/includes/Abilities/Elementor/Add_Post_Tabs.php
@@ -27,7 +27,7 @@ class Add_Post_Tabs extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-add-post-tabs',
+			'name' => 'elementor/add-post-tabs',
 			'args' => array(
 				'label'               => __( 'Add Elementor Post Tabs', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Insert a Nested Tabs widget where each tab contains a native Posts widget. Each tab can filter by taxonomy term or a custom query.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Add_Text_Editor.php
+++ b/includes/Abilities/Elementor/Add_Text_Editor.php
@@ -24,7 +24,7 @@ class Add_Text_Editor extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-add-text-editor',
+			'name' => 'elementor/add-text-editor',
 			'args' => array(
 				'label'               => __( 'Add Elementor Text Editor', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Insert an Elementor text-editor widget with HTML content and alignment.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Add_Widget.php
+++ b/includes/Abilities/Elementor/Add_Widget.php
@@ -3,7 +3,7 @@
  * Feature 067 — insert an Elementor widget element.
  *
  * Validates the widget type against Elementor's live widget registry
- * before writing. Combined with acrossai/elementor-get-widget-controls
+ * before writing. Combined with elementor/get-widget-controls
  * this ability supports every registered widget without per-widget
  * wrappers.
  *
@@ -31,7 +31,7 @@ class Add_Widget extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-add-widget',
+			'name' => 'elementor/add-widget',
 			'args' => array(
 				'label'               => __( 'Add Elementor Widget', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Insert any registered Elementor widget (free, Pro, or third-party) at root or nested inside a parent element. Widget type is validated against the live registry before writing. Use get-widget-controls first to discover valid settings keys.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Base_Audit_Ability.php
+++ b/includes/Abilities/Elementor/Base_Audit_Ability.php
@@ -57,7 +57,7 @@ abstract class Base_Audit_Ability extends Ability_Definition { // phpcs:ignore
 		$readonly    = ! $this->is_destructive();
 		$destructive = $this->is_destructive();
 		return array(
-			'name' => 'acrossai/elementor-' . $this->audit_slug(),
+			'name' => 'elementor/' . $this->audit_slug(),
 			'args' => array(
 				'label'               => $this->audit_label(),
 				'description'         => $this->audit_description(),

--- a/includes/Abilities/Elementor/Clear_Cache.php
+++ b/includes/Abilities/Elementor/Clear_Cache.php
@@ -26,7 +26,7 @@ class Clear_Cache extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-clear-cache',
+			'name' => 'elementor/clear-cache',
 			'args' => array(
 				'label'               => __( 'Clear Elementor Cache', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Clear Elementor cache at post scope, site scope, or both. Optional regenerate_css=true to also invalidate the per-post CSS meta for one post.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Clone_Data.php
+++ b/includes/Abilities/Elementor/Clone_Data.php
@@ -27,7 +27,7 @@ class Clone_Data extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-clone-data',
+			'name' => 'elementor/clone-data',
 			'args' => array(
 				'label'               => __( 'Clone Elementor Document Data', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Copy the full Elementor tree from one post to another with fresh element IDs throughout. Optionally include page settings. Guarded by force_replace when the target already has content.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Create_Custom_Code.php
+++ b/includes/Abilities/Elementor/Create_Custom_Code.php
@@ -19,7 +19,7 @@ class Create_Custom_Code extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-create-custom-code',
+			'name' => 'elementor/create-custom-code',
 			'args' => array(
 				'label'               => __( 'Create Elementor Pro Custom Code', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Create a new Elementor Pro Custom Code snippet with title, code, location, priority, and status. Requires Elementor Pro.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Create_Page.php
+++ b/includes/Abilities/Elementor/Create_Page.php
@@ -26,7 +26,7 @@ class Create_Page extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-create-page',
+			'name' => 'elementor/create-page',
 			'args' => array(
 				'label'               => __( 'Create Elementor Page', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Create a new post or page with Elementor builder mode enabled. Returns the new post ID and edit URL.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Create_Template.php
+++ b/includes/Abilities/Elementor/Create_Template.php
@@ -22,7 +22,7 @@ class Create_Template extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-create-template',
+			'name' => 'elementor/create-template',
 			'args' => array(
 				'label'               => __( 'Create Elementor Template', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Create a new Elementor template. Supports type = page | section | popup | header | footer | single | archive.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Delete_Custom_Code.php
+++ b/includes/Abilities/Elementor/Delete_Custom_Code.php
@@ -19,7 +19,7 @@ class Delete_Custom_Code extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-delete-custom-code',
+			'name' => 'elementor/delete-custom-code',
 			'args' => array(
 				'label'               => __( 'Delete Elementor Pro Custom Code', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Trash (default) or permanently delete an Elementor Pro Custom Code snippet. Requires Elementor Pro.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Delete_Element.php
+++ b/includes/Abilities/Elementor/Delete_Element.php
@@ -26,7 +26,7 @@ class Delete_Element extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-delete-element',
+			'name' => 'elementor/delete-element',
 			'args' => array(
 				'label'               => __( 'Delete Elementor Element', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Remove the Elementor element at the given ID. Guarded by force_delete=true for populated or top-level elements.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Delete_Form_Submission.php
+++ b/includes/Abilities/Elementor/Delete_Form_Submission.php
@@ -23,7 +23,7 @@ class Delete_Form_Submission extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-delete-form-submission',
+			'name' => 'elementor/delete-form-submission',
 			'args' => array(
 				'label'               => __( 'Delete Elementor Pro Form Submission', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Permanently delete an Elementor Pro Form widget submission plus its associated field values. Requires confirm=true. Requires Elementor Pro.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Delete_Template.php
+++ b/includes/Abilities/Elementor/Delete_Template.php
@@ -20,7 +20,7 @@ class Delete_Template extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-delete-template',
+			'name' => 'elementor/delete-template',
 			'args' => array(
 				'label'               => __( 'Delete Elementor Template', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Move an Elementor template to trash (default) or permanently delete when force=true.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Duplicate_Element.php
+++ b/includes/Abilities/Elementor/Duplicate_Element.php
@@ -26,7 +26,7 @@ class Duplicate_Element extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-duplicate-element',
+			'name' => 'elementor/duplicate-element',
 			'args' => array(
 				'label'               => __( 'Duplicate Elementor Element', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Deep-clone an Elementor element (including all nested children) and insert the clone as the next sibling of the source. IDs are regenerated throughout the cloned subtree.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Duplicate_Template.php
+++ b/includes/Abilities/Elementor/Duplicate_Template.php
@@ -20,7 +20,7 @@ class Duplicate_Template extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-duplicate-template',
+			'name' => 'elementor/duplicate-template',
 			'args' => array(
 				'label'               => __( 'Duplicate Elementor Template', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Duplicate a saved Elementor template with fresh element IDs, preserving type + conditions + sub_type.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Empty_Trash.php
+++ b/includes/Abilities/Elementor/Empty_Trash.php
@@ -20,7 +20,7 @@ class Empty_Trash extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-empty-trash',
+			'name' => 'elementor/empty-trash',
 			'args' => array(
 				'label'               => __( 'Empty Elementor Template Trash', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Permanently delete every trashed Elementor template. Requires confirm=true.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Evaluate_Design.php
+++ b/includes/Abilities/Elementor/Evaluate_Design.php
@@ -24,7 +24,7 @@ class Evaluate_Design extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-evaluate-design',
+			'name' => 'elementor/evaluate-design',
 			'args' => array(
 				'label'               => __( 'Evaluate Elementor Design', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Aggregate report across every registered Elementor design audit — score + findings + recommendations.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Evaluate_Render_Context.php
+++ b/includes/Abilities/Elementor/Evaluate_Render_Context.php
@@ -27,7 +27,7 @@ class Evaluate_Render_Context extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-evaluate-render-context',
+			'name' => 'elementor/evaluate-render-context',
 			'args' => array(
 				'label'               => __( 'Evaluate Elementor Render Context', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Inspect the frontend wrapper and render context for a post: template file, canvas type (default / elementor_canvas / elementor_header_footer), and Elementor edit-mode flag.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Export_Template.php
+++ b/includes/Abilities/Elementor/Export_Template.php
@@ -20,7 +20,7 @@ class Export_Template extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-export-template',
+			'name' => 'elementor/export-template',
 			'args' => array(
 				'label'               => __( 'Export Elementor Template', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Export an Elementor template as a JSON-encodable object for portability across sites.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Find_Elements.php
+++ b/includes/Abilities/Elementor/Find_Elements.php
@@ -26,7 +26,7 @@ class Find_Elements extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-find-elements',
+			'name' => 'elementor/find-elements',
 			'args' => array(
 				'label'               => __( 'Find Elementor Elements', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Search Elementor elements in a post by element type, widget type, or text contained in the serialised settings. Returns matches with their parent-ID paths.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Find_Template_For_Pattern.php
+++ b/includes/Abilities/Elementor/Find_Template_For_Pattern.php
@@ -20,7 +20,7 @@ class Find_Template_For_Pattern extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-find-template-for-pattern',
+			'name' => 'elementor/find-template-for-pattern',
 			'args' => array(
 				'label'               => __( 'Find Elementor Template For Pattern', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Rank saved Elementor templates by keyword match (title / template_type / widget-types present in content). Use before raw authoring to reuse existing patterns.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Custom_Code.php
+++ b/includes/Abilities/Elementor/Get_Custom_Code.php
@@ -19,7 +19,7 @@ class Get_Custom_Code extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-custom-code',
+			'name' => 'elementor/get-custom-code',
 			'args' => array(
 				'label'               => __( 'Get Elementor Pro Custom Code', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Read a single Elementor Pro Custom Code snippet including its code body. Requires Elementor Pro.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Data.php
+++ b/includes/Abilities/Elementor/Get_Data.php
@@ -26,7 +26,7 @@ class Get_Data extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-data',
+			'name' => 'elementor/get-data',
 			'args' => array(
 				'label'               => __( 'Get Elementor Document Data', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Return the parsed Elementor document tree + page settings for a post.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Element.php
+++ b/includes/Abilities/Elementor/Get_Element.php
@@ -26,7 +26,7 @@ class Get_Element extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-element',
+			'name' => 'elementor/get-element',
 			'args' => array(
 				'label'               => __( 'Get Elementor Element', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Return the Elementor element at the given 7-character hex ID for a post, plus its parent-ID path from the root.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Form_Submission.php
+++ b/includes/Abilities/Elementor/Get_Form_Submission.php
@@ -19,7 +19,7 @@ class Get_Form_Submission extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-form-submission',
+			'name' => 'elementor/get-form-submission',
 			'args' => array(
 				'label'               => __( 'Get Elementor Pro Form Submission', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Read one Elementor Pro Form widget submission by ID; optional include_values to fetch field values. Requires Elementor Pro.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Kit_Settings.php
+++ b/includes/Abilities/Elementor/Get_Kit_Settings.php
@@ -19,7 +19,7 @@ class Get_Kit_Settings extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-kit-settings',
+			'name' => 'elementor/get-kit-settings',
 			'args' => array(
 				'label'               => __( 'Get Elementor Kit Settings', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Return the settings for an Elementor kit (defaults to active kit) — colors, typography, buttons, forms, layout, custom CSS.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Maintenance_Mode.php
+++ b/includes/Abilities/Elementor/Get_Maintenance_Mode.php
@@ -26,7 +26,7 @@ class Get_Maintenance_Mode extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-maintenance-mode',
+			'name' => 'elementor/get-maintenance-mode',
 			'args' => array(
 				'label'               => __( 'Get Elementor Maintenance Mode', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Return the current Elementor maintenance mode settings: mode, active template, exclude rules.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Official_Pattern_Guidance.php
+++ b/includes/Abilities/Elementor/Get_Official_Pattern_Guidance.php
@@ -26,7 +26,7 @@ class Get_Official_Pattern_Guidance extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-official-pattern-guidance',
+			'name' => 'elementor/get-official-pattern-guidance',
 			'args' => array(
 				'label'               => __( 'Get Elementor Pattern Guidance', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Return canonical Elementor.com pattern and layout guidance (widgets, patterns, layouts). Grounded in Elementor documentation.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Official_Widget_Catalog.php
+++ b/includes/Abilities/Elementor/Get_Official_Widget_Catalog.php
@@ -27,7 +27,7 @@ class Get_Official_Widget_Catalog extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-official-widget-catalog',
+			'name' => 'elementor/get-official-widget-catalog',
 			'args' => array(
 				'label'               => __( 'Get Elementor Official Widget Catalog', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Return the canonical Elementor widget catalog (Basic / Pro / Theme / WooCommerce). Uses a 12-hour transient over the seeded catalog.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Style_Guide.php
+++ b/includes/Abilities/Elementor/Get_Style_Guide.php
@@ -26,7 +26,7 @@ class Get_Style_Guide extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-style-guide',
+			'name' => 'elementor/get-style-guide',
 			'args' => array(
 				'label'               => __( 'Get Elementor Style Guide', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Build a style-guide summary from the active Elementor kit: global colors, typography, buttons, form defaults, layout, custom CSS.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Template.php
+++ b/includes/Abilities/Elementor/Get_Template.php
@@ -20,7 +20,7 @@ class Get_Template extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-template',
+			'name' => 'elementor/get-template',
 			'args' => array(
 				'label'               => __( 'Get Elementor Template', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Return a single Elementor template with metadata, conditions, and optional _elementor_data payload.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Theme_Builder_Conditions.php
+++ b/includes/Abilities/Elementor/Get_Theme_Builder_Conditions.php
@@ -26,7 +26,7 @@ class Get_Theme_Builder_Conditions extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-theme-builder-conditions',
+			'name' => 'elementor/get-theme-builder-conditions',
 			'args' => array(
 				'label'               => __( 'Get Theme Builder Conditions', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Return the display conditions attached to an Elementor template (Theme Builder / popup targeting).', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Theme_Context.php
+++ b/includes/Abilities/Elementor/Get_Theme_Context.php
@@ -25,7 +25,7 @@ class Get_Theme_Context extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-theme-context',
+			'name' => 'elementor/get-theme-context',
 			'args' => array(
 				'label'               => __( 'Get Elementor Theme Context', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Return the active theme, Elementor version, active kit, and viewport settings — foundation snapshot used by other design abilities.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Get_Widget_Controls.php
+++ b/includes/Abilities/Elementor/Get_Widget_Controls.php
@@ -35,7 +35,7 @@ class Get_Widget_Controls extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-get-widget-controls',
+			'name' => 'elementor/get-widget-controls',
 			'args' => array(
 				'label'               => __( 'Get Elementor Widget Controls', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Return the schema-safe summary of the native Elementor controls exposed by a widget type on the current site. Use this before authoring add-widget or update-element calls to discover valid setting keys and types.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Import_Template.php
+++ b/includes/Abilities/Elementor/Import_Template.php
@@ -20,7 +20,7 @@ class Import_Template extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-import-template',
+			'name' => 'elementor/import-template',
 			'args' => array(
 				'label'               => __( 'Import Elementor Template', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Import an Elementor template from a JSON export (as produced by export-template). Regenerates element IDs to avoid collisions.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/List_Custom_Code.php
+++ b/includes/Abilities/Elementor/List_Custom_Code.php
@@ -27,7 +27,7 @@ class List_Custom_Code extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-list-custom-code',
+			'name' => 'elementor/list-custom-code',
 			'args' => array(
 				'label'               => __( 'List Elementor Pro Custom Code', 'acrossai-abilities-manager' ),
 				'description'         => __( 'List Elementor Pro Custom Code snippets. Filter by location and status. Requires Elementor Pro.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/List_Experiments.php
+++ b/includes/Abilities/Elementor/List_Experiments.php
@@ -22,7 +22,7 @@ class List_Experiments extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-list-experiments',
+			'name' => 'elementor/list-experiments',
 			'args' => array(
 				'label'               => __( 'List Elementor Experiments', 'acrossai-abilities-manager' ),
 				'description'         => __( 'List Elementor experiment feature flags with their current state (active | inactive | default) and default state.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/List_Form_Submissions.php
+++ b/includes/Abilities/Elementor/List_Form_Submissions.php
@@ -27,7 +27,7 @@ class List_Form_Submissions extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-list-form-submissions',
+			'name' => 'elementor/list-form-submissions',
 			'args' => array(
 				'label'               => __( 'List Elementor Pro Form Submissions', 'acrossai-abilities-manager' ),
 				'description'         => __( 'List Elementor Pro Form widget submissions with optional form_id filter and include_values flag. Requires Elementor Pro.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/List_Global_Widgets.php
+++ b/includes/Abilities/Elementor/List_Global_Widgets.php
@@ -24,7 +24,7 @@ class List_Global_Widgets extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-list-global-widgets',
+			'name' => 'elementor/list-global-widgets',
 			'args' => array(
 				'label'               => __( 'List Elementor Global Widgets', 'acrossai-abilities-manager' ),
 				'description'         => __( 'List all Elementor global (reusable) widgets — elementor_library posts with template_type=widget.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/List_Kits.php
+++ b/includes/Abilities/Elementor/List_Kits.php
@@ -20,7 +20,7 @@ class List_Kits extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-list-kits',
+			'name' => 'elementor/list-kits',
 			'args' => array(
 				'label'               => __( 'List Elementor Kits', 'acrossai-abilities-manager' ),
 				'description'         => __( 'List all Elementor Kits (elementor_library posts with template_type=kit). Marks the active kit.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/List_Templates.php
+++ b/includes/Abilities/Elementor/List_Templates.php
@@ -20,7 +20,7 @@ class List_Templates extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-list-templates',
+			'name' => 'elementor/list-templates',
 			'args' => array(
 				'label'               => __( 'List Elementor Templates', 'acrossai-abilities-manager' ),
 				'description'         => __( 'List saved Elementor templates (elementor_library CPT). Filter by template_type and status.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Merge_Element_Settings.php
+++ b/includes/Abilities/Elementor/Merge_Element_Settings.php
@@ -30,7 +30,7 @@ class Merge_Element_Settings extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-merge-element-settings',
+			'name' => 'elementor/merge-element-settings',
 			'args' => array(
 				'label'               => __( 'Merge Elementor Element Settings', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Deep-merge new settings into a single Elementor element by ID. Only the supplied setting keys are changed; siblings and unchanged settings are preserved.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Move_Element.php
+++ b/includes/Abilities/Elementor/Move_Element.php
@@ -29,7 +29,7 @@ class Move_Element extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-move-element',
+			'name' => 'elementor/move-element',
 			'args' => array(
 				'label'               => __( 'Move Elementor Element', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Move an Elementor element to a new parent and sibling position. Atomic: source and destination are updated together. Refuses moves whose destination lies inside the source subtree.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Patch_Data.php
+++ b/includes/Abilities/Elementor/Patch_Data.php
@@ -26,7 +26,7 @@ class Patch_Data extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-patch-data',
+			'name' => 'elementor/patch-data',
 			'args' => array(
 				'label'               => __( 'Patch Elementor Document Data', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Find and replace text within an Elementor document\'s serialised JSON. Operates on the raw string so it can update text in any control (headings, text-editors, buttons, image alt-text, etc.) in one pass. Case-sensitive.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Remove_Element.php
+++ b/includes/Abilities/Elementor/Remove_Element.php
@@ -26,7 +26,7 @@ class Remove_Element extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-remove-element',
+			'name' => 'elementor/remove-element',
 			'args' => array(
 				'label'               => __( 'Remove Elementor Element', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Remove the Elementor element at the given ID. Semantically identical to delete-element; force_delete required for populated or top-level elements.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Reorder_Elements.php
+++ b/includes/Abilities/Elementor/Reorder_Elements.php
@@ -26,7 +26,7 @@ class Reorder_Elements extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-reorder-elements',
+			'name' => 'elementor/reorder-elements',
 			'args' => array(
 				'label'               => __( 'Reorder Elementor Elements', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Reorder the direct children of a parent (or root children when parent_id is null). Children not listed in ordered_element_ids retain their prior relative order and are appended after.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Replace_Urls.php
+++ b/includes/Abilities/Elementor/Replace_Urls.php
@@ -28,7 +28,7 @@ class Replace_Urls extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-replace-urls',
+			'name' => 'elementor/replace-urls',
 			'args' => array(
 				'label'               => __( 'Replace URLs in Elementor Documents', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Bulk-replace URLs (or any string) inside every Elementor document across the site. Useful for post-migration domain rewrites. Supports dry_run for a preview count with no writes.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Restore_Template.php
+++ b/includes/Abilities/Elementor/Restore_Template.php
@@ -20,7 +20,7 @@ class Restore_Template extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-restore-template',
+			'name' => 'elementor/restore-template',
 			'args' => array(
 				'label'               => __( 'Restore Elementor Template', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Restore a trashed Elementor template.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Set_Active_Kit.php
+++ b/includes/Abilities/Elementor/Set_Active_Kit.php
@@ -20,7 +20,7 @@ class Set_Active_Kit extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-set-active-kit',
+			'name' => 'elementor/set-active-kit',
 			'args' => array(
 				'label'               => __( 'Set Active Elementor Kit', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Switch the site-wide active Elementor kit. Invalidates Elementor CSS cache site-wide.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Suggest_Design_Fixes.php
+++ b/includes/Abilities/Elementor/Suggest_Design_Fixes.php
@@ -20,7 +20,7 @@ class Suggest_Design_Fixes extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-suggest-design-fixes',
+			'name' => 'elementor/suggest-design-fixes',
 			'args' => array(
 				'label'               => __( 'Suggest Elementor Design Fixes', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Turn aggregated design-audit findings into concrete fix recommendations.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Update_Custom_Code.php
+++ b/includes/Abilities/Elementor/Update_Custom_Code.php
@@ -19,7 +19,7 @@ class Update_Custom_Code extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-update-custom-code',
+			'name' => 'elementor/update-custom-code',
 			'args' => array(
 				'label'               => __( 'Update Elementor Pro Custom Code', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Update fields on an existing Elementor Pro Custom Code snippet. Requires Elementor Pro.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Update_Data.php
+++ b/includes/Abilities/Elementor/Update_Data.php
@@ -32,7 +32,7 @@ class Update_Data extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-update-data',
+			'name' => 'elementor/update-data',
 			'args' => array(
 				'label'               => __( 'Update Elementor Document Data', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Overwrite the full Elementor document tree for a post with a caller-supplied element array. Optional page_settings. Guarded by force_replace=true when replacing a populated document with a smaller payload.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Update_Element.php
+++ b/includes/Abilities/Elementor/Update_Element.php
@@ -27,7 +27,7 @@ class Update_Element extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-update-element',
+			'name' => 'elementor/update-element',
 			'args' => array(
 				'label'               => __( 'Update Elementor Element', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Replace the Elementor element at the given ID with a new element payload. Guarded by force_replace to prevent silent wipes.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Update_Experiment.php
+++ b/includes/Abilities/Elementor/Update_Experiment.php
@@ -22,7 +22,7 @@ class Update_Experiment extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-update-experiment',
+			'name' => 'elementor/update-experiment',
 			'args' => array(
 				'label'               => __( 'Update Elementor Experiment', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Update an Elementor experiment state (active | inactive | default). Writes to elementor_experiment_<name> option.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Update_Kit_Settings.php
+++ b/includes/Abilities/Elementor/Update_Kit_Settings.php
@@ -19,7 +19,7 @@ class Update_Kit_Settings extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-update-kit-settings',
+			'name' => 'elementor/update-kit-settings',
 			'args' => array(
 				'label'               => __( 'Update Elementor Kit Settings', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Merge new kit settings into the active kit (or specified kit_id). force_replace=true replaces the full settings object.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Update_Maintenance_Mode.php
+++ b/includes/Abilities/Elementor/Update_Maintenance_Mode.php
@@ -25,7 +25,7 @@ class Update_Maintenance_Mode extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-update-maintenance-mode',
+			'name' => 'elementor/update-maintenance-mode',
 			'args' => array(
 				'label'               => __( 'Update Elementor Maintenance Mode', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Enable or disable Elementor maintenance mode. Set mode (maintenance | coming_soon), template ID, and exclude rules.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Update_Page_Settings.php
+++ b/includes/Abilities/Elementor/Update_Page_Settings.php
@@ -26,7 +26,7 @@ class Update_Page_Settings extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-update-page-settings',
+			'name' => 'elementor/update-page-settings',
 			'args' => array(
 				'label'               => __( 'Update Elementor Page Settings', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Update the Elementor document-level page settings (layout, title, background, custom CSS). Merges new keys into existing settings; use force_replace=true to overwrite the full settings object.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Update_Template.php
+++ b/includes/Abilities/Elementor/Update_Template.php
@@ -20,7 +20,7 @@ class Update_Template extends Ability_Definition {
 
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-update-template',
+			'name' => 'elementor/update-template',
 			'args' => array(
 				'label'               => __( 'Update Elementor Template', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Update an Elementor template — change title, page_settings, or replace the full data tree. force_replace=true required for destructive full-data overwrites.', 'acrossai-abilities-manager' ),

--- a/includes/Abilities/Elementor/Update_Theme_Builder_Conditions.php
+++ b/includes/Abilities/Elementor/Update_Theme_Builder_Conditions.php
@@ -26,7 +26,7 @@ class Update_Theme_Builder_Conditions extends Ability_Definition {
 	 */
 	protected function ability(): array {
 		return array(
-			'name' => 'acrossai/elementor-update-theme-builder-conditions',
+			'name' => 'elementor/update-theme-builder-conditions',
 			'args' => array(
 				'label'               => __( 'Update Theme Builder Conditions', 'acrossai-abilities-manager' ),
 				'description'         => __( 'Replace the display conditions attached to an Elementor template. Pass an empty array to clear all conditions.', 'acrossai-abilities-manager' ),

--- a/specs/067-elementor-abilities/contracts/abilities.md
+++ b/specs/067-elementor-abilities/contracts/abilities.md
@@ -3,12 +3,12 @@
 **Feature**: 067-elementor-abilities
 **Date**: 2026-08-13
 
-Every ability under this feature registers via `wp_register_ability( 'acrossai/elementor-<slug>', [...] )`, is gated on `class_exists( '\Elementor\Plugin' )`, and returns the shared response envelope defined in [data-model.md § Response Envelope](../data-model.md#entity-response-envelope). The 8 Pro-gated abilities additionally require `class_exists( '\ElementorPro\Plugin' )`.
+Every ability under this feature registers via `wp_register_ability( 'elementor/<slug>', [...] )`, is gated on `class_exists( '\Elementor\Plugin' )`, and returns the shared response envelope defined in [data-model.md § Response Envelope](../data-model.md#entity-response-envelope). The 8 Pro-gated abilities additionally require `class_exists( '\ElementorPro\Plugin' )`.
 
 **Shared cross-cutting behaviour** (documented once here, applied by every ability):
 
 - **Category**: `acrossai-abilities-manager-elementor`
-- **Namespace**: `acrossai/elementor-<verb-noun>`
+- **Namespace**: `elementor/<verb-noun>`
 - **Capability model** (writes): `manage_options` AND `edit_posts` globally + `edit_post($post_id)` per-post
 - **Capability model** (reads scoped to a post): `manage_options` AND `edit_posts` globally + `read_post($post_id)` per-post
 - **Post-type gate** (writes): refuse `revision`, `nav_menu_item`, `custom_css`, `customize_changeset`, `oembed_cache`, `user_request`
@@ -23,100 +23,100 @@ Every ability under this feature registers via `wp_register_ability( 'acrossai/e
 
 ## Group 1 — Document / element operations (17 abilities)
 
-### 1.1 `acrossai/elementor-get-data`
+### 1.1 `elementor/get-data`
 **Type**: read
 **Input**: `{ post_id: int }`
 **Output** (success): `{ success, post_id, data: array<Element>, page_settings: object, message }`
 **Errors**: `post_not_found`, `post_type_forbidden`, `insufficient_capability`
 
-### 1.2 `acrossai/elementor-update-data`
+### 1.2 `elementor/update-data`
 **Type**: write · destructive · non-idempotent
 **Input**: `{ post_id: int, data: array<Element>, page_settings?: object, force_replace?: bool, cache_scope?: 'none'|'post'|'site' }`
 **Output**: `{ success, post_id, element_count, cache: { scope, cleared }, message }`
 **Errors**: standard + `force_replace_required` (when replacing a populated doc without the flag)
 
-### 1.3 `acrossai/elementor-patch-data`
+### 1.3 `elementor/patch-data`
 **Type**: write · destructive · non-idempotent
 **Input**: `{ post_id: int, find: string, replace: string, cache_scope?: string }`
 **Output**: `{ success, post_id, replacements: int, message }`
 **Errors**: standard
 
-### 1.4 `acrossai/elementor-clone-data`
+### 1.4 `elementor/clone-data`
 **Type**: write · destructive · non-idempotent
 **Input**: `{ source_post_id: int, target_post_id: int, include_page_settings?: bool, force_replace?: bool }`
 **Output**: `{ success, source_post_id, target_post_id, message }`
 **Errors**: standard + `force_replace_required`
 
-### 1.5 `acrossai/elementor-get-element`
+### 1.5 `elementor/get-element`
 **Type**: read
 **Input**: `{ post_id: int, element_id: string }`
 **Output**: `{ success, post_id, element: Element, path: array<string>, message }`
 **Errors**: standard + `element_not_found`
 
-### 1.6 `acrossai/elementor-find-elements`
+### 1.6 `elementor/find-elements`
 **Type**: read
 **Input**: `{ post_id: int, element_type?: 'container'|'widget'|'section'|'column', widget_type?: string, contains?: string, include_path?: bool }`
 **Output**: `{ success, post_id, elements: array<Element+path?>, count, message }`
 **Errors**: standard
 
-### 1.7 `acrossai/elementor-update-element`
+### 1.7 `elementor/update-element`
 **Type**: write · destructive · non-idempotent
 **Input**: `{ post_id: int, element_id: string, element: Element, force_replace?: bool, cache_scope?: string, allow_legacy_style_preservation?: bool }`
 **Output**: `{ success, post_id, element_id, element, message }`
 **Errors**: standard + `element_not_found` + `force_replace_required`
 
-### 1.8 `acrossai/elementor-merge-element-settings`
+### 1.8 `elementor/merge-element-settings`
 **Type**: write · idempotent (same input = same result)
 **Input**: `{ post_id: int, element_id: string, settings: object, cache_scope?: string }`
 **Output**: `{ success, post_id, element_id, element, changed_keys: array<string>, message }`
 **Errors**: standard + `element_not_found`
 
-### 1.9 `acrossai/elementor-delete-element`
+### 1.9 `elementor/delete-element`
 **Type**: write · destructive · non-idempotent
 **Input**: `{ post_id: int, element_id: string, force_delete?: bool, cache_scope?: string }`
 **Output**: `{ success, post_id, element_id, removed: Element, message }`
 **Errors**: standard + `element_not_found` + `force_delete_required`
 
-### 1.10 `acrossai/elementor-remove-element`
+### 1.10 `elementor/remove-element`
 Safer alias for `delete-element` with `force_delete` defaulting to false and mandatory when element is populated.
 
-### 1.11 `acrossai/elementor-move-element`
+### 1.11 `elementor/move-element`
 **Type**: write · non-idempotent
 **Input**: `{ post_id: int, element_id: string, new_parent_id: string|null, position: int }` (`new_parent_id=null` means root)
 **Output**: `{ success, post_id, element_id, previous_parent_id, new_parent_id, new_position, message }`
 **Errors**: standard + `element_not_found` + `descendant_destination`
 
-### 1.12 `acrossai/elementor-duplicate-element`
+### 1.12 `elementor/duplicate-element`
 **Type**: write · non-idempotent
 **Input**: `{ post_id: int, element_id: string }`
 **Output**: `{ success, post_id, source_element_id, clone_element_id, message }` (clone has fresh IDs throughout its subtree)
 **Errors**: standard + `element_not_found`
 
-### 1.13 `acrossai/elementor-reorder-elements`
+### 1.13 `elementor/reorder-elements`
 **Type**: write · non-idempotent
 **Input**: `{ post_id: int, parent_id: string|null, ordered_element_ids: array<string> }`
 **Output**: `{ success, post_id, parent_id, new_order: array<string>, message }`
 **Errors**: standard + `element_not_found`
 
-### 1.14 `acrossai/elementor-add-container`
+### 1.14 `elementor/add-container`
 **Type**: write · non-idempotent
 **Input**: `{ post_id: int, parent_id?: string|null, position?: int, settings?: object, is_inner?: bool }`
 **Output**: `{ success, post_id, element_id, element, message }`
 **Errors**: standard
 
-### 1.15 `acrossai/elementor-add-widget`
+### 1.15 `elementor/add-widget`
 **Type**: write · non-idempotent
 **Input**: `{ post_id: int, widget_type: string, parent_id?: string|null, position?: int, settings?: object }`
 **Output**: `{ success, post_id, element_id, element, message }`
 **Errors**: standard + `invalid_widget_type`
 
-### 1.16 `acrossai/elementor-update-page-settings`
+### 1.16 `elementor/update-page-settings`
 **Type**: write · destructive · non-idempotent
 **Input**: `{ post_id: int, page_settings: object, force_replace?: bool }`
 **Output**: `{ success, post_id, page_settings, message }`
 **Errors**: standard
 
-### 1.17 `acrossai/elementor-create-page`
+### 1.17 `elementor/create-page`
 **Type**: write · non-idempotent
 **Input**: `{ title: string, post_type?: 'page'|'post', status?: 'draft'|'publish', template?: string, page_settings?: object }`
 **Output**: `{ success, post_id, edit_url, message }`
@@ -128,23 +128,23 @@ Safer alias for `delete-element` with `force_delete` defaulting to false and man
 
 Thin wrappers over `add-widget` with type-specific input schemas.
 
-### 2.1 `acrossai/elementor-add-heading`
+### 2.1 `elementor/add-heading`
 **Input**: `{ post_id: int, parent_id?: string, position?: int, title: string, header_size?: 'h1'..'h6', align?: string, color?: string }`
 **Output**: `{ success, post_id, element_id, element, message }`
 
-### 2.2 `acrossai/elementor-add-text-editor`
+### 2.2 `elementor/add-text-editor`
 **Input**: `{ post_id: int, parent_id?: string, position?: int, editor: string, align?: string }`
 **Output**: same
 
-### 2.3 `acrossai/elementor-add-image`
+### 2.3 `elementor/add-image`
 **Input**: `{ post_id: int, parent_id?: string, position?: int, image: { id?: int, url?: string }, size?: string, align?: string, caption?: string, link?: object }`
 **Output**: same
 
-### 2.4 `acrossai/elementor-add-button`
+### 2.4 `elementor/add-button`
 **Input**: `{ post_id: int, parent_id?: string, position?: int, text: string, link?: object, size?: string, align?: string }`
 **Output**: same
 
-### 2.5 `acrossai/elementor-add-post-tabs`
+### 2.5 `elementor/add-post-tabs`
 **Input**: `{ post_id: int, parent_id?: string, position?: int, tabs: array<{title:string, taxonomy?:string, term_id?:int, query?:object}> }` (creates native Nested Tabs where each tab contains a Posts widget)
 **Output**: same
 
@@ -152,34 +152,34 @@ Thin wrappers over `add-widget` with type-specific input schemas.
 
 ## Group 3 — Discovery & guidance (6 abilities)
 
-### 3.1 `acrossai/elementor-get-widget-controls`
+### 3.1 `elementor/get-widget-controls`
 **Type**: read
 **Input**: `{ widget_type: string, search?: string }`
 **Output**: `{ success, widget_type, count, controls: array<Control>, message }`
 **Errors**: `elementor_missing`, `invalid_widget_type`
 
-### 3.2 `acrossai/elementor-get-official-widget-catalog`
+### 3.2 `elementor/get-official-widget-catalog`
 **Type**: read
 **Input**: `{ category?: 'basic'|'pro'|'theme'|'woocommerce' }` (optional filter)
 **Output**: `{ success, widgets: array<{name, title, category, tier}>, count, message }`
 **Note**: uses cached fetch from Elementor.com; 12-hour transient.
 
-### 3.3 `acrossai/elementor-get-official-pattern-guidance`
+### 3.3 `elementor/get-official-pattern-guidance`
 **Type**: read
 **Input**: `{ topic?: 'widgets'|'patterns'|'layouts' }` (optional)
 **Output**: `{ success, guidance: object, source_policy: string, message }`
 
-### 3.4 `acrossai/elementor-get-theme-context`
+### 3.4 `elementor/get-theme-context`
 **Type**: read
 **Input**: `{}`
 **Output**: `{ success, theme: {name, version, is_block_theme}, elementor: {version, pro_version?, container_experiment_active}, active_kit: {id, title}, viewport: object, guidance_basis: string, message }`
 
-### 3.5 `acrossai/elementor-get-style-guide`
+### 3.5 `elementor/get-style-guide`
 **Type**: read
 **Input**: `{}` or `{ kit_id?: int }`
 **Output**: `{ success, colors: array, typography: array, buttons: object, forms: object, layout: object, guidance_basis: string, message }`
 
-### 3.6 `acrossai/elementor-evaluate-render-context`
+### 3.6 `elementor/evaluate-render-context`
 **Type**: read
 **Input**: `{ post_id: int }`
 **Output**: `{ success, post_id, template: string, canvas_type: string, header_present: bool, footer_present: bool, wrapper_classes: array<string>, message }`
@@ -188,49 +188,49 @@ Thin wrappers over `add-widget` with type-specific input schemas.
 
 ## Group 4 — Templates (11 abilities)
 
-### 4.1 `acrossai/elementor-list-templates`
+### 4.1 `elementor/list-templates`
 **Input**: `{ template_type?: string, status?: 'publish'|'draft'|'trash'|'any', limit?: int, offset?: int }`
 **Output**: `{ success, templates: array<Template>, count, message }`
 
-### 4.2 `acrossai/elementor-get-template`
+### 4.2 `elementor/get-template`
 **Input**: `{ template_id: int, include_data?: bool }`
 **Output**: `{ success, template: Template, message }`
 
-### 4.3 `acrossai/elementor-create-template`
+### 4.3 `elementor/create-template`
 **Input**: `{ title: string, type: 'page'|'section'|'popup'|'header'|'footer'|'single'|'archive', status?: string, data?: array<Element>, conditions?: array<Condition>, popup_settings?: object }`
 **Output**: `{ success, template_id, edit_url, message }`
 **Errors**: standard + `invalid_template_type`
 
-### 4.4 `acrossai/elementor-update-template`
+### 4.4 `elementor/update-template`
 **Input**: `{ template_id: int, title?: string, data?: array<Element>, page_settings?: object, force_replace?: bool }`
 **Output**: `{ success, template_id, message }`
 
-### 4.5 `acrossai/elementor-delete-template`
+### 4.5 `elementor/delete-template`
 **Input**: `{ template_id: int, force?: bool }` (`force=true` → permanent delete, default trashes)
 **Output**: `{ success, template_id, action: 'trashed'|'deleted', message }`
 
-### 4.6 `acrossai/elementor-restore-template`
+### 4.6 `elementor/restore-template`
 **Input**: `{ template_id: int }`
 **Output**: `{ success, template_id, message }`
 
-### 4.7 `acrossai/elementor-duplicate-template`
+### 4.7 `elementor/duplicate-template`
 **Input**: `{ template_id: int, title?: string }`
 **Output**: `{ success, source_template_id, duplicate_template_id, message }`
 
-### 4.8 `acrossai/elementor-empty-trash`
+### 4.8 `elementor/empty-trash`
 **Input**: `{ confirm: true }`
 **Output**: `{ success, deleted_count, message }`
 **Errors**: standard + refuses without `confirm=true`
 
-### 4.9 `acrossai/elementor-export-template`
+### 4.9 `elementor/export-template`
 **Input**: `{ template_id: int }`
 **Output**: `{ success, template_id, data: object, message }` (JSON-encodable)
 
-### 4.10 `acrossai/elementor-import-template`
+### 4.10 `elementor/import-template`
 **Input**: `{ data: object, title?: string, overwrite_id?: int }`
 **Output**: `{ success, template_id, message }`
 
-### 4.11 `acrossai/elementor-find-template-for-pattern`
+### 4.11 `elementor/find-template-for-pattern`
 **Input**: `{ pattern_keywords: string, template_type?: string, limit?: int }`
 **Output**: `{ success, templates: array<{id, title, score, snippet}>, count, message }`
 
@@ -238,31 +238,31 @@ Thin wrappers over `add-widget` with type-specific input schemas.
 
 ## Group 5 — Kits & site settings (7 abilities)
 
-### 5.1 `acrossai/elementor-list-kits`
+### 5.1 `elementor/list-kits`
 **Input**: `{}`
 **Output**: `{ success, kits: array<Kit>, active_kit_id, message }`
 
-### 5.2 `acrossai/elementor-get-kit-settings`
+### 5.2 `elementor/get-kit-settings`
 **Input**: `{ kit_id?: int }` (defaults to active)
 **Output**: `{ success, kit_id, settings: object, message }`
 
-### 5.3 `acrossai/elementor-update-kit-settings`
+### 5.3 `elementor/update-kit-settings`
 **Input**: `{ kit_id?: int, settings: object, force_replace?: bool }`
 **Output**: `{ success, kit_id, changed_keys: array<string>, message }`
 
-### 5.4 `acrossai/elementor-set-active-kit`
+### 5.4 `elementor/set-active-kit`
 **Input**: `{ kit_id: int }`
 **Output**: `{ success, previous_kit_id, active_kit_id, message }`
 
-### 5.5 `acrossai/elementor-list-global-widgets`
+### 5.5 `elementor/list-global-widgets`
 **Input**: `{}`
 **Output**: `{ success, global_widgets: array, count, message }`
 
-### 5.6 `acrossai/elementor-list-experiments`
+### 5.6 `elementor/list-experiments`
 **Input**: `{}`
 **Output**: `{ success, experiments: array<{name, state, default_state, description}>, message }`
 
-### 5.7 `acrossai/elementor-update-experiment`
+### 5.7 `elementor/update-experiment`
 **Input**: `{ experiment: string, state: 'active'|'inactive'|'default' }`
 **Output**: `{ success, experiment, previous_state, new_state, message }`
 
@@ -270,11 +270,11 @@ Thin wrappers over `add-widget` with type-specific input schemas.
 
 ## Group 6 — Theme Builder (2 abilities)
 
-### 6.1 `acrossai/elementor-get-theme-builder-conditions`
+### 6.1 `elementor/get-theme-builder-conditions`
 **Input**: `{ template_id: int }`
 **Output**: `{ success, template_id, conditions: array<Condition>, message }`
 
-### 6.2 `acrossai/elementor-update-theme-builder-conditions`
+### 6.2 `elementor/update-theme-builder-conditions`
 **Input**: `{ template_id: int, conditions: array<Condition> }`
 **Output**: `{ success, template_id, conditions, message }`
 
@@ -282,19 +282,19 @@ Thin wrappers over `add-widget` with type-specific input schemas.
 
 ## Group 7 — System / maintenance (4 abilities)
 
-### 7.1 `acrossai/elementor-clear-cache`
+### 7.1 `elementor/clear-cache`
 **Input**: `{ scope?: 'post'|'site'|'all', post_id?: int, regenerate_css?: bool }`
 **Output**: `{ success, scope, cleared: bool, css_regenerated?: bool, message }`
 
-### 7.2 `acrossai/elementor-replace-urls`
+### 7.2 `elementor/replace-urls`
 **Input**: `{ from: string, to: string, dry_run?: bool, post_types?: array<string> }`
 **Output**: `{ success, replacements: int, posts_affected: int, dry_run: bool, message }`
 
-### 7.3 `acrossai/elementor-get-maintenance-mode`
+### 7.3 `elementor/get-maintenance-mode`
 **Input**: `{}`
 **Output**: `{ success, enabled: bool, mode?: 'maintenance'|'coming_soon', template_id?: int, exclude_mode?: string, message }`
 
-### 7.4 `acrossai/elementor-update-maintenance-mode`
+### 7.4 `elementor/update-maintenance-mode`
 **Input**: `{ enabled: bool, mode?: string, template_id?: int, exclude_mode?: string }`
 **Output**: `{ success, enabled, mode, template_id, message }`
 
@@ -305,28 +305,28 @@ Thin wrappers over `add-widget` with type-specific input schemas.
 All share the shape: `{ success, post_id, findings: array<Finding>, recommendations: array<Recommendation>, score?: number, source_policy: string, guidance_basis: string, message }`.
 
 **Aggregators**:
-- `acrossai/elementor-evaluate-design` — composes findings from every individual audit; returns aggregate score + issue list + recommendations
-- `acrossai/elementor-suggest-design-fixes` — turns aggregated findings into concrete fix suggestions
-- `acrossai/elementor-score-distinctiveness` — structural repetition score
-- `acrossai/elementor-extract-design-tokens` — recurring colors/typography/spacing tokens
+- `elementor/evaluate-design` — composes findings from every individual audit; returns aggregate score + issue list + recommendations
+- `elementor/suggest-design-fixes` — turns aggregated findings into concrete fix suggestions
+- `elementor/score-distinctiveness` — structural repetition score
+- `elementor/extract-design-tokens` — recurring colors/typography/spacing tokens
 
 **Individual audits** (14) — each `{ post_id: int, subtree_id?: string }` → findings/recommendations:
 `audit-column-alignment-rhythm`, `audit-column-balance`, `audit-column-dominance`, `audit-column-necessity`, `audit-column-patterns`, `audit-composition-rhythm`, `audit-emphasis-drift`, `audit-generic-component-repetition`, `audit-generic-layout-patterns`, `audit-layout-mechanism-fit`, `audit-native-widget-opportunities`, `audit-section-rivalry`, `audit-separator-discipline`, `audit-surface-overuse`
 
 **Normalise / fix / apply subtree operations** (7):
-- `acrossai/elementor-apply-text-hierarchy` — normalise heading/body/button typography in a subtree
-- `acrossai/elementor-enforce-boundary-coherence` — normalise a subtree to true full-width or coherent boxed boundaries
-- `acrossai/elementor-fix-visible-gap-rhythm` — remove hidden leading spacing that breaks visible gap rhythm
-- `acrossai/elementor-normalize-responsive-values` — fill tablet/mobile from desktop with capped spacing; inputs `{ post_id, subtree_id?, tablet_horizontal_spacing_cap?, mobile_horizontal_spacing_cap? }`
-- `acrossai/elementor-normalize-section-spacing-rhythm` — snap section padding and row gaps to a consistent rhythm
-- `acrossai/elementor-reset-negative-margins-subtree` — clamp negative margins in a subtree
-- `acrossai/elementor-zero-container-padding-subtree` — zero container padding in a subtree
+- `elementor/apply-text-hierarchy` — normalise heading/body/button typography in a subtree
+- `elementor/enforce-boundary-coherence` — normalise a subtree to true full-width or coherent boxed boundaries
+- `elementor/fix-visible-gap-rhythm` — remove hidden leading spacing that breaks visible gap rhythm
+- `elementor/normalize-responsive-values` — fill tablet/mobile from desktop with capped spacing; inputs `{ post_id, subtree_id?, tablet_horizontal_spacing_cap?, mobile_horizontal_spacing_cap? }`
+- `elementor/normalize-section-spacing-rhythm` — snap section padding and row gaps to a consistent rhythm
+- `elementor/reset-negative-margins-subtree` — clamp negative margins in a subtree
+- `elementor/zero-container-padding-subtree` — zero container padding in a subtree
 
 **Copy / sync / convert helpers** (4):
-- `acrossai/elementor-copy-lane-settings` — copy width/gap lane settings between elements
-- `acrossai/elementor-copy-row-balance` — copy row rhythm + child balance between rows
-- `acrossai/elementor-image-widget-to-background-container` — convert an image-widget container into a native background-image container
-- `acrossai/elementor-sync-component-variant` — copy design-relevant settings from one subtree to another
+- `elementor/copy-lane-settings` — copy width/gap lane settings between elements
+- `elementor/copy-row-balance` — copy row rhythm + child balance between rows
+- `elementor/image-widget-to-background-container` — convert an image-widget container into a native background-image container
+- `elementor/sync-component-variant` — copy design-relevant settings from one subtree to another
 
 All design-audit writes (apply/normalize/fix/copy/sync) go through `Document_Repository::save_data()` with `cache_scope` support and standard `force_replace` guarding.
 
@@ -334,23 +334,23 @@ All design-audit writes (apply/normalize/fix/copy/sync) go through `Document_Rep
 
 ## Group 9 — Elementor Pro Custom Code (5 abilities, Pro-gated)
 
-### 9.1 `acrossai/elementor-list-custom-code`
+### 9.1 `elementor/list-custom-code`
 **Input**: `{ location?: 'head'|'body_start'|'body_end'|'footer', status?: string }`
 **Output**: `{ success, snippets: array<Snippet>, count, message }`
 
-### 9.2 `acrossai/elementor-get-custom-code`
+### 9.2 `elementor/get-custom-code`
 **Input**: `{ snippet_id: int }`
 **Output**: `{ success, snippet: Snippet, message }`
 
-### 9.3 `acrossai/elementor-create-custom-code`
+### 9.3 `elementor/create-custom-code`
 **Input**: `{ title: string, code: string, location: string, priority?: int, status?: 'publish'|'draft' }`
 **Output**: `{ success, snippet_id, message }`
 
-### 9.4 `acrossai/elementor-update-custom-code`
+### 9.4 `elementor/update-custom-code`
 **Input**: `{ snippet_id: int, title?: string, code?: string, location?: string, priority?: int, status?: string }`
 **Output**: `{ success, snippet_id, message }`
 
-### 9.5 `acrossai/elementor-delete-custom-code`
+### 9.5 `elementor/delete-custom-code`
 **Input**: `{ snippet_id: int, force?: bool }`
 **Output**: `{ success, snippet_id, action: 'trashed'|'deleted', message }`
 
@@ -360,15 +360,15 @@ All design-audit writes (apply/normalize/fix/copy/sync) go through `Document_Rep
 
 ## Group 10 — Elementor Pro Form Submissions (3 abilities, Pro-gated)
 
-### 10.1 `acrossai/elementor-list-form-submissions`
+### 10.1 `elementor/list-form-submissions`
 **Input**: `{ form_id?: string, limit?: int, offset?: int, include_values?: bool }`
 **Output**: `{ success, submissions: array<Submission>, count, message }`
 
-### 10.2 `acrossai/elementor-get-form-submission`
+### 10.2 `elementor/get-form-submission`
 **Input**: `{ submission_id: int, include_values?: bool }`
 **Output**: `{ success, submission: Submission, message }`
 
-### 10.3 `acrossai/elementor-delete-form-submission`
+### 10.3 `elementor/delete-form-submission`
 **Input**: `{ submission_id: int, confirm: true }`
 **Output**: `{ success, submission_id, message }`
 

--- a/specs/067-elementor-abilities/quickstart.md
+++ b/specs/067-elementor-abilities/quickstart.md
@@ -25,7 +25,7 @@ Expected: 80 abilities listed (or 88 if Pro active). None if Elementor is not in
 ## Step 1 — Discover a widget's schema (Group 3)
 
 ```json
-Ability: acrossai/elementor-get-widget-controls
+Ability: elementor/get-widget-controls
 Input:   { "widget_type": "heading" }
 ```
 
@@ -36,7 +36,7 @@ Input:   { "widget_type": "heading" }
 ## Step 2 — Create an Elementor page (Group 1)
 
 ```json
-Ability: acrossai/elementor-create-page
+Ability: elementor/create-page
 Input:   { "title": "067 Demo Page", "post_type": "page", "status": "draft", "template": "elementor_canvas" }
 ```
 
@@ -47,7 +47,7 @@ Input:   { "title": "067 Demo Page", "post_type": "page", "status": "draft", "te
 ## Step 3 — Add a container (Group 1)
 
 ```json
-Ability: acrossai/elementor-add-container
+Ability: elementor/add-container
 Input:   { "post_id": POST_ID, "settings": { "content_width": "boxed", "gap": { "size": 20, "unit": "px" } } }
 ```
 
@@ -58,19 +58,19 @@ Input:   { "post_id": POST_ID, "settings": { "content_width": "boxed", "gap": { 
 ## Step 4 — Add three widgets inside the container (Group 1 + Group 2)
 
 ```json
-Ability: acrossai/elementor-add-heading
+Ability: elementor/add-heading
 Input:   { "post_id": POST_ID, "parent_id": "CONTAINER_ID", "title": "Hello Elementor", "header_size": "h1" }
 ```
 → `element_id: "b2c3d4e"` (HEADING_ID)
 
 ```json
-Ability: acrossai/elementor-add-text-editor
+Ability: elementor/add-text-editor
 Input:   { "post_id": POST_ID, "parent_id": "CONTAINER_ID", "editor": "<p>Body copy for the demo.</p>", "align": "left" }
 ```
 → `element_id: "c3d4e5f"` (TEXT_ID)
 
 ```json
-Ability: acrossai/elementor-add-button
+Ability: elementor/add-button
 Input:   { "post_id": POST_ID, "parent_id": "CONTAINER_ID", "text": "Learn more", "link": { "url": "https://example.com", "is_external": true }, "align": "center" }
 ```
 → `element_id: "d4e5f6a"` (BUTTON_ID)
@@ -82,7 +82,7 @@ Input:   { "post_id": POST_ID, "parent_id": "CONTAINER_ID", "text": "Learn more"
 ## Step 5 — Read the document back (Group 1)
 
 ```json
-Ability: acrossai/elementor-get-data
+Ability: elementor/get-data
 Input:   { "post_id": POST_ID }
 ```
 
@@ -93,7 +93,7 @@ Input:   { "post_id": POST_ID }
 ## Step 6 — Find elements by widget type (Group 1)
 
 ```json
-Ability: acrossai/elementor-find-elements
+Ability: elementor/find-elements
 Input:   { "post_id": POST_ID, "widget_type": "heading", "include_path": true }
 ```
 
@@ -104,7 +104,7 @@ Input:   { "post_id": POST_ID, "widget_type": "heading", "include_path": true }
 ## Step 7 — Merge settings into an element (Group 1)
 
 ```json
-Ability: acrossai/elementor-merge-element-settings
+Ability: elementor/merge-element-settings
 Input:   { "post_id": POST_ID, "element_id": "HEADING_ID", "settings": { "align": "center", "title_color": "#ff5722" } }
 ```
 
@@ -115,7 +115,7 @@ Input:   { "post_id": POST_ID, "element_id": "HEADING_ID", "settings": { "align"
 ## Step 8 — Update an element (Group 1, guarded)
 
 ```json
-Ability: acrossai/elementor-update-element
+Ability: elementor/update-element
 Input:   { "post_id": POST_ID, "element_id": "TEXT_ID", "element": { "widgetType": "text-editor", "settings": { "editor": "<p>Updated body copy.</p>" } } }
 ```
 
@@ -126,7 +126,7 @@ Input:   { "post_id": POST_ID, "element_id": "TEXT_ID", "element": { "widgetType
 ## Step 9 — Duplicate an element (Group 1)
 
 ```json
-Ability: acrossai/elementor-duplicate-element
+Ability: elementor/duplicate-element
 Input:   { "post_id": POST_ID, "element_id": "BUTTON_ID" }
 ```
 
@@ -137,7 +137,7 @@ Input:   { "post_id": POST_ID, "element_id": "BUTTON_ID" }
 ## Step 10 — Move an element (Group 1)
 
 ```json
-Ability: acrossai/elementor-move-element
+Ability: elementor/move-element
 Input:   { "post_id": POST_ID, "element_id": "HEADING_ID", "new_parent_id": null, "position": 0 }
 ```
 
@@ -148,14 +148,14 @@ Input:   { "post_id": POST_ID, "element_id": "HEADING_ID", "new_parent_id": null
 ## Step 11 — Reorder + Delete (Group 1)
 
 ```json
-Ability: acrossai/elementor-reorder-elements
+Ability: elementor/reorder-elements
 Input:   { "post_id": POST_ID, "parent_id": "CONTAINER_ID", "ordered_element_ids": ["BUTTON_ID", "TEXT_ID", "d4e5f6a"] }
 ```
 
 Then delete the duplicate button:
 
 ```json
-Ability: acrossai/elementor-delete-element
+Ability: elementor/delete-element
 Input:   { "post_id": POST_ID, "element_id": "d4e5f6a" }
 ```
 
@@ -168,30 +168,30 @@ Input:   { "post_id": POST_ID, "element_id": "d4e5f6a" }
 Save the current design as a template:
 
 ```json
-Ability: acrossai/elementor-create-template
+Ability: elementor/create-template
 Input:   { "title": "067 Demo Template", "type": "page", "status": "publish", "data": [/* container tree from Step 5 */] }
 ```
 
 Then list and get:
 
 ```json
-Ability: acrossai/elementor-list-templates    Input: { "template_type": "page" }
-Ability: acrossai/elementor-get-template      Input: { "template_id": TEMPLATE_ID, "include_data": true }
-Ability: acrossai/elementor-duplicate-template Input: { "template_id": TEMPLATE_ID, "title": "Copy of 067 Demo" }
+Ability: elementor/list-templates    Input: { "template_type": "page" }
+Ability: elementor/get-template      Input: { "template_id": TEMPLATE_ID, "include_data": true }
+Ability: elementor/duplicate-template Input: { "template_id": TEMPLATE_ID, "title": "Copy of 067 Demo" }
 ```
 
 Trash and restore:
 
 ```json
-Ability: acrossai/elementor-delete-template   Input: { "template_id": TEMPLATE_ID }
-Ability: acrossai/elementor-restore-template  Input: { "template_id": TEMPLATE_ID }
+Ability: elementor/delete-template   Input: { "template_id": TEMPLATE_ID }
+Ability: elementor/restore-template  Input: { "template_id": TEMPLATE_ID }
 ```
 
 Export / import round-trip:
 
 ```json
-Ability: acrossai/elementor-export-template   Input: { "template_id": TEMPLATE_ID }
-Ability: acrossai/elementor-import-template   Input: { "data": <exported_json>, "title": "Reimported 067 Demo" }
+Ability: elementor/export-template   Input: { "template_id": TEMPLATE_ID }
+Ability: elementor/import-template   Input: { "data": <exported_json>, "title": "Reimported 067 Demo" }
 ```
 
 ---
@@ -199,9 +199,9 @@ Ability: acrossai/elementor-import-template   Input: { "data": <exported_json>, 
 ## Step 13 — Kit & site settings (Group 5)
 
 ```json
-Ability: acrossai/elementor-list-kits            Input: {}
-Ability: acrossai/elementor-get-kit-settings     Input: {}
-Ability: acrossai/elementor-update-kit-settings  Input: { "settings": { "system_colors": [{"_id":"primary","title":"Primary","color":"#00695c"}, /* ... */] } }
+Ability: elementor/list-kits            Input: {}
+Ability: elementor/get-kit-settings     Input: {}
+Ability: elementor/update-kit-settings  Input: { "settings": { "system_colors": [{"_id":"primary","title":"Primary","color":"#00695c"}, /* ... */] } }
 ```
 
 **Expected**: kit reads show the new palette. Frontend renders using the new color token on next request.
@@ -211,8 +211,8 @@ Ability: acrossai/elementor-update-kit-settings  Input: { "settings": { "system_
 ## Step 14 — Theme Builder conditions (Group 6, requires template of type header/footer/single/archive)
 
 ```json
-Ability: acrossai/elementor-get-theme-builder-conditions   Input: { "template_id": HEADER_ID }
-Ability: acrossai/elementor-update-theme-builder-conditions Input: { "template_id": HEADER_ID, "conditions": [{"type":"include","name":"general"}] }
+Ability: elementor/get-theme-builder-conditions   Input: { "template_id": HEADER_ID }
+Ability: elementor/update-theme-builder-conditions Input: { "template_id": HEADER_ID, "conditions": [{"type":"include","name":"general"}] }
 ```
 
 **Expected**: subsequent reads reflect new conditions; frontend renders the template on matching pages.
@@ -222,11 +222,11 @@ Ability: acrossai/elementor-update-theme-builder-conditions Input: { "template_i
 ## Step 15 — System / cache (Group 7)
 
 ```json
-Ability: acrossai/elementor-clear-cache           Input: { "scope": "post", "post_id": POST_ID, "regenerate_css": true }
-Ability: acrossai/elementor-clear-cache           Input: { "scope": "site" }
-Ability: acrossai/elementor-replace-urls          Input: { "from": "http://old.example.com", "to": "https://new.example.com", "dry_run": true }
-Ability: acrossai/elementor-get-maintenance-mode  Input: {}
-Ability: acrossai/elementor-update-maintenance-mode Input: { "enabled": false }
+Ability: elementor/clear-cache           Input: { "scope": "post", "post_id": POST_ID, "regenerate_css": true }
+Ability: elementor/clear-cache           Input: { "scope": "site" }
+Ability: elementor/replace-urls          Input: { "from": "http://old.example.com", "to": "https://new.example.com", "dry_run": true }
+Ability: elementor/get-maintenance-mode  Input: {}
+Ability: elementor/update-maintenance-mode Input: { "enabled": false }
 ```
 
 ---
@@ -236,8 +236,8 @@ Ability: acrossai/elementor-update-maintenance-mode Input: { "enabled": false }
 Aggregate:
 
 ```json
-Ability: acrossai/elementor-evaluate-design        Input: { "post_id": POST_ID }
-Ability: acrossai/elementor-suggest-design-fixes   Input: { "post_id": POST_ID }
+Ability: elementor/evaluate-design        Input: { "post_id": POST_ID }
+Ability: elementor/suggest-design-fixes   Input: { "post_id": POST_ID }
 ```
 
 **SC-009 checkpoint**: response returns within 3 seconds on the small demo page. On a larger fixture page (100+ elements), verify still <3s.
@@ -245,9 +245,9 @@ Ability: acrossai/elementor-suggest-design-fixes   Input: { "post_id": POST_ID }
 Individual audits (spot check 2-3):
 
 ```json
-Ability: acrossai/elementor-audit-column-balance         Input: { "post_id": POST_ID }
-Ability: acrossai/elementor-audit-native-widget-opportunities Input: { "post_id": POST_ID }
-Ability: acrossai/elementor-normalize-responsive-values  Input: { "post_id": POST_ID, "tablet_horizontal_spacing_cap": 20 }
+Ability: elementor/audit-column-balance         Input: { "post_id": POST_ID }
+Ability: elementor/audit-native-widget-opportunities Input: { "post_id": POST_ID }
+Ability: elementor/normalize-responsive-values  Input: { "post_id": POST_ID, "tablet_horizontal_spacing_cap": 20 }
 ```
 
 ---
@@ -257,18 +257,18 @@ Ability: acrossai/elementor-normalize-responsive-values  Input: { "post_id": POS
 Custom Code CRUD:
 
 ```json
-Ability: acrossai/elementor-create-custom-code  Input: { "title": "GA snippet", "code": "<script>console.log('ga');</script>", "location": "head", "status": "publish" }
-Ability: acrossai/elementor-list-custom-code    Input: {}
-Ability: acrossai/elementor-update-custom-code  Input: { "snippet_id": SNIPPET_ID, "priority": 20 }
-Ability: acrossai/elementor-delete-custom-code  Input: { "snippet_id": SNIPPET_ID }
+Ability: elementor/create-custom-code  Input: { "title": "GA snippet", "code": "<script>console.log('ga');</script>", "location": "head", "status": "publish" }
+Ability: elementor/list-custom-code    Input: {}
+Ability: elementor/update-custom-code  Input: { "snippet_id": SNIPPET_ID, "priority": 20 }
+Ability: elementor/delete-custom-code  Input: { "snippet_id": SNIPPET_ID }
 ```
 
 Form submissions:
 
 ```json
-Ability: acrossai/elementor-list-form-submissions   Input: { "form_id": "contact", "limit": 25, "include_values": true }
-Ability: acrossai/elementor-get-form-submission     Input: { "submission_id": SUBMISSION_ID, "include_values": true }
-Ability: acrossai/elementor-delete-form-submission  Input: { "submission_id": SUBMISSION_ID, "confirm": true }
+Ability: elementor/list-form-submissions   Input: { "form_id": "contact", "limit": 25, "include_values": true }
+Ability: elementor/get-form-submission     Input: { "submission_id": SUBMISSION_ID, "include_values": true }
+Ability: elementor/delete-form-submission  Input: { "submission_id": SUBMISSION_ID, "confirm": true }
 ```
 
 ---
@@ -300,7 +300,7 @@ Expected: 0. Reactivate Pro → 8 Pro abilities reappear.
 
 **Mid-session deactivation**:
 
-Start a WP-CLI session, invoke `acrossai/elementor-get-widget-controls` — succeeds. Deactivate Elementor in another terminal. Invoke again — expect `success:false, error_code:elementor_missing`, no fatal error.
+Start a WP-CLI session, invoke `elementor/get-widget-controls` — succeeds. Deactivate Elementor in another terminal. Invoke again — expect `success:false, error_code:elementor_missing`, no fatal error.
 
 ---
 

--- a/specs/067-elementor-abilities/research.md
+++ b/specs/067-elementor-abilities/research.md
@@ -155,7 +155,7 @@ Cache scope defaults to `post`; `clear-cache` ability supports both `post` and `
 
 **Decision**:
 - Category slug: `acrossai-abilities-manager-elementor` (mirrors `acrossai-abilities-manager-block`, `acrossai-abilities-manager-content`).
-- Ability namespace: `acrossai/elementor-<verb>-<noun>` (e.g. `acrossai/elementor-get-widget-controls`).
+- Ability namespace: `elementor/<verb>-<noun>` (e.g. `elementor/get-widget-controls`).
 
 **Rationale**:
 - Preserves the plugin-wide `acrossai/` prefix — clients can filter all AcrossAI abilities with a single namespace check.
@@ -169,7 +169,7 @@ Cache scope defaults to `post`; `clear-cache` ability supports both `post` and `
 - **`elementor/<verb-noun>`** (source plugin convention): breaks AcrossAI's single-namespace rule. Rejected.
 - **`acrossai/<verb-noun>` + rely on category to disambiguate**: multiple existing collisions (`create-page`, etc.); brittle. Rejected.
 
-**Impact**: 88 abilities all have the `acrossai/elementor-` prefix. Clients can locate them either by slug prefix or by category.
+**Impact**: 88 abilities all have the `elementor/` prefix. Clients can locate them either by slug prefix or by category.
 
 ---
 
@@ -202,7 +202,7 @@ Cache scope defaults to `post`; `clear-cache` ability supports both `post` and `
 | R6 | Force-guard idiom | `force_replace=true` / `force_delete=true` required for populated-document destructive writes |
 | R7 | Elementor version target | 3.x+ (container era); v2 documents remain readable but authoring primitives assume v3+ |
 | R8 | Cache invalidation | `Document_Repository::invalidate_cache()` — Elementor files manager + WP post cache + `_elementor_css` meta delete |
-| R9 | Slug + category convention | Category `acrossai-abilities-manager-elementor`; abilities `acrossai/elementor-<verb-noun>` |
+| R9 | Slug + category convention | Category `acrossai-abilities-manager-elementor`; abilities `elementor/<verb-noun>` |
 | R10 | Pattern-scoring algorithm | Port source plugin's title + meta + content-signature keyword scoring |
 
 **All NEEDS CLARIFICATION resolved. Ready for Phase 1 design.**

--- a/specs/067-elementor-abilities/spec.md
+++ b/specs/067-elementor-abilities/spec.md
@@ -190,7 +190,7 @@ A client on a site with Elementor Pro installed needs to manage Elementor's Cust
 **Registration and gating**
 
 - **FR-001**: All 88 new abilities MUST live under a new category with the slug `acrossai-abilities-manager-elementor`.
-- **FR-002**: All ability slugs MUST use the prefix `acrossai/elementor-` (e.g. `acrossai/elementor-get-widget-controls`) to disambiguate from existing content abilities.
+- **FR-002**: All ability slugs MUST use the prefix `elementor/` (e.g. `elementor/get-widget-controls`) to disambiguate from existing content abilities.
 - **FR-003**: All 88 abilities MUST be gated on the presence of Elementor. When Elementor is not installed, none of the abilities register and the category is not advertised.
 - **FR-004**: 8 abilities (5 Custom Code + 3 Form Submissions) MUST additionally be gated on Elementor Pro being installed.
 - **FR-005**: The gating check MUST happen at both registration time (bootstrap) and execution time (per-ability defense-in-depth). Runtime deactivation of Elementor must not cause fatal errors.

--- a/specs/067-elementor-abilities/tasks.md
+++ b/specs/067-elementor-abilities/tasks.md
@@ -58,12 +58,12 @@ WordPress plugin single-project layout (from plan.md § Project Structure):
 
 ## Phase 3: US1 — Widget-schema discovery (P1) 🎯 MVP
 
-**Goal**: `acrossai/elementor-get-widget-controls` returns any registered widget's control schema at runtime.
+**Goal**: `elementor/get-widget-controls` returns any registered widget's control schema at runtime.
 
 **Independent Test**: On a site with Elementor, request the schema for `heading`. Verify `count > 0` and `controls` includes `title`, `header_size`, `align`, `title_color`.
 
 - [ ] T017 [P] [US1] Create `includes/Abilities/Elementor/Get_Widget_Controls.php` per contracts/abilities.md § 3.1 — extends `Ability_Definition`, category `acrossai-abilities-manager-elementor`, uses `Widget_Controls::get_type` + `summarize`
-- [ ] T018 [P] [US1] Create `tests/phpunit/abilities/Test_Elementor_Get_Widget_Controls.php` — assert registration, slug `acrossai/elementor-get-widget-controls`, category, schema shape, error branches
+- [ ] T018 [P] [US1] Create `tests/phpunit/abilities/Test_Elementor_Get_Widget_Controls.php` — assert registration, slug `elementor/get-widget-controls`, category, schema shape, error branches
 - [ ] T019 [US1] Register `Get_Widget_Controls` in bootstrap (T010's free-Elementor block)
 
 **Checkpoint**: US1 fully functional.

--- a/tests/phpunit/abilities/Test_Elementor_Add_Button.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Button.php
@@ -26,7 +26,7 @@ class Test_Elementor_Add_Button extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-add-button'", $this->src );
+		$this->assertStringContainsString( "'elementor/add-button'", $this->src );
 	}
 
 	public function test_requires_post_id_and_text(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Add_Container.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Container.php
@@ -26,7 +26,7 @@ class Test_Elementor_Add_Container extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-add-container'", $this->src );
+		$this->assertStringContainsString( "'elementor/add-container'", $this->src );
 	}
 
 	public function test_input_requires_post_id_only(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Add_Heading.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Heading.php
@@ -26,7 +26,7 @@ class Test_Elementor_Add_Heading extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-add-heading'", $this->src );
+		$this->assertStringContainsString( "'elementor/add-heading'", $this->src );
 	}
 
 	public function test_requires_post_id_and_title(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Add_Image.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Image.php
@@ -26,7 +26,7 @@ class Test_Elementor_Add_Image extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-add-image'", $this->src );
+		$this->assertStringContainsString( "'elementor/add-image'", $this->src );
 	}
 
 	public function test_requires_post_id_and_image(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Add_Post_Tabs.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Post_Tabs.php
@@ -26,7 +26,7 @@ class Test_Elementor_Add_Post_Tabs extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-add-post-tabs'", $this->src );
+		$this->assertStringContainsString( "'elementor/add-post-tabs'", $this->src );
 	}
 
 	public function test_requires_post_id_and_tabs(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Add_Text_Editor.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Text_Editor.php
@@ -26,7 +26,7 @@ class Test_Elementor_Add_Text_Editor extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-add-text-editor'", $this->src );
+		$this->assertStringContainsString( "'elementor/add-text-editor'", $this->src );
 	}
 
 	public function test_requires_post_id_and_editor(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Add_Widget.php
+++ b/tests/phpunit/abilities/Test_Elementor_Add_Widget.php
@@ -26,7 +26,7 @@ class Test_Elementor_Add_Widget extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-add-widget'", $this->src );
+		$this->assertStringContainsString( "'elementor/add-widget'", $this->src );
 	}
 
 	public function test_input_requires_post_id_and_widget_type(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Clear_Cache.php
+++ b/tests/phpunit/abilities/Test_Elementor_Clear_Cache.php
@@ -26,7 +26,7 @@ class Test_Elementor_Clear_Cache extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-clear-cache'", $this->src );
+		$this->assertStringContainsString( "'elementor/clear-cache'", $this->src );
 	}
 
 	public function test_scope_enum(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Clone_Data.php
+++ b/tests/phpunit/abilities/Test_Elementor_Clone_Data.php
@@ -26,7 +26,7 @@ class Test_Elementor_Clone_Data extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-clone-data'", $this->src );
+		$this->assertStringContainsString( "'elementor/clone-data'", $this->src );
 	}
 
 	public function test_requires_source_and_target(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Create_Custom_Code.php
+++ b/tests/phpunit/abilities/Test_Elementor_Create_Custom_Code.php
@@ -7,7 +7,7 @@ class Test_Elementor_Create_Custom_Code extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Create_Custom_Code.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-create-custom-code'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/create-custom-code'", $this->src ); }
 	public function test_requires_title_code_location(): void { $this->assertStringContainsString( "'required' => array( 'title', 'code', 'location' )", $this->src ); }
 	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
 	public function test_inserts_snippet_cpt(): void { $this->assertStringContainsString( 'List_Custom_Code::CPT', $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Create_Page.php
+++ b/tests/phpunit/abilities/Test_Elementor_Create_Page.php
@@ -26,7 +26,7 @@ class Test_Elementor_Create_Page extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-create-page'", $this->src );
+		$this->assertStringContainsString( "'elementor/create-page'", $this->src );
 	}
 
 	public function test_input_requires_title(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Create_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Create_Template.php
@@ -7,7 +7,7 @@ class Test_Elementor_Create_Template extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Create_Template.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-create-template'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/create-template'", $this->src ); }
 	public function test_type_enum_includes_common(): void { $this->assertStringContainsString( "'page', 'section', 'popup', 'header', 'footer', 'single', 'archive'", $this->src ); }
 	public function test_requires_title_and_type(): void { $this->assertStringContainsString( "'required'   => array( 'title', 'type' )", $this->src ); }
 	public function test_sets_taxonomy_term(): void { $this->assertStringContainsString( 'wp_set_object_terms(', $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Delete_Custom_Code.php
+++ b/tests/phpunit/abilities/Test_Elementor_Delete_Custom_Code.php
@@ -7,7 +7,7 @@ class Test_Elementor_Delete_Custom_Code extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Delete_Custom_Code.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-delete-custom-code'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/delete-custom-code'", $this->src ); }
 	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
 	public function test_supports_trash_and_force_delete(): void { $this->assertStringContainsString( 'wp_trash_post(', $this->src ); $this->assertStringContainsString( 'wp_delete_post( $snippet_id, true )', $this->src ); }
 	public function test_destructive(): void { $this->assertStringContainsString( "'destructive' => true", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Delete_Element.php
+++ b/tests/phpunit/abilities/Test_Elementor_Delete_Element.php
@@ -26,7 +26,7 @@ class Test_Elementor_Delete_Element extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-delete-element'", $this->src );
+		$this->assertStringContainsString( "'elementor/delete-element'", $this->src );
 	}
 
 	public function test_destructive_annotation(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Delete_Form_Submission.php
+++ b/tests/phpunit/abilities/Test_Elementor_Delete_Form_Submission.php
@@ -7,7 +7,7 @@ class Test_Elementor_Delete_Form_Submission extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Delete_Form_Submission.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-delete-form-submission'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/delete-form-submission'", $this->src ); }
 	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
 	public function test_requires_confirm(): void { $this->assertStringContainsString( "'required' => array( 'submission_id', 'confirm' )", $this->src ); }
 	public function test_force_delete_error_when_no_confirm(): void { $this->assertStringContainsString( "'force_delete_required'", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Delete_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Delete_Template.php
@@ -7,7 +7,7 @@ class Test_Elementor_Delete_Template extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Delete_Template.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-delete-template'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/delete-template'", $this->src ); }
 	public function test_uses_trash_by_default(): void { $this->assertStringContainsString( 'wp_trash_post(', $this->src ); }
 	public function test_force_permanent_delete(): void { $this->assertStringContainsString( 'wp_delete_post( $template_id, true )', $this->src ); }
 	public function test_destructive(): void { $this->assertStringContainsString( "'destructive' => true", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Design_Audits.php
+++ b/tests/phpunit/abilities/Test_Elementor_Design_Audits.php
@@ -97,7 +97,7 @@ class Test_Elementor_Design_Audits extends WP_UnitTestCase {
 		$src = (string) file_get_contents(
 			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Evaluate_Design.php'
 		);
-		$this->assertStringContainsString( "'acrossai/elementor-evaluate-design'", $src );
+		$this->assertStringContainsString( "'elementor/evaluate-design'", $src );
 		$this->assertStringContainsString( 'Design_Audit_Runner::run_all(', $src );
 	}
 
@@ -105,7 +105,7 @@ class Test_Elementor_Design_Audits extends WP_UnitTestCase {
 		$src = (string) file_get_contents(
 			dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Suggest_Design_Fixes.php'
 		);
-		$this->assertStringContainsString( "'acrossai/elementor-suggest-design-fixes'", $src );
+		$this->assertStringContainsString( "'elementor/suggest-design-fixes'", $src );
 		$this->assertStringContainsString( 'Design_Audit_Runner::run_all(', $src );
 	}
 

--- a/tests/phpunit/abilities/Test_Elementor_Duplicate_Element.php
+++ b/tests/phpunit/abilities/Test_Elementor_Duplicate_Element.php
@@ -26,7 +26,7 @@ class Test_Elementor_Duplicate_Element extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-duplicate-element'", $this->src );
+		$this->assertStringContainsString( "'elementor/duplicate-element'", $this->src );
 	}
 
 	public function test_reassigns_subtree_ids(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Duplicate_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Duplicate_Template.php
@@ -7,7 +7,7 @@ class Test_Elementor_Duplicate_Template extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Duplicate_Template.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-duplicate-template'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/duplicate-template'", $this->src ); }
 	public function test_reassigns_element_ids(): void { $this->assertStringContainsString( 'Document_Repository::reassign_subtree_ids', $this->src ); }
 	public function test_preserves_conditions_and_sub_type(): void { $this->assertStringContainsString( "'_elementor_conditions'", $this->src ); $this->assertStringContainsString( "'_elementor_template_sub_type'", $this->src ); }
 }

--- a/tests/phpunit/abilities/Test_Elementor_Empty_Trash.php
+++ b/tests/phpunit/abilities/Test_Elementor_Empty_Trash.php
@@ -7,7 +7,7 @@ class Test_Elementor_Empty_Trash extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Empty_Trash.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-empty-trash'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/empty-trash'", $this->src ); }
 	public function test_requires_confirm(): void { $this->assertStringContainsString( "'required'   => array( 'confirm' )", $this->src ); }
 	public function test_refuses_without_confirm(): void { $this->assertStringContainsString( "'force_delete_required'", $this->src ); }
 	public function test_destructive(): void { $this->assertStringContainsString( "'destructive' => true", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Evaluate_Render_Context.php
+++ b/tests/phpunit/abilities/Test_Elementor_Evaluate_Render_Context.php
@@ -26,7 +26,7 @@ class Test_Elementor_Evaluate_Render_Context extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-evaluate-render-context'", $this->src );
+		$this->assertStringContainsString( "'elementor/evaluate-render-context'", $this->src );
 	}
 
 	public function test_requires_post_id(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Export_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Export_Template.php
@@ -7,7 +7,7 @@ class Test_Elementor_Export_Template extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Export_Template.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-export-template'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/export-template'", $this->src ); }
 	public function test_returns_content_and_page_settings(): void { $this->assertStringContainsString( "'content'", $this->src ); $this->assertStringContainsString( "'page_settings'", $this->src ); }
 	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
 }

--- a/tests/phpunit/abilities/Test_Elementor_Find_Elements.php
+++ b/tests/phpunit/abilities/Test_Elementor_Find_Elements.php
@@ -26,7 +26,7 @@ class Test_Elementor_Find_Elements extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-find-elements'", $this->src );
+		$this->assertStringContainsString( "'elementor/find-elements'", $this->src );
 	}
 
 	public function test_supports_element_type_widget_type_and_contains_filters(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Find_Template_For_Pattern.php
+++ b/tests/phpunit/abilities/Test_Elementor_Find_Template_For_Pattern.php
@@ -7,7 +7,7 @@ class Test_Elementor_Find_Template_For_Pattern extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Find_Template_For_Pattern.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-find-template-for-pattern'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/find-template-for-pattern'", $this->src ); }
 	public function test_requires_keywords(): void { $this->assertStringContainsString( "'required'   => array( 'pattern_keywords' )", $this->src ); }
 	public function test_uses_rank_by_pattern(): void { $this->assertStringContainsString( 'Template_Query::rank_by_pattern', $this->src ); }
 	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Get_Custom_Code.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Custom_Code.php
@@ -7,7 +7,7 @@ class Test_Elementor_Get_Custom_Code extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Get_Custom_Code.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-get-custom-code'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/get-custom-code'", $this->src ); }
 	public function test_requires_snippet_id(): void { $this->assertStringContainsString( "'required' => array( 'snippet_id' )", $this->src ); }
 	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
 	public function test_returns_code(): void { $this->assertStringContainsString( "'code' => (string) \$post->post_content", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Get_Data.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Data.php
@@ -26,7 +26,7 @@ class Test_Elementor_Get_Data extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug_and_category(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-get-data'", $this->src );
+		$this->assertStringContainsString( "'elementor/get-data'", $this->src );
 		$this->assertStringContainsString( "'acrossai-abilities-manager-elementor'", $this->src );
 	}
 

--- a/tests/phpunit/abilities/Test_Elementor_Get_Element.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Element.php
@@ -26,7 +26,7 @@ class Test_Elementor_Get_Element extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug_and_category(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-get-element'", $this->src );
+		$this->assertStringContainsString( "'elementor/get-element'", $this->src );
 		$this->assertStringContainsString( "'acrossai-abilities-manager-elementor'", $this->src );
 	}
 

--- a/tests/phpunit/abilities/Test_Elementor_Get_Form_Submission.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Form_Submission.php
@@ -7,7 +7,7 @@ class Test_Elementor_Get_Form_Submission extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Get_Form_Submission.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-get-form-submission'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/get-form-submission'", $this->src ); }
 	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
 	public function test_requires_submission_id(): void { $this->assertStringContainsString( "'required' => array( 'submission_id' )", $this->src ); }
 	public function test_optionally_includes_values(): void { $this->assertStringContainsString( 'List_Form_Submissions::fetch_values(', $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Get_Kit_Settings.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Kit_Settings.php
@@ -7,7 +7,7 @@ class Test_Elementor_Get_Kit_Settings extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Get_Kit_Settings.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-get-kit-settings'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/get-kit-settings'", $this->src ); }
 	public function test_defaults_to_active_kit(): void { $this->assertStringContainsString( "get_option( 'elementor_active_kit', 0 )", $this->src ); }
 	public function test_reads_page_settings_meta(): void { $this->assertStringContainsString( "get_post_meta( \$kit_id, '_elementor_page_settings', true )", $this->src ); }
 	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Get_Maintenance_Mode.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Maintenance_Mode.php
@@ -26,7 +26,7 @@ class Test_Elementor_Get_Maintenance_Mode extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-get-maintenance-mode'", $this->src );
+		$this->assertStringContainsString( "'elementor/get-maintenance-mode'", $this->src );
 	}
 
 	public function test_reads_maintenance_options(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Get_Official_Pattern_Guidance.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Official_Pattern_Guidance.php
@@ -26,7 +26,7 @@ class Test_Elementor_Get_Official_Pattern_Guidance extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-get-official-pattern-guidance'", $this->src );
+		$this->assertStringContainsString( "'elementor/get-official-pattern-guidance'", $this->src );
 	}
 
 	public function test_topic_enum(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Get_Official_Widget_Catalog.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Official_Widget_Catalog.php
@@ -26,7 +26,7 @@ class Test_Elementor_Get_Official_Widget_Catalog extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-get-official-widget-catalog'", $this->src );
+		$this->assertStringContainsString( "'elementor/get-official-widget-catalog'", $this->src );
 	}
 
 	public function test_delegates_to_guidance_catalog(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Get_Style_Guide.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Style_Guide.php
@@ -26,7 +26,7 @@ class Test_Elementor_Get_Style_Guide extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-get-style-guide'", $this->src );
+		$this->assertStringContainsString( "'elementor/get-style-guide'", $this->src );
 	}
 
 	public function test_defaults_to_active_kit(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Get_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Template.php
@@ -7,7 +7,7 @@ class Test_Elementor_Get_Template extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Get_Template.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-get-template'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/get-template'", $this->src ); }
 	public function test_requires_template_id(): void { $this->assertStringContainsString( "'required'   => array( 'template_id' )", $this->src ); }
 	public function test_uses_template_query_summary(): void { $this->assertStringContainsString( 'Template_Query::to_summary(', $this->src ); }
 	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Get_Theme_Builder_Conditions.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Theme_Builder_Conditions.php
@@ -26,7 +26,7 @@ class Test_Elementor_Get_Theme_Builder_Conditions extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-get-theme-builder-conditions'", $this->src );
+		$this->assertStringContainsString( "'elementor/get-theme-builder-conditions'", $this->src );
 	}
 
 	public function test_requires_template_id(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Get_Theme_Context.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Theme_Context.php
@@ -26,7 +26,7 @@ class Test_Elementor_Get_Theme_Context extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-get-theme-context'", $this->src );
+		$this->assertStringContainsString( "'elementor/get-theme-context'", $this->src );
 	}
 
 	public function test_reads_active_theme(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Get_Widget_Controls.php
+++ b/tests/phpunit/abilities/Test_Elementor_Get_Widget_Controls.php
@@ -26,7 +26,7 @@ class Test_Elementor_Get_Widget_Controls extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug_and_category(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-get-widget-controls'", $this->src );
+		$this->assertStringContainsString( "'elementor/get-widget-controls'", $this->src );
 		$this->assertStringContainsString( "'acrossai-abilities-manager-elementor'", $this->src );
 	}
 

--- a/tests/phpunit/abilities/Test_Elementor_Import_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Import_Template.php
@@ -7,7 +7,7 @@ class Test_Elementor_Import_Template extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Import_Template.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-import-template'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/import-template'", $this->src ); }
 	public function test_requires_data(): void { $this->assertStringContainsString( "'required'   => array( 'data' )", $this->src ); }
 	public function test_regenerates_element_ids(): void { $this->assertStringContainsString( 'Document_Repository::reassign_subtree_ids', $this->src ); }
 	public function test_supports_overwrite_id(): void { $this->assertStringContainsString( '$overwrite_id', $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_List_Custom_Code.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Custom_Code.php
@@ -7,7 +7,7 @@ class Test_Elementor_List_Custom_Code extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Custom_Code.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-custom-code'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/list-custom-code'", $this->src ); }
 	public function test_uses_elementor_snippet_cpt(): void { $this->assertStringContainsString( "public const CPT = 'elementor_snippet'", $this->src ); }
 	public function test_pro_gate(): void { $this->assertStringContainsString( 'Document_Repository::assert_elementor_pro_available()', $this->src ); }
 	public function test_location_enum(): void { $this->assertStringContainsString( "'head', 'body_start', 'body_end', 'footer'", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_List_Experiments.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Experiments.php
@@ -7,7 +7,7 @@ class Test_Elementor_List_Experiments extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Experiments.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-experiments'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/list-experiments'", $this->src ); }
 	public function test_uses_experiments_manager(): void { $this->assertStringContainsString( '$instance->experiments->get_features()', $this->src ); }
 	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
 }

--- a/tests/phpunit/abilities/Test_Elementor_List_Form_Submissions.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Form_Submissions.php
@@ -7,7 +7,7 @@ class Test_Elementor_List_Form_Submissions extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Form_Submissions.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-form-submissions'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/list-form-submissions'", $this->src ); }
 	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
 	public function test_uses_e_submissions_table(): void { $this->assertStringContainsString( "public const TABLE = 'e_submissions'", $this->src ); }
 	public function test_graceful_degradation_when_table_missing(): void { $this->assertStringContainsString( "'Elementor Pro submissions storage not available.'", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_List_Global_Widgets.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Global_Widgets.php
@@ -7,7 +7,7 @@ class Test_Elementor_List_Global_Widgets extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Global_Widgets.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-global-widgets'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/list-global-widgets'", $this->src ); }
 	public function test_queries_widget_template_type(): void { $this->assertStringContainsString( "'template_type' => 'widget'", $this->src ); }
 	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
 }

--- a/tests/phpunit/abilities/Test_Elementor_List_Kits.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Kits.php
@@ -7,7 +7,7 @@ class Test_Elementor_List_Kits extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Kits.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-kits'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/list-kits'", $this->src ); }
 	public function test_queries_kit_template_type(): void { $this->assertStringContainsString( "'template_type' => 'kit'", $this->src ); }
 	public function test_marks_active_kit(): void { $this->assertStringContainsString( "get_option( 'elementor_active_kit', 0 )", $this->src ); }
 	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_List_Templates.php
+++ b/tests/phpunit/abilities/Test_Elementor_List_Templates.php
@@ -7,7 +7,7 @@ class Test_Elementor_List_Templates extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/List_Templates.php' ); }
 	public function test_extends_ability_definition(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-list-templates'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/list-templates'", $this->src ); }
 	public function test_uses_template_query(): void { $this->assertStringContainsString( 'Template_Query::query(', $this->src ); }
 	public function test_readonly(): void { $this->assertStringContainsString( "'readonly' => true", $this->src ); }
 	public function test_gate(): void { $this->assertStringContainsString( 'assert_elementor_available()', $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Merge_Element_Settings.php
+++ b/tests/phpunit/abilities/Test_Elementor_Merge_Element_Settings.php
@@ -26,7 +26,7 @@ class Test_Elementor_Merge_Element_Settings extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-merge-element-settings'", $this->src );
+		$this->assertStringContainsString( "'elementor/merge-element-settings'", $this->src );
 	}
 
 	public function test_input_requires_post_id_element_id_and_settings(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Move_Element.php
+++ b/tests/phpunit/abilities/Test_Elementor_Move_Element.php
@@ -26,7 +26,7 @@ class Test_Elementor_Move_Element extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-move-element'", $this->src );
+		$this->assertStringContainsString( "'elementor/move-element'", $this->src );
 	}
 
 	public function test_input_requires_post_id_element_id_position(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Patch_Data.php
+++ b/tests/phpunit/abilities/Test_Elementor_Patch_Data.php
@@ -26,7 +26,7 @@ class Test_Elementor_Patch_Data extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-patch-data'", $this->src );
+		$this->assertStringContainsString( "'elementor/patch-data'", $this->src );
 	}
 
 	public function test_requires_post_id_find_replace(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Remove_Element.php
+++ b/tests/phpunit/abilities/Test_Elementor_Remove_Element.php
@@ -26,7 +26,7 @@ class Test_Elementor_Remove_Element extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-remove-element'", $this->src );
+		$this->assertStringContainsString( "'elementor/remove-element'", $this->src );
 	}
 
 	public function test_destructive_annotation(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Reorder_Elements.php
+++ b/tests/phpunit/abilities/Test_Elementor_Reorder_Elements.php
@@ -26,7 +26,7 @@ class Test_Elementor_Reorder_Elements extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-reorder-elements'", $this->src );
+		$this->assertStringContainsString( "'elementor/reorder-elements'", $this->src );
 	}
 
 	public function test_input_requires_post_id_and_ordered_ids(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Replace_Urls.php
+++ b/tests/phpunit/abilities/Test_Elementor_Replace_Urls.php
@@ -26,7 +26,7 @@ class Test_Elementor_Replace_Urls extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-replace-urls'", $this->src );
+		$this->assertStringContainsString( "'elementor/replace-urls'", $this->src );
 	}
 
 	public function test_requires_from_and_to(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Restore_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Restore_Template.php
@@ -7,7 +7,7 @@ class Test_Elementor_Restore_Template extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Restore_Template.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-restore-template'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/restore-template'", $this->src ); }
 	public function test_uses_untrash(): void { $this->assertStringContainsString( 'wp_untrash_post(', $this->src ); }
 	public function test_idempotent(): void { $this->assertStringContainsString( "'idempotent' => true", $this->src ); }
 }

--- a/tests/phpunit/abilities/Test_Elementor_Set_Active_Kit.php
+++ b/tests/phpunit/abilities/Test_Elementor_Set_Active_Kit.php
@@ -7,7 +7,7 @@ class Test_Elementor_Set_Active_Kit extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Set_Active_Kit.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-set-active-kit'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/set-active-kit'", $this->src ); }
 	public function test_requires_kit_id(): void { $this->assertStringContainsString( "'required' => array( 'kit_id' )", $this->src ); }
 	public function test_updates_active_kit_option(): void { $this->assertStringContainsString( "update_option( 'elementor_active_kit', \$kit_id )", $this->src ); }
 	public function test_returns_previous(): void { $this->assertStringContainsString( "'previous_kit_id'", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Update_Custom_Code.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Custom_Code.php
@@ -7,7 +7,7 @@ class Test_Elementor_Update_Custom_Code extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Update_Custom_Code.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-update-custom-code'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/update-custom-code'", $this->src ); }
 	public function test_pro_gate(): void { $this->assertStringContainsString( 'assert_elementor_pro_available()', $this->src ); }
 	public function test_updates_post(): void { $this->assertStringContainsString( 'wp_update_post( $post_update )', $this->src ); }
 	public function test_updates_location_and_priority_meta(): void { $this->assertStringContainsString( "'_elementor_snippet_location'", $this->src ); $this->assertStringContainsString( "'_elementor_snippet_priority'", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Update_Data.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Data.php
@@ -26,7 +26,7 @@ class Test_Elementor_Update_Data extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-update-data'", $this->src );
+		$this->assertStringContainsString( "'elementor/update-data'", $this->src );
 	}
 
 	public function test_requires_post_id_and_data(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Update_Element.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Element.php
@@ -26,7 +26,7 @@ class Test_Elementor_Update_Element extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-update-element'", $this->src );
+		$this->assertStringContainsString( "'elementor/update-element'", $this->src );
 	}
 
 	public function test_destructive_annotations(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Update_Experiment.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Experiment.php
@@ -7,7 +7,7 @@ class Test_Elementor_Update_Experiment extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Update_Experiment.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-update-experiment'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/update-experiment'", $this->src ); }
 	public function test_state_enum(): void { $this->assertStringContainsString( "'active', 'inactive', 'default'", $this->src ); }
 	public function test_writes_experiment_option(): void { $this->assertStringContainsString( "update_option( \$option_key, \$state )", $this->src ); }
 	public function test_returns_previous_state(): void { $this->assertStringContainsString( "'previous_state'", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Update_Kit_Settings.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Kit_Settings.php
@@ -7,7 +7,7 @@ class Test_Elementor_Update_Kit_Settings extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Update_Kit_Settings.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-update-kit-settings'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/update-kit-settings'", $this->src ); }
 	public function test_supports_force_replace(): void { $this->assertStringContainsString( "'force_replace'", $this->src ); }
 	public function test_invalidates_cache_site_scope(): void { $this->assertStringContainsString( "Document_Repository::invalidate_cache( \$kit_id, 'site' )", $this->src ); }
 	public function test_writes_page_settings(): void { $this->assertStringContainsString( "update_post_meta( \$kit_id, '_elementor_page_settings'", $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Update_Maintenance_Mode.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Maintenance_Mode.php
@@ -26,7 +26,7 @@ class Test_Elementor_Update_Maintenance_Mode extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-update-maintenance-mode'", $this->src );
+		$this->assertStringContainsString( "'elementor/update-maintenance-mode'", $this->src );
 	}
 
 	public function test_requires_enabled(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Update_Page_Settings.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Page_Settings.php
@@ -26,7 +26,7 @@ class Test_Elementor_Update_Page_Settings extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-update-page-settings'", $this->src );
+		$this->assertStringContainsString( "'elementor/update-page-settings'", $this->src );
 	}
 
 	public function test_requires_post_id_and_page_settings(): void {

--- a/tests/phpunit/abilities/Test_Elementor_Update_Template.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Template.php
@@ -7,7 +7,7 @@ class Test_Elementor_Update_Template extends WP_UnitTestCase {
 	private string $src = '';
 	protected function setUp(): void { parent::setUp(); $this->src = (string) file_get_contents( dirname( __DIR__, 3 ) . '/includes/Abilities/Elementor/Update_Template.php' ); }
 	public function test_extends(): void { $this->assertStringContainsString( 'extends Ability_Definition', $this->src ); }
-	public function test_slug(): void { $this->assertStringContainsString( "'acrossai/elementor-update-template'", $this->src ); }
+	public function test_slug(): void { $this->assertStringContainsString( "'elementor/update-template'", $this->src ); }
 	public function test_force_replace_guard(): void { $this->assertStringContainsString( "'force_replace_required'", $this->src ); }
 	public function test_destructive(): void { $this->assertStringContainsString( "'destructive' => true", $this->src ); }
 	public function test_uses_save_data(): void { $this->assertStringContainsString( 'Document_Repository::save_data(', $this->src ); }

--- a/tests/phpunit/abilities/Test_Elementor_Update_Theme_Builder_Conditions.php
+++ b/tests/phpunit/abilities/Test_Elementor_Update_Theme_Builder_Conditions.php
@@ -26,7 +26,7 @@ class Test_Elementor_Update_Theme_Builder_Conditions extends WP_UnitTestCase {
 	}
 
 	public function test_registers_correct_slug(): void {
-		$this->assertStringContainsString( "'acrossai/elementor-update-theme-builder-conditions'", $this->src );
+		$this->assertStringContainsString( "'elementor/update-theme-builder-conditions'", $this->src );
 	}
 
 	public function test_requires_template_id_and_conditions(): void {


### PR DESCRIPTION
## Summary
- Rename **62 Elementor abilities** (plus every dynamically-generated audit ability) from `acrossai/elementor-<action>` to `elementor/<action>`. The `acrossai/` vendor prefix carried no discovery information and `elementor-` was redundant once the namespace does the grouping.
- Base class change is one line: `Base_Audit_Ability::ability()` now builds slugs as `'elementor/' . audit_slug()`, so all subclass audits pick up the new prefix automatically.
- 131 files touched, 322 insertions / 322 deletions. Every cross-reference updated: 65 phpunit tests (source-inspection asserts the slug), spec 067 artifacts, `README.txt`, and one code comment in `AcrossAI_Core_Abilities_Bootstrap.php`.

## Why this shape
Continuation of the topic-based namespace convention piloted in the blocks PR. Elementor is a stronger case than blocks because the redundant fragment (`elementor-`) is *literally* the namespace name — collapsing is trivially safe with no ambiguity risk.

Examples:
- `acrossai/elementor-add-widget` → `elementor/add-widget`
- `acrossai/elementor-create-template` → `elementor/create-template`
- `acrossai/elementor-get-data` → `elementor/get-data`

## Out of scope
- Category taxonomy slug (`acrossai-abilities-manager-elementor`) — that's the category, not the ability slug.
- Internal PHP class namespaces — unchanged.
- Non-Elementor abilities — separate follow-up PRs per domain.

## Breaking change
Any MCP client, docs, or integration referencing `acrossai/elementor-<action>` must switch to `elementor/<action>`. Needs a release-notes callout.

## Test plan
- [x] `vendor/bin/phpunit` on all `Test_Elementor_*.php` files — **64/64 pass** on the sampled set (Create_Template through Update_Template + Template_Query).
- [ ] Full Elementor test-file run in CI.
- [ ] Verify `mcp-adapter-discover-abilities` on a running site returns the abilities under the `elementor/` prefix.
- [ ] Smoke-test an `elementor/add-widget` and one Base_Audit_Ability subclass end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)