### PR TITLE
feat(090): add append, mkdir, rmdir, file-info to file-manager namespace

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/089-file-abilities-consolidation"}
+{"feature_directory":"specs/090-file-manager-additions"}

--- a/README.txt
+++ b/README.txt
@@ -139,6 +139,8 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased =
+**Feature 090 — file-manager additions.** Four new abilities extend the `file-manager/*` namespace to cover directory management and metadata: `file-manager/append-file` (append or prepend to an existing file; refuses missing files and refuses `wp-config.php` / `.htaccess`), `file-manager/create-directory` (recursive-by-default `mkdir` under ABSPATH; idempotent), `file-manager/delete-directory` (empty-only by default; opt-in `recursive:true`; requires `confirm:true`; refuses nine critical WordPress directories), and `file-manager/file-info` (read-only stat wrapper with optional POSIX owner/group names). Ability count 385 → 389.
+
 **Feature 089 — file abilities consolidation.** Every file read / write / list / copy / move for the WordPress installation now flows through the `file-manager/*` namespace. Three new abilities added; six duplicate theme- and plugin-scoped abilities removed; a pre-existing security gap closed.
 
 **Added — three new `file-manager/*` abilities:**

--- a/docs/abilities-inventory.md
+++ b/docs/abilities-inventory.md
@@ -3,7 +3,7 @@
 Generated snapshot of every ability the plugin registers, using the **post-rename** slugs
 (after PRs #134 blocks, #135 elementor, #136 rank-math, #137 topic-namespaces land).
 
-**Total abilities:** 385 across 24 topic namespaces.
+**Total abilities:** 389 across 24 topic namespaces.
 
 ## Summary
 
@@ -19,7 +19,7 @@ Generated snapshot of every ability the plugin registers, using the **post-renam
 | `cron/` | 16 | `acrossai-abilities-manager-cron` |
 | `database/` | 11 | `acrossai-abilities-manager-database` |
 | `elementor/` | 62 | `acrossai-abilities-manager-elementor` |
-| `file-manager/` | 18 | `acrossai-abilities-manager-file-manager` |
+| `file-manager/` | 22 | `acrossai-abilities-manager-file-manager` |
 | `fonts/` | 8 | `acrossai-abilities-manager-fonts` |
 | `media/` | 11 | `acrossai-abilities-manager-media` |
 | `menus/` | 12 | `acrossai-abilities-manager-menus` |
@@ -247,10 +247,14 @@ Sorted by namespace → sub-group → slug.
 | `file-manager/` | `file-manager/upload-zip-backup` | file-manager | backups | Upload Zip Backup |
 | `file-manager/` | `file-manager/clear-debug-log` | file-manager | debug | Clear Debug Log |
 | `file-manager/` | `file-manager/read-debug-log` | file-manager | debug | Read Debug Log |
+| `file-manager/` | `file-manager/append-file` | file-manager | files | Append to File |
 | `file-manager/` | `file-manager/copy-file` | file-manager | files | Copy File |
+| `file-manager/` | `file-manager/create-directory` | file-manager | files | Create Directory |
 | `file-manager/` | `file-manager/create-file` | file-manager | files | Create File |
+| `file-manager/` | `file-manager/delete-directory` | file-manager | files | Delete Directory |
 | `file-manager/` | `file-manager/delete-file` | file-manager | files | Delete File |
 | `file-manager/` | `file-manager/edit-file` | file-manager | files | Create or Overwrite File |
+| `file-manager/` | `file-manager/file-info` | file-manager | files | Get File Info |
 | `file-manager/` | `file-manager/list-directory` | file-manager | files | List Directory |
 | `file-manager/` | `file-manager/move-file` | file-manager | files | Move File |
 | `file-manager/` | `file-manager/read-file` | file-manager | files | Read File |

--- a/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
+++ b/includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php
@@ -195,6 +195,11 @@ final class AcrossAI_Core_Abilities_Bootstrap {
 		new FileManager\List_Directory();
 		new FileManager\Copy_File();
 		new FileManager\Move_File();
+		// Feature 090 — directory + append + file-info.
+		new FileManager\Append_File();
+		new FileManager\Create_Directory();
+		new FileManager\Delete_Directory();
+		new FileManager\File_Info();
 		new FileManager\Read_Wp_Config();
 		new FileManager\Edit_Wp_Config();
 		new FileManager\Read_Debug_Log();

--- a/includes/Abilities/FileManager/Append_File.php
+++ b/includes/Abilities/FileManager/Append_File.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * File-manager append-file ability (Feature 090).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\FileManager
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Append_File ability class.
+ *
+ * Append (default) or prepend caller-supplied bytes to an existing file
+ * under ABSPATH. Refuses missing files (use create-file instead) and
+ * refuses wp-config.php or .htaccess at ABSPATH root.
+ *
+ * Append uses FILE_APPEND | LOCK_EX for atomic-ish tail-writes.
+ * Prepend reads then rewrites the entire file — not atomic; a concurrent
+ * writer between the read and write would win. Callers are warned in the
+ * ability description to avoid prepending to large files.
+ */
+class Append_File extends Ability_Definition {
+
+	/**
+	 * Filenames refused as targets even when they exist.
+	 * Same list as Read_File / Delete_File / Create_File / Edit_File /
+	 * Copy_File / Move_File (mirrors feature 089 hardening).
+	 *
+	 * @var array<int,string>
+	 */
+	private const PROTECTED_FILES = array(
+		'wp-config.php',
+		'.htaccess',
+	);
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'file-manager/append-file',
+			'args' => array(
+				'label'               => __( 'Append to File', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Append (default) or prepend caller-supplied bytes to an existing file inside the WordPress installation. Path must be relative to ABSPATH. Refuses missing files (use create-file instead) and refuses wp-config.php or .htaccess at ABSPATH root. Append uses FILE_APPEND | LOCK_EX; prepend reads then rewrites (not atomic; avoid on large files).', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-file-manager',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'path'    => array(
+							'type'        => 'string',
+							'description' => __( 'File path relative to ABSPATH. Must exist.', 'acrossai-abilities-manager' ),
+						),
+						'content' => array(
+							'type'        => 'string',
+							'description' => __( 'Bytes to append (or prepend).', 'acrossai-abilities-manager' ),
+						),
+						'prepend' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'When true, content is written to the head of the file; otherwise appended to the tail.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'required'             => array( 'path', 'content' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'path'           => array( 'type' => 'string' ),
+						'bytes_written'  => array( 'type' => 'integer' ),
+						'new_size'       => array( 'type' => 'integer' ),
+						'prepended'      => array( 'type' => 'boolean' ),
+						'message'        => array( 'type' => 'string' ),
+						'blocked_reason' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success', 'message' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'file-manager',
+						'sub_group'       => 'files',
+						'sub_group_label' => __( 'Files', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response();
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		$rel_path = sanitize_text_field( $input['path'] ?? '' );
+		$content  = isset( $input['content'] ) ? (string) $input['content'] : '';
+		$prepend  = ! empty( $input['prepend'] );
+
+		$base   = rtrim( realpath( ABSPATH ) ?: ABSPATH, '/' );
+		$real   = realpath( $base . '/' . ltrim( $rel_path, '/' ) );
+
+		if ( false === $real || 0 !== strpos( $real, $base . '/' ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'invalid_path',
+				'message'        => __( 'Invalid or disallowed file path.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Protected-file guard: refuse to write secret-holding files at
+		// ABSPATH root. Same guard as Read_File / Delete_File / Create_File /
+		// Edit_File / Copy_File / Move_File.
+		if ( in_array( basename( $real ), self::PROTECTED_FILES, true )
+			&& dirname( $real ) === $base ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'protected_write',
+				/* translators: %s: filename */
+				'message'        => sprintf( __( 'File "%s" is protected and cannot be written.', 'acrossai-abilities-manager' ), basename( $real ) ),
+			);
+		}
+
+		if ( ! is_file( $real ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'source_not_found',
+				'message'        => __( 'File does not exist. Use file-manager/create-file to create it first.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( $prepend ) {
+			$existing = file_get_contents( $real ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			if ( false === $existing ) {
+				return array(
+					'success' => false,
+					'message' => __( 'Could not read file for prepend.', 'acrossai-abilities-manager' ),
+				);
+			}
+			$result = file_put_contents( $real, $content . $existing, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		} else {
+			$result = file_put_contents( $real, $content, FILE_APPEND | LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		}
+
+		if ( false === $result ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Could not write file.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		clearstatcache( true, $real );
+
+		return array(
+			'success'       => true,
+			'path'          => $real,
+			'bytes_written' => strlen( $content ),
+			'new_size'      => (int) filesize( $real ),
+			'prepended'     => $prepend,
+			'message'       => $prepend
+				? __( 'Content prepended.', 'acrossai-abilities-manager' )
+				: __( 'Content appended.', 'acrossai-abilities-manager' ),
+		);
+	}
+}

--- a/includes/Abilities/FileManager/Create_Directory.php
+++ b/includes/Abilities/FileManager/Create_Directory.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * File-manager create-directory ability (Feature 090).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\FileManager
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Create_Directory ability class.
+ *
+ * Create a directory under ABSPATH. Recursive by default (wp_mkdir_p);
+ * pass recursive:false for a single-level mkdir. Idempotent — returns
+ * success with created:false when the target already exists.
+ */
+class Create_Directory extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'file-manager/create-directory',
+			'args' => array(
+				'label'               => __( 'Create Directory', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Create a directory inside the WordPress installation. Path must be relative to ABSPATH. Default recursive:true uses wp_mkdir_p (creates any missing parents); recursive:false requires the parent to exist. Idempotent — returns success with created:false when the target already exists as a directory. Refuses when the target exists as a file.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-file-manager',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'path'      => array(
+							'type'        => 'string',
+							'description' => __( 'Directory path relative to ABSPATH.', 'acrossai-abilities-manager' ),
+						),
+						'recursive' => array(
+							'type'        => 'boolean',
+							'default'     => true,
+							'description' => __( 'When true (default), missing parent directories are created via wp_mkdir_p. When false, a single mkdir is used and refuses if the parent does not exist.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'required'             => array( 'path' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'path'           => array( 'type' => 'string' ),
+						'created'        => array( 'type' => 'boolean' ),
+						'message'        => array( 'type' => 'string' ),
+						'blocked_reason' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success', 'message' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'file-manager',
+						'sub_group'       => 'files',
+						'sub_group_label' => __( 'Files', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$blocked = File_Mods_Guard::blocked_response();
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		$rel_path  = sanitize_text_field( $input['path'] ?? '' );
+		$recursive = array_key_exists( 'recursive', $input ) ? (bool) $input['recursive'] : true;
+
+		$base = rtrim( realpath( ABSPATH ) ?: ABSPATH, '/' );
+		$abs  = $base . '/' . ltrim( $rel_path, '/' );
+
+		// If the target already exists as a directory, treat as idempotent success.
+		if ( is_dir( $abs ) ) {
+			$real = realpath( $abs );
+			if ( false === $real || ( $real !== $base && 0 !== strpos( $real, $base . '/' ) ) ) {
+				return array(
+					'success'        => false,
+					'blocked_reason' => 'invalid_path',
+					'message'        => __( 'Invalid or disallowed directory path.', 'acrossai-abilities-manager' ),
+				);
+			}
+			return array(
+				'success' => true,
+				'path'    => $real,
+				'created' => false,
+				'message' => __( 'Directory already exists.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( file_exists( $abs ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'path_is_file',
+				'message'        => __( 'Path exists as a file; cannot create a directory here.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Parent-scope check for the (not-yet-created) target.
+		if ( $recursive ) {
+			// wp_mkdir_p handles missing parents; we still need to bound the
+			// requested path itself to ABSPATH before calling it.
+			if ( 0 !== strpos( $abs, $base . '/' ) ) {
+				return array(
+					'success'        => false,
+					'blocked_reason' => 'invalid_path',
+					'message'        => __( 'Invalid or disallowed directory path.', 'acrossai-abilities-manager' ),
+				);
+			}
+			if ( ! wp_mkdir_p( $abs ) ) {
+				return array(
+					'success' => false,
+					'message' => __( 'Could not create directory.', 'acrossai-abilities-manager' ),
+				);
+			}
+		} else {
+			$parent = realpath( dirname( $abs ) );
+			if ( false === $parent ) {
+				return array(
+					'success'        => false,
+					'blocked_reason' => 'parent_missing',
+					'message'        => __( 'Parent directory does not exist. Pass recursive:true to create it.', 'acrossai-abilities-manager' ),
+				);
+			}
+			if ( $parent !== $base && 0 !== strpos( $parent, $base . '/' ) ) {
+				return array(
+					'success'        => false,
+					'blocked_reason' => 'invalid_path',
+					'message'        => __( 'Invalid or disallowed directory path.', 'acrossai-abilities-manager' ),
+				);
+			}
+			if ( ! mkdir( $abs ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+				return array(
+					'success' => false,
+					'message' => __( 'Could not create directory.', 'acrossai-abilities-manager' ),
+				);
+			}
+		}
+
+		return array(
+			'success' => true,
+			'path'    => realpath( $abs ) ?: $abs,
+			'created' => true,
+			'message' => __( 'Directory created.', 'acrossai-abilities-manager' ),
+		);
+	}
+}

--- a/includes/Abilities/FileManager/Delete_Directory.php
+++ b/includes/Abilities/FileManager/Delete_Directory.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * File-manager delete-directory ability (Feature 090).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\FileManager
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Delete_Directory ability class.
+ *
+ * Remove a directory under ABSPATH. Requires confirm:true. Default
+ * recursive:false refuses non-empty directories. Refuses a hardcoded
+ * list of critical WordPress directories regardless of inputs.
+ * Symlinks are unlinked (not followed).
+ */
+class Delete_Directory extends Ability_Definition {
+
+	/**
+	 * ABSPATH-relative directory paths that this ability refuses to delete
+	 * regardless of confirm/recursive inputs. Deleting any of these would
+	 * irreversibly break the site.
+	 *
+	 * Empty string means ABSPATH itself.
+	 *
+	 * @var array<int,string>
+	 */
+	private const PROTECTED_DIRS = array(
+		'',
+		'wp-admin',
+		'wp-includes',
+		'wp-content',
+		'wp-content/plugins',
+		'wp-content/themes',
+		'wp-content/mu-plugins',
+		'wp-content/uploads',
+		'wp-content/plugins/acrossai-abilities-manager',
+	);
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'file-manager/delete-directory',
+			'args' => array(
+				'label'               => __( 'Delete Directory', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Delete a directory inside the WordPress installation. Path must be relative to ABSPATH. Requires confirm:true. Default recursive:false refuses non-empty directories. Refuses a hardcoded list of critical WordPress directories (ABSPATH, wp-admin, wp-includes, wp-content, wp-content/plugins, wp-content/themes, wp-content/mu-plugins, wp-content/uploads, and this plugin\'s directory). Symlinks are not followed during recursive walks. Idempotent — a missing target returns success with entries_removed:0.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-file-manager',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'path'      => array(
+							'type'        => 'string',
+							'description' => __( 'Directory path relative to ABSPATH.', 'acrossai-abilities-manager' ),
+						),
+						'recursive' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'When true, contents are removed bottom-up before the directory itself. Default false requires the directory to be empty.', 'acrossai-abilities-manager' ),
+						),
+						'confirm'   => array(
+							'type'        => 'boolean',
+							'description' => __( 'Must be true to proceed. Guards against accidental deletes.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'required'             => array( 'path', 'confirm' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'         => array( 'type' => 'boolean' ),
+						'path'            => array( 'type' => 'string' ),
+						'entries_removed' => array( 'type' => 'integer' ),
+						'message'         => array( 'type' => 'string' ),
+						'blocked_reason'  => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success', 'message' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'file-manager',
+						'sub_group'       => 'files',
+						'sub_group_label' => __( 'Files', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		// Explicit-confirmation guard. Refuse before any I/O.
+		if ( empty( $input['confirm'] ) || true !== (bool) $input['confirm'] ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'confirmation_required',
+				'message'        => __( 'Deleting a directory is permanent. Pass confirm:true to proceed.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$blocked = File_Mods_Guard::blocked_response();
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
+		$rel_path  = sanitize_text_field( $input['path'] ?? '' );
+		$recursive = ! empty( $input['recursive'] );
+
+		$base = rtrim( realpath( ABSPATH ) ?: ABSPATH, '/' );
+		$abs  = $base . '/' . ltrim( $rel_path, '/' );
+		$real = realpath( $abs );
+
+		// Missing target: idempotent success.
+		if ( false === $real ) {
+			// Still enforce scope on the requested path so a caller can't
+			// probe outside ABSPATH by asking us to "delete" a path there.
+			if ( 0 !== strpos( $abs, $base . '/' ) && $abs !== $base ) {
+				return array(
+					'success'        => false,
+					'blocked_reason' => 'invalid_path',
+					'message'        => __( 'Invalid or disallowed directory path.', 'acrossai-abilities-manager' ),
+				);
+			}
+			return array(
+				'success'         => true,
+				'path'            => $abs,
+				'entries_removed' => 0,
+				'message'         => __( 'Directory does not exist.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( $real !== $base && 0 !== strpos( $real, $base . '/' ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'invalid_path',
+				'message'        => __( 'Invalid or disallowed directory path.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( ! is_dir( $real ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'not_a_directory',
+				'message'        => __( 'Path exists but is not a directory.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Protected-directory guard: compare $real against each protected
+		// entry resolved to its absolute path. Refuses ABSPATH itself and
+		// the eight critical WordPress subdirectories.
+		foreach ( self::PROTECTED_DIRS as $rel ) {
+			$protected_abs = '' === $rel ? $base : $base . '/' . $rel;
+			$protected_real = realpath( $protected_abs );
+			if ( false !== $protected_real && $protected_real === $real ) {
+				return array(
+					'success'        => false,
+					'blocked_reason' => 'protected_directory',
+					/* translators: %s: relative directory path */
+					'message'        => sprintf( __( 'Directory "%s" is protected and cannot be deleted.', 'acrossai-abilities-manager' ), '' === $rel ? 'ABSPATH' : $rel ),
+				);
+			}
+		}
+
+		if ( ! $recursive ) {
+			if ( ! rmdir( $real ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+				return array(
+					'success'         => false,
+					'blocked_reason'  => 'not_empty',
+					'entries_removed' => 0,
+					'message'         => __( 'Directory is not empty. Pass recursive:true to delete its contents.', 'acrossai-abilities-manager' ),
+				);
+			}
+			return array(
+				'success'         => true,
+				'path'            => $real,
+				'entries_removed' => 1,
+				'message'         => __( 'Empty directory removed.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		// Recursive walk, bottom-up.
+		$entries_removed = 0;
+		$iterator        = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $real, RecursiveDirectoryIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+
+		foreach ( $iterator as $file_info ) {
+			$entry_path = $file_info->getPathname();
+
+			// Symlinks are unlinked as references — never followed.
+			if ( $file_info->isLink() ) {
+				if ( ! @unlink( $entry_path ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+					return array(
+						'success'         => false,
+						'entries_removed' => $entries_removed,
+						/* translators: %s: entry path */
+						'message'         => sprintf( __( 'Could not remove symlink at "%s".', 'acrossai-abilities-manager' ), $entry_path ),
+					);
+				}
+				++$entries_removed;
+				continue;
+			}
+
+			if ( $file_info->isDir() ) {
+				if ( ! @rmdir( $entry_path ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+					return array(
+						'success'         => false,
+						'entries_removed' => $entries_removed,
+						/* translators: %s: entry path */
+						'message'         => sprintf( __( 'Could not remove directory at "%s".', 'acrossai-abilities-manager' ), $entry_path ),
+					);
+				}
+			} elseif ( ! @unlink( $entry_path ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				return array(
+					'success'         => false,
+					'entries_removed' => $entries_removed,
+					/* translators: %s: entry path */
+					'message'         => sprintf( __( 'Could not remove file at "%s".', 'acrossai-abilities-manager' ), $entry_path ),
+				);
+			}
+			++$entries_removed;
+		}
+
+		if ( ! @rmdir( $real ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			return array(
+				'success'         => false,
+				'entries_removed' => $entries_removed,
+				'message'         => __( 'Could not remove the top-level directory after clearing its contents.', 'acrossai-abilities-manager' ),
+			);
+		}
+		++$entries_removed;
+
+		return array(
+			'success'         => true,
+			'path'            => $real,
+			'entries_removed' => $entries_removed,
+			/* translators: %d: entries removed */
+			'message'         => sprintf( __( 'Directory removed (%d entries).', 'acrossai-abilities-manager' ), $entries_removed ),
+		);
+	}
+}

--- a/includes/Abilities/FileManager/File_Info.php
+++ b/includes/Abilities/FileManager/File_Info.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * File-manager file-info ability (Feature 090).
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\FileManager
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
+
+use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * File_Info ability class.
+ *
+ * Return stat metadata for any path under ABSPATH without loading its
+ * content. Owner/group names are resolved via the PHP POSIX extension
+ * when available and omitted otherwise.
+ */
+class File_Info extends Ability_Definition {
+
+	/**
+	 * Full ability spec for wp_register_ability().
+	 *
+	 * @return array
+	 */
+	protected function ability(): array {
+		return array(
+			'name' => 'file-manager/file-info',
+			'args' => array(
+				'label'               => __( 'Get File Info', 'acrossai-abilities-manager' ),
+				'description'         => __( 'Return stat metadata (type, size, timestamps, mode/permissions, ownership, readability, writability, symlink flag) for any path inside the WordPress installation. Path must be relative to ABSPATH. Read-only — does not open the file. Owner/group name fields are omitted when the PHP POSIX extension is absent.', 'acrossai-abilities-manager' ),
+				'category'            => 'acrossai-abilities-manager-file-manager',
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'path' => array(
+							'type'        => 'string',
+							'description' => __( 'File or directory path relative to ABSPATH.', 'acrossai-abilities-manager' ),
+						),
+					),
+					'required'             => array( 'path' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'success'        => array( 'type' => 'boolean' ),
+						'path'           => array( 'type' => 'string' ),
+						'type'           => array(
+							'type' => 'string',
+							'enum' => array( 'file', 'dir', 'link' ),
+						),
+						'size'           => array( 'type' => 'integer' ),
+						'mtime'          => array( 'type' => 'integer' ),
+						'ctime'          => array( 'type' => 'integer' ),
+						'atime'          => array( 'type' => 'integer' ),
+						'mode_octal'     => array( 'type' => 'string' ),
+						'owner_uid'      => array( 'type' => 'integer' ),
+						'owner_name'     => array( 'type' => 'string' ),
+						'group_gid'      => array( 'type' => 'integer' ),
+						'group_name'     => array( 'type' => 'string' ),
+						'readable'       => array( 'type' => 'boolean' ),
+						'writable'       => array( 'type' => 'boolean' ),
+						'is_link'        => array( 'type' => 'boolean' ),
+						'message'        => array( 'type' => 'string' ),
+						'blocked_reason' => array( 'type' => 'string' ),
+					),
+					'required'             => array( 'success', 'message' ),
+					'additionalProperties' => false,
+				),
+				'meta'                => array(
+					'acrossai'     => array(
+						'tab_group'       => 'file-manager',
+						'sub_group'       => 'files',
+						'sub_group_label' => __( 'Files', 'acrossai-abilities-manager' ),
+					),
+					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => false,
+						'type'   => 'tool',
+					),
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Ability input payload.
+	 * @return array
+	 */
+	public function execute( array $input = array() ): array {
+		$rel_path = sanitize_text_field( $input['path'] ?? '' );
+		$base     = rtrim( realpath( ABSPATH ) ?: ABSPATH, '/' );
+		$candidate = $base . '/' . ltrim( $rel_path, '/' );
+
+		// Scope check: parent must resolve inside ABSPATH. This mirrors the
+		// pattern used by Read_File and lets us handle broken symlinks (where
+		// realpath($candidate) itself is false but the parent resolves).
+		$parent = realpath( dirname( $candidate ) );
+		if ( false === $parent || ( $parent !== $base && 0 !== strpos( $parent, $base . '/' ) ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'invalid_path',
+				'message'        => __( 'Invalid or disallowed path.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		if ( ! file_exists( $candidate ) && ! is_link( $candidate ) ) {
+			return array(
+				'success'        => false,
+				'blocked_reason' => 'path_not_found',
+				'message'        => __( 'Path does not exist.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$stat = @stat( $candidate ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( ! is_array( $stat ) ) {
+			return array(
+				'success' => false,
+				'message' => __( 'Could not stat path.', 'acrossai-abilities-manager' ),
+			);
+		}
+
+		$is_link = is_link( $candidate );
+		if ( $is_link && ! file_exists( $candidate ) ) {
+			$type = 'link';
+		} elseif ( is_dir( $candidate ) ) {
+			$type = 'dir';
+		} else {
+			$type = 'file';
+		}
+
+		$response = array(
+			'success'    => true,
+			'path'       => $candidate,
+			'type'       => $type,
+			'size'       => 'dir' === $type ? 0 : (int) $stat['size'],
+			'mtime'      => (int) $stat['mtime'],
+			'ctime'      => (int) $stat['ctime'],
+			'atime'      => (int) $stat['atime'],
+			'mode_octal' => substr( (string) decoct( (int) $stat['mode'] ), -4 ),
+			'owner_uid'  => (int) $stat['uid'],
+			'group_gid'  => (int) $stat['gid'],
+			'readable'   => is_readable( $candidate ),
+			'writable'   => is_writable( $candidate ),
+			'is_link'    => $is_link,
+			'message'    => __( 'Path metadata retrieved.', 'acrossai-abilities-manager' ),
+		);
+
+		if ( function_exists( 'posix_getpwuid' ) ) {
+			$pw = posix_getpwuid( (int) $stat['uid'] );
+			if ( is_array( $pw ) && isset( $pw['name'] ) && '' !== $pw['name'] ) {
+				$response['owner_name'] = (string) $pw['name'];
+			}
+		}
+		if ( function_exists( 'posix_getgrgid' ) ) {
+			$gr = posix_getgrgid( (int) $stat['gid'] );
+			if ( is_array( $gr ) && isset( $gr['name'] ) && '' !== $gr['name'] ) {
+				$response['group_name'] = (string) $gr['name'];
+			}
+		}
+
+		return $response;
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -239,6 +239,10 @@
 		<testsuite name="feature-089-unit">
 			<file>tests/phpunit/abilities/Test_Feature_089_File_Consolidation.php</file>
 		</testsuite>
+		<!-- Feature 090 — file-manager additions. -->
+		<testsuite name="feature-090-unit">
+			<file>tests/phpunit/abilities/Test_Feature_090_File_Manager_Additions.php</file>
+		</testsuite>
 	</testsuites>
 	<source>
 		<include>

--- a/specs/090-file-manager-additions/checklists/requirements.md
+++ b/specs/090-file-manager-additions/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: File-Manager Additions (090)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-25
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+Validation pass 1: all items pass.
+
+Domain-specific terms used in the spec that could look like implementation details but are actually the WordPress platform vocabulary the product is defined against (kept intentionally): `wp-config.php`, `.htaccess`, `ABSPATH`, `wp-admin`, `wp-includes`, `wp-content`, `wp_mkdir_p` (in Assumptions only), `DISALLOW_FILE_MODS`, `manage_options`, `posix_getpwuid` / `posix_getgrgid` (POSIX API — required to state the graceful-degradation rule in FR-013).

--- a/specs/090-file-manager-additions/contracts/file-manager-append-file.json
+++ b/specs/090-file-manager-additions/contracts/file-manager-append-file.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "ability": "file-manager/append-file",
+  "label": "Append to File",
+  "description": "Append (default) or prepend caller-supplied bytes to an existing file inside the WordPress installation. Path must be relative to ABSPATH. Refuses missing files (use create-file instead) and refuses wp-config.php or .htaccess at ABSPATH root. Append uses FILE_APPEND | LOCK_EX; prepend reads then rewrites (not atomic; avoid on large files).",
+  "annotations": { "readonly": false, "destructive": false, "idempotent": false },
+  "input_schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["path", "content"],
+    "properties": {
+      "path":    { "type": "string", "minLength": 1 },
+      "content": { "type": "string" },
+      "prepend": { "type": "boolean", "default": false }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["success", "message"],
+    "properties": {
+      "success":        { "type": "boolean" },
+      "path":           { "type": "string" },
+      "bytes_written":  { "type": "integer" },
+      "new_size":       { "type": "integer" },
+      "prepended":      { "type": "boolean" },
+      "message":        { "type": "string" },
+      "blocked_reason": {
+        "type": "string",
+        "enum": ["invalid_path", "source_not_found", "protected_write", "file_mods_disabled"]
+      }
+    }
+  }
+}

--- a/specs/090-file-manager-additions/contracts/file-manager-create-directory.json
+++ b/specs/090-file-manager-additions/contracts/file-manager-create-directory.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "ability": "file-manager/create-directory",
+  "label": "Create Directory",
+  "description": "Create a directory inside the WordPress installation. Path must be relative to ABSPATH. Default recursive:true uses wp_mkdir_p; recursive:false uses a single mkdir call. Idempotent — returns success with created:false when the target already exists as a directory. Refuses when the target exists as a file.",
+  "annotations": { "readonly": false, "destructive": false, "idempotent": true },
+  "input_schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["path"],
+    "properties": {
+      "path":      { "type": "string", "minLength": 1 },
+      "recursive": { "type": "boolean", "default": true }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["success", "message"],
+    "properties": {
+      "success":        { "type": "boolean" },
+      "path":           { "type": "string" },
+      "created":        { "type": "boolean" },
+      "message":        { "type": "string" },
+      "blocked_reason": {
+        "type": "string",
+        "enum": ["invalid_path", "path_is_file", "parent_missing", "file_mods_disabled"]
+      }
+    }
+  }
+}

--- a/specs/090-file-manager-additions/contracts/file-manager-delete-directory.json
+++ b/specs/090-file-manager-additions/contracts/file-manager-delete-directory.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "ability": "file-manager/delete-directory",
+  "label": "Delete Directory",
+  "description": "Delete a directory inside the WordPress installation. Path must be relative to ABSPATH. Requires confirm:true. Default recursive:false refuses non-empty directories. Refuses a hardcoded list of critical WordPress directories (ABSPATH, wp-admin, wp-includes, wp-content, wp-content/plugins, wp-content/themes, wp-content/mu-plugins, wp-content/uploads, and this plugin's directory). Symlinks are not followed during recursive walks. Idempotent — a missing target returns success with entries_removed:0.",
+  "annotations": { "readonly": false, "destructive": true, "idempotent": true },
+  "input_schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["path", "confirm"],
+    "properties": {
+      "path":      { "type": "string", "minLength": 1 },
+      "recursive": { "type": "boolean", "default": false },
+      "confirm":   { "type": "boolean", "description": "Must be true to proceed." }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["success", "message"],
+    "properties": {
+      "success":         { "type": "boolean" },
+      "path":            { "type": "string" },
+      "entries_removed": { "type": "integer" },
+      "message":         { "type": "string" },
+      "blocked_reason":  {
+        "type": "string",
+        "enum": ["confirmation_required", "invalid_path", "not_a_directory", "protected_directory", "not_empty", "file_mods_disabled"]
+      }
+    }
+  }
+}

--- a/specs/090-file-manager-additions/contracts/file-manager-file-info.json
+++ b/specs/090-file-manager-additions/contracts/file-manager-file-info.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "ability": "file-manager/file-info",
+  "label": "Get File Info",
+  "description": "Return stat metadata (type, size, timestamps, mode, ownership, permissions, symlink flag) for any path inside the WordPress installation. Path must be relative to ABSPATH. Read-only — does not open the file. Owner/group name fields are omitted when the PHP POSIX extension is absent.",
+  "annotations": { "readonly": true, "destructive": false, "idempotent": true },
+  "input_schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["path"],
+    "properties": {
+      "path": { "type": "string", "minLength": 1 }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["success", "message"],
+    "properties": {
+      "success":        { "type": "boolean" },
+      "path":           { "type": "string" },
+      "type":           { "type": "string", "enum": ["file", "dir", "link"] },
+      "size":           { "type": "integer" },
+      "mtime":          { "type": "integer" },
+      "ctime":          { "type": "integer" },
+      "atime":          { "type": "integer" },
+      "mode_octal":     { "type": "string" },
+      "owner_uid":      { "type": "integer" },
+      "owner_name":     { "type": "string" },
+      "group_gid":      { "type": "integer" },
+      "group_name":     { "type": "string" },
+      "readable":       { "type": "boolean" },
+      "writable":       { "type": "boolean" },
+      "is_link":        { "type": "boolean" },
+      "message":        { "type": "string" },
+      "blocked_reason": { "type": "string", "enum": ["invalid_path", "path_not_found"] }
+    }
+  }
+}

--- a/specs/090-file-manager-additions/data-model.md
+++ b/specs/090-file-manager-additions/data-model.md
@@ -1,0 +1,97 @@
+# Data Model: File-Manager Additions (090)
+
+No persistent data model. This feature touches the WordPress ability registry (in-memory) and the filesystem under ABSPATH. The "entities" below describe the runtime shapes exchanged over the abilities API.
+
+## 1. Append/prepend envelope
+
+Response of `file-manager/append-file`.
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | boolean | `true` on completion. `false` on refusal or error. |
+| `path` | string | Echoed ABSPATH-relative path. |
+| `bytes_written` | integer | Bytes added by this call. Equals `strlen($content)` on success. |
+| `new_size` | integer | File size after the write. |
+| `prepended` | boolean | `true` iff the caller passed `prepend:true` and the write succeeded. |
+| `message` | string | Human-readable status. |
+| `blocked_reason` | string \| absent | Present only on refusal. Values: `invalid_path`, `source_not_found`, `protected_write`, `file_mods_disabled`. |
+
+## 2. Create-directory envelope
+
+Response of `file-manager/create-directory`.
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | boolean | `true` on completion or when directory already existed. |
+| `path` | string | Echoed ABSPATH-relative path. |
+| `created` | boolean | `true` when a new directory was created; `false` when it already existed. |
+| `message` | string | Human-readable status. |
+| `blocked_reason` | string \| absent | Values: `invalid_path`, `path_is_file`, `parent_missing`, `file_mods_disabled`. |
+
+## 3. Delete-directory envelope
+
+Response of `file-manager/delete-directory`.
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | boolean | `true` on completion or when directory did not exist. |
+| `path` | string | Echoed ABSPATH-relative path. |
+| `entries_removed` | integer | Total count of files + directories removed. `0` for a missing target. `1` for an empty-directory removal. |
+| `message` | string | Human-readable status. |
+| `blocked_reason` | string \| absent | Values: `confirmation_required`, `invalid_path`, `not_a_directory`, `protected_directory`, `not_empty`, `file_mods_disabled`. |
+
+## 4. File-info envelope
+
+Response of `file-manager/file-info`.
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | boolean | `true` on a resolvable path. `false` on missing path or invalid input. |
+| `path` | string | Echoed ABSPATH-relative path. |
+| `type` | enum `file` \| `dir` \| `link` | Kind of filesystem entry. `link` only when the target is a symlink AND its target does not resolve. |
+| `size` | integer | Bytes for files; `0` for directories. |
+| `mtime` | integer | Unix epoch seconds. |
+| `ctime` | integer | Unix epoch seconds. |
+| `atime` | integer | Unix epoch seconds. |
+| `mode_octal` | string | Last four octal digits, e.g. `"0644"`. |
+| `owner_uid` | integer | Numeric uid from `stat()`. |
+| `owner_name` | string \| absent | Present only when `function_exists('posix_getpwuid')`. |
+| `group_gid` | integer | Numeric gid from `stat()`. |
+| `group_name` | string \| absent | Present only when `function_exists('posix_getgrgid')`. |
+| `readable` | boolean | `is_readable()` result. |
+| `writable` | boolean | `is_writable()` result. |
+| `is_link` | boolean | `is_link()` result. |
+| `message` | string | Human-readable status. |
+| `blocked_reason` | string \| absent | Values: `invalid_path`, `path_not_found`. |
+
+## 5. Ability-registration record (in-memory)
+
+Every ability the plugin registers is keyed by slug in the WordPress ability registry. Feature 090's operations:
+
+| Slug | Operation |
+|---|---|
+| `file-manager/append-file` | **Register** (new). |
+| `file-manager/create-directory` | **Register** (new). |
+| `file-manager/delete-directory` | **Register** (new). |
+| `file-manager/file-info` | **Register** (new). |
+
+Every other ability remains registered unchanged.
+
+## 6. Guard constants (per-class)
+
+| Class | Constant | Members | Behaviour |
+|---|---|---|---|
+| `Append_File` | `PROTECTED_FILES` | `wp-config.php`, `.htaccess` | Refuse writes at ABSPATH root. |
+| `Delete_Directory` | `PROTECTED_DIRS` | `ABSPATH`, `wp-admin`, `wp-includes`, `wp-content`, `wp-content/plugins`, `wp-content/themes`, `wp-content/mu-plugins`, `wp-content/uploads`, `wp-content/plugins/acrossai-abilities-manager` | Refuse recursive delete regardless of `confirm:true`. |
+
+Constants are duplicated per class rather than extracted to a shared helper — see `research.md §3` for rationale (matches feature 089 convention).
+
+## Validation rules
+
+- `path` MUST be a non-empty string resolvable under `realpath(ABSPATH)`.
+- `content` (`append-file`) MUST be a string. Empty string is a valid no-op.
+- `prepend` (`append-file`) MUST be boolean; default `false`.
+- `recursive` (`create-directory`) MUST be boolean; default `true`.
+- `recursive` (`delete-directory`) MUST be boolean; default `false`.
+- `confirm` (`delete-directory`) MUST be boolean; MUST be exactly `true` to proceed.
+- Every ability rejects unknown properties per JSON Schema `additionalProperties: false` (matches existing convention).

--- a/specs/090-file-manager-additions/plan.md
+++ b/specs/090-file-manager-additions/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: File-Manager Additions
+
+**Branch**: `090-file-manager-additions` | **Date**: 2026-08-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/090-file-manager-additions/spec.md`
+
+## Summary
+
+Add four new abilities to the `file-manager/*` namespace: `append-file`, `create-directory`, `delete-directory`, `file-info`. All four are thin wrappers over WordPress core / PHP built-ins (`wp_mkdir_p`, `mkdir`, `rmdir`, `unlink`, `file_put_contents(..., FILE_APPEND)`, `RecursiveDirectoryIterator`, `stat`). Each mirrors the shape of an existing peer under `includes/Abilities/FileManager/`, reuses the same guard patterns (`File_Mods_Guard`, ABSPATH scope check, `PROTECTED_FILES` refusal), and requires no new utility classes or Composer dependencies.
+
+Cross-check against two reference plugins was completed during planning: (a) `mcp-abilities-filesystem` (single-file, MIT-flavour, `filesystem/*` slugs) surfaced the four gaps; (b) `wp-file-manager` (elFinder-based, GPLv2, v8.0.4) was evaluated for library reuse — verdict: don't vendor elFinder, it's a 10+ MB volume-abstraction library that's overkill for four thin ability wrappers. Use WordPress core primitives, keep the module coherent with peer abilities from feature 089.
+
+## Technical Context
+
+**Language/Version**: PHP 8.1+ (per Constitution §II).
+**Primary Dependencies**: WordPress 6.9+, `Ability_Definition` base class (`AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition`), `File_Mods_Guard` utility (`includes/Abilities/Utilities/File_Mods_Guard.php`), WordPress core `wp_register_ability()` API, `wp_mkdir_p()`. No new Composer or npm packages.
+**Storage**: Filesystem under ABSPATH only. No database schema, options, meta, transients, or cron.
+**Testing**: PHPUnit (`phpunit.xml.dist`) under `tests/phpunit/abilities/` following the existing `Test_Feature_089_File_Consolidation.php` structural-inspection convention. Static analysis via PHPStan level 8 (`phpstan.neon.dist`), lint via PHPCS WPCS strict (`phpcs.xml.dist`).
+**Target Platform**: WordPress 6.9+ single-site and multisite installations on PHP 8.1+. Consumed by MCP clients through the abilities API and via WP-CLI (`wp ability call`).
+**Project Type**: WordPress plugin (single project layout, module directory pattern per Constitution §Architecture).
+**Performance Goals**: Every operation completes within one HTTP request timeout. `append` uses `FILE_APPEND | LOCK_EX` and returns immediately. `create-directory` is a bounded `wp_mkdir_p` call. `delete-directory` recursive walk uses the same `RecursiveDirectoryIterator` idiom as feature 089's `list-directory` (bounded to what the caller supplies) and reports partial state on error rather than throwing. `file-info` is a single `stat()` call.
+**Constraints**: Every ability requires `manage_options` capability. Every path resolves under `realpath(ABSPATH)` via the parent-scope pattern from `Read_File.php:114-123`. Every write-capable ability honours `DISALLOW_FILE_MODS` / `DISALLOW_FILE_EDIT` via `File_Mods_Guard::blocked_response()`. Response envelopes match the shape used by existing `file-manager/*` peers so MCP clients handle them uniformly.
+**Scale/Scope**: Four new PHP ability classes; one new bootstrap block (four `new FileManager\<Class>()` lines); one new PHPUnit test class; one new testsuite entry in `phpunit.xml.dist`; two edits to `docs/abilities-inventory.md` (counts + rows); one edit to `README.txt` (bullet under `= Unreleased =`). No existing behaviour changes.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Verdict | Notes |
+|-----------|---------|-------|
+| I. Modular Architecture | ✅ Pass | All changes contained to `includes/Abilities/FileManager/` (four new files) plus the shared bootstrap. Reuses existing `File_Mods_Guard`; introduces no cross-module coupling. |
+| II. WordPress Standards Compliance | ✅ Pass | PHP 8.1+; new classes follow the PHPCS-clean pattern of `Read_File.php`, `Create_File.php`, `List_Directory.php` etc. Plugin Check compatible (no `eval`, no `extract`, no shell). No deprecated WP functions. |
+| III. User-Centric Design | ✅ N/A | No admin UI change; DataForm/DataViews not touched. |
+| IV. Security First (NON-NEGOTIABLE) | ✅ Pass | `manage_options` on every ability. Every path resolved via `realpath()` under ABSPATH. `append-file` refuses `wp-config.php` / `.htaccess` via `PROTECTED_FILES` (same shape as `Read_File`, `Delete_File`, and the four hardened/added abilities from feature 089). `delete-directory` refuses a hardcoded `PROTECTED_DIRS` list plus honours `DISALLOW_FILE_MODS`. Symlink descent is refused during recursive delete. `file-info` is read-only and requires the same capability. |
+| V. Extensibility Without Core Modification | ✅ Pass | Internal additions to this plugin only; no third-party integration touched. |
+| VI. Reusability & DRY | ✅ Pass | Reuses `File_Mods_Guard`, `Ability_Definition`, the `PROTECTED_FILES` guard pattern from `Delete_File.php:131-138`, and the ABSPATH parent-scope check from `Read_File.php:114-123`. No new utilities introduced. |
+| VII. Definition of Done | ✅ Achievable | PHPUnit test class planned (structural, mirrors feature 089's convention). PHPStan level 8 target. PHPCS clean via peer-consistent style. Class naming follows the FileManager module convention (unprefixed class names, namespace-based prefixing). |
+
+**No violations require justification.** Complexity Tracking section intentionally empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/090-file-manager-additions/
+├── plan.md              # This file
+├── spec.md              # Written by /speckit-specify
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (ability schemas)
+├── checklists/
+│   └── requirements.md  # Written by /speckit-specify
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+includes/Abilities/
+├── FileManager/
+│   ├── {all existing feature-089 files}     # unchanged
+│   ├── Append_File.php                       # NEW
+│   ├── Create_Directory.php                  # NEW
+│   ├── Delete_Directory.php                  # NEW
+│   └── File_Info.php                         # NEW
+├── Utilities/
+│   └── File_Mods_Guard.php                   # unchanged (reused)
+└── AcrossAI_Core_Abilities_Bootstrap.php     # MODIFIED — four new instantiations
+
+tests/phpunit/abilities/
+└── Test_Feature_090_File_Manager_Additions.php  # NEW
+
+phpunit.xml.dist                               # MODIFIED — add feature-090-unit testsuite
+docs/abilities-inventory.md                    # MODIFIED — bump counts, add four rows
+README.txt                                     # MODIFIED — append bullet under = Unreleased =
+```
+
+**Structure Decision**: Existing plugin layout preserved. All new PHP classes live under `includes/Abilities/FileManager/` with namespace `AcrossAI_Abilities_Manager\Includes\Abilities\FileManager`.
+
+## Complexity Tracking
+
+*None. Constitution Check passed without violations.*

--- a/specs/090-file-manager-additions/quickstart.md
+++ b/specs/090-file-manager-additions/quickstart.md
@@ -1,0 +1,136 @@
+# Quickstart: File-Manager Additions (090)
+
+End-to-end verification for feature 090. Working directory: `/Users/raftaar1191/local-sites/wordpress-7-0/app/public/wp-content/plugins/acrossai-abilities-manager`.
+
+## Prerequisites
+
+- WordPress 6.9+ install at `/Users/raftaar1191/local-sites/wordpress-7-0/app/public`.
+- Plugin activated on that install.
+- WP-CLI available (`wp --info` succeeds).
+- MCP connector `claude.ai acrosai` reachable (for the optional MCP steps).
+
+## Step 1 — Confirm the four new abilities are registered
+
+```bash
+wp ability list --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  | grep -E '^file-manager/(append-file|create-directory|delete-directory|file-info)$'
+```
+
+Expect four rows. Empty output means bootstrap wiring is missing.
+
+## Step 2 — Create a scratch directory tree
+
+```bash
+wp ability call file-manager/create-directory \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/acrossai-test-090/nested/deeper"}'
+```
+
+Expect `{success:true, created:true}`. Repeat the call — expect `{success:true, created:false}`.
+
+## Step 3 — Inspect the new directory
+
+```bash
+wp ability call file-manager/file-info \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/acrossai-test-090/nested"}'
+```
+
+Expect `{success:true, type:"dir", mode_octal:"0755", readable:true, writable:true, ...}`.
+
+## Step 4 — Create a file and append to it
+
+```bash
+wp ability call file-manager/create-file \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/acrossai-test-090/log.txt","content":"line 1\n"}'
+
+wp ability call file-manager/append-file \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/acrossai-test-090/log.txt","content":"line 2\n"}'
+
+wp ability call file-manager/append-file \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/acrossai-test-090/log.txt","content":"line 0\n","prepend":true}'
+
+wp ability call file-manager/read-file \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/acrossai-test-090/log.txt"}'
+```
+
+Expect the last read to return `content:"line 0\nline 1\nline 2\n"`.
+
+## Step 5 — Confirm append-file refuses missing files and protected files
+
+```bash
+wp ability call file-manager/append-file \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/does-not-exist.txt","content":"x"}'
+
+wp ability call file-manager/append-file \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-config.php","content":"x"}'
+```
+
+First call: `{success:false, blocked_reason:"source_not_found"}`. Second call: `{success:false, blocked_reason:"protected_write"}`.
+
+## Step 6 — Delete the scratch tree, recursive-off then recursive-on
+
+```bash
+wp ability call file-manager/delete-directory \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/acrossai-test-090","confirm":true}'
+
+wp ability call file-manager/delete-directory \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/acrossai-test-090","confirm":true,"recursive":true}'
+
+wp ability call file-manager/delete-directory \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/acrossai-test-090","confirm":true,"recursive":true}'
+```
+
+First call: `{success:false, blocked_reason:"not_empty"}` (tree still has files). Second call: `{success:true, entries_removed:N}`. Third call: `{success:true, entries_removed:0}` (idempotent re-run).
+
+## Step 7 — Confirm delete-directory refuses critical paths
+
+```bash
+wp ability call file-manager/delete-directory \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content","confirm":true,"recursive":true}'
+
+wp ability call file-manager/delete-directory \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-admin","confirm":true,"recursive":true}'
+```
+
+Both: `{success:false, blocked_reason:"protected_directory"}`.
+
+## Step 8 — Confirm delete-directory requires confirm:true
+
+```bash
+wp ability call file-manager/delete-directory \
+  --path=/Users/raftaar1191/local-sites/wordpress-7-0/app/public \
+  '{"path":"wp-content/uploads/some-empty-dir"}'
+```
+
+Expect `{success:false, blocked_reason:"confirmation_required"}`.
+
+## Step 9 — MCP live check (optional)
+
+Via the `claude.ai acrosai` connector:
+1. `mcp-adapter-discover-abilities` returns the four new slugs.
+2. Call `file-manager/create-directory` on a fresh path.
+3. Call `file-manager/append-file` on an existing text file.
+4. Call `file-manager/file-info` on any path.
+5. Call `file-manager/delete-directory` with `confirm:true` on the empty dir from step 2.
+
+## Step 10 — Static + unit gates
+
+```bash
+composer test          # PHPUnit — full suite green, +N new tests
+vendor/bin/phpstan analyse  # level 8 clean
+vendor/bin/phpcs             # WPCS clean
+```
+
+All three must pass with zero errors and no delta on the pre-existing warning baseline.

--- a/specs/090-file-manager-additions/research.md
+++ b/specs/090-file-manager-additions/research.md
@@ -1,0 +1,109 @@
+# Research: File-Manager Additions (090)
+
+Phase 0 records the decisions and alternatives evaluated for each of the four new abilities. All NEEDS CLARIFICATION items from the spec are resolved.
+
+## 1. Library evaluation — should we vendor elFinder?
+
+**Decision**: No. Use WordPress core + PHP built-ins.
+
+**Rationale**: The reference plugin `wp-file-manager` (v8.0.4, GPLv2) vendors the full elFinder PHP library at `lib/php/` (multiple 3000+ line volume driver classes). Every operation needed for feature 090 is one WordPress or PHP built-in call:
+- `create-directory` → `wp_mkdir_p($abs)` (WordPress core, recursive-by-default, ABSPATH-friendly).
+- `delete-directory` → `RecursiveIteratorIterator( RecursiveDirectoryIterator, CHILD_FIRST )` + `unlink` / `rmdir` (same idiom feature 089 uses for `list-directory`).
+- `append-file` → `file_put_contents( $abs, $content, FILE_APPEND | LOCK_EX )` (native).
+- `file-info` → `stat($abs)` + `posix_getpwuid` / `posix_getgrgid` when available (native).
+
+Vendoring ~10 MB of volume-abstraction / hash-encoding / caching code for four thin wrappers is disproportionate and would fragment the module's style (peer abilities from feature 089 already use raw PHP through `File_Mods_Guard`).
+
+**Alternatives considered**:
+- Vendor elFinder — rejected on size + coupling grounds.
+- Use `WP_Filesystem` abstraction — rejected on consistency grounds. Peer abilities in `includes/Abilities/FileManager/` all use raw PHP (`file_get_contents`, `file_put_contents`, `copy`, `rename`, `RecursiveDirectoryIterator`). Introducing `WP_Filesystem` here would create two coexisting patterns.
+
+## 2. Reference for elFinder patterns worth mirroring
+
+Even without vendoring, elFinder's local-volume driver contains patterns worth studying:
+- `_stat()` at `lib/php/elFinderVolumeLocalFileSystem.class.php:559` — approach for optional POSIX name resolution guarded by `stat()` support and conditional feature detection.
+- `_inpath()` at the same file:525 — path scoping via `realpath()` + prefix check (matches the pattern we already use in `Read_File.php`).
+- `delTree()` at `lib/php/elFinderVolumeDriver.class.php:4316` — recursive scan + `_unlink` + `_rmdir` bottom-up. Simpler than an iterator but equivalent.
+
+Feature 090 uses the same shapes but expressed via standard-library iterators for concision.
+
+## 3. Path scoping + traversal check
+
+**Decision**: Reuse the `realpath()`-parent check from `Read_File.php:114-123`. Copy the block into each new ability rather than extract a helper.
+
+**Rationale**: Established convention from feature 089 — keeps the guard visible at the point of use, avoids proliferating tiny utility classes, matches how peer abilities read on a code review.
+
+**Alternatives considered**:
+- Extract a `Path_Scope::check(string $rel): string|WP_Error` helper — rejected on the same grounds as feature 089 (the copy is small and per-call visibility is more important than DRY for a security guard).
+
+## 4. Protected-file guard for `append-file`
+
+**Decision**: Duplicate the `PROTECTED_FILES = ['wp-config.php', '.htaccess']` constant plus the basename-at-ABSPATH-root refusal from `Delete_File.php:131-138` into `Append_File.php`.
+
+**Rationale**: Same list, same shape, same rationale as feature 089's hardening of `Create_File` and `Edit_File`. Consistency is the design constraint.
+
+## 5. Protected-directory guard for `delete-directory`
+
+**Decision**: New class constant `PROTECTED_DIRS` on `Delete_Directory.php` listing critical WordPress directories:
+- `ABSPATH` itself
+- `wp-admin`, `wp-includes`
+- `wp-content`, `wp-content/plugins`, `wp-content/themes`, `wp-content/mu-plugins`, `wp-content/uploads`
+- This plugin's own directory: `wp-content/plugins/acrossai-abilities-manager`
+
+Refusal check: compare `realpath($abs)` against `realpath(ABSPATH . <entry>)` for each entry. Refuse with `blocked_reason:'protected_directory'`.
+
+**Rationale**: A recursive `delete-directory` on any of these paths would irreversibly break the site. The list is short and stable enough to hardcode; a filter hook can be added later if a real integrator needs to extend it.
+
+**Alternatives considered**:
+- Filter hook (`acrossai_abilities_manager_protected_dirs`) from day one — rejected as premature abstraction; can be added the moment a third caller requests it.
+- Only refuse `ABSPATH` root and rely on operator judgement for the rest — rejected as too weak; the whole point of the guard is preventing accidental site destruction by an LLM-driven MCP client.
+
+## 6. Recursive-delete implementation
+
+**Decision**: `RecursiveIteratorIterator( new RecursiveDirectoryIterator( $abs, SKIP_DOTS ), RecursiveIteratorIterator::CHILD_FIRST )`. For each entry: skip symlinks, `unlink()` files, `rmdir()` empty directories. Count as we go; if any single `unlink`/`rmdir` fails, capture that entry name, return `success:false` with `entries_removed` set to the partial count.
+
+**Rationale**: Standard PHP idiom, no new deps. `CHILD_FIRST` guarantees files are removed before their parent directory. `SKIP_DOTS` avoids the `.` / `..` self-references. Explicit symlink skip mirrors the same rule feature 089's `list-directory` uses.
+
+**Alternatives considered**:
+- Recursive function that calls `scandir` + `is_dir` + recurse — equivalent behaviour, marginally more code, no clear win.
+- `wp_delete_file` for each file — offers no advantage over `unlink()` for this use case; the WordPress helper adds filter hooks that would fire per-file (potential N-times overhead).
+
+## 7. `file-info` implementation
+
+**Decision**: Single `stat($abs)` for size / mtime / ctime / atime / mode / uid / gid. Booleans via `is_dir`, `is_file`, `is_link`, `is_readable`, `is_writable`. Octal permissions via `substr( decoct( $stat['mode'] ), -4 )`. Owner/group name resolution via `posix_getpwuid( $uid )` / `posix_getgrgid( $gid )` gated behind `function_exists( 'posix_getpwuid' )` — omit the name fields entirely when POSIX is absent (Windows hosts, containers without the extension).
+
+**Rationale**: Read-only, cheap, matches the `elFinder` approach at `_stat()` without the volume-abstraction overhead. Type field is derived at the top of the response: `is_link` first (broken-symlink case), then `is_dir` → `"dir"`, else `"file"`.
+
+## 8. `append-file` implementation
+
+**Decision**:
+- Append path: `file_put_contents( $abs, $content, FILE_APPEND | LOCK_EX )`. Atomic-ish; single system call.
+- Prepend path: `file_get_contents` → `$content . $existing` → `file_put_contents( $abs, $joined, LOCK_EX )`. Not atomic — a concurrent writer between read and write would win. Documented as a caveat in the ability description.
+- File-must-exist guard: `is_file( $abs )` check before either path. If absent, refuse with a message directing the caller to `create-file`.
+- Return `bytes_written` (the delta) and `new_size` (post-op file size for the caller's sanity check).
+
+**Rationale**: Straightforward. `FILE_APPEND | LOCK_EX` is the right primitive for the common (append) case. Prepend is a small ergonomic extra that costs one extra read.
+
+**Alternatives considered**:
+- Support create-if-missing via a `create_if_missing:true` flag — rejected. Muddies the ability's contract. Callers who want that can call `create-file` first.
+- Chunked prepend — rejected as premature optimisation. The ability description warns operators away from prepending to large files.
+
+## 9. Idempotency semantics
+
+**Decision**:
+- `create-directory` returns `success:true, created:true` on first call, `success:true, created:false` on repeat calls when the directory already exists — safe to re-run.
+- `delete-directory` returns `success:true, entries_removed:0, message:"Directory does not exist."` on a missing target — also safe to re-run.
+- `append-file` is not idempotent (each call appends more bytes) — do NOT mark `idempotent:true` in annotations.
+- `file-info` is trivially idempotent.
+
+**Rationale**: Matches user expectation for MCP-driven workflows where the same call may be retried after a transport hiccup.
+
+## 10. Test convention
+
+**Decision**: Structural-inspection tests in `tests/phpunit/abilities/Test_Feature_090_File_Manager_Additions.php`, following the exact pattern from `Test_Feature_089_File_Consolidation.php`. Load the source file as a string; assert on class name, extends clause, ability slug, category slug, capability check, guard invocation, key implementation calls (`FILE_APPEND | LOCK_EX`, `wp_mkdir_p`, `RecursiveIteratorIterator`, `stat()`, `posix_getpwuid` guarded by `function_exists`).
+
+**Rationale**: Established plugin-wide convention. Runtime tests would need a real filesystem sandbox + WordPress test-suite bootstrap that this plugin doesn't currently ship.
+
+## Open questions
+
+None. All FRs and edge cases in `spec.md` have unambiguous implementations.

--- a/specs/090-file-manager-additions/spec.md
+++ b/specs/090-file-manager-additions/spec.md
@@ -1,0 +1,149 @@
+# Feature Specification: File-Manager Additions — Append, mkdir, rmdir, File-Info
+
+**Feature Branch**: `090-file-manager-additions`
+**Created**: 2026-08-25
+**Status**: Draft
+**Input**: Cross-check against `mcp-abilities-filesystem` (see feature-090 planning notes) surfaced four capabilities the consolidated `file-manager/*` surface lacks. Add them as small, focused abilities; skip defense-in-depth hardening (audit log, polyglot PHP scan, .htaccess allowlist) for a later feature.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Append or prepend to an existing file (Priority: P1)
+
+An operator working through an MCP client needs to add a line to `wp-content/debug.log`, a config file, or a helper script without loading and rewriting the entire file. Today they must call `read-file`, concatenate the new content in their own memory, and call `edit-file` to write the whole thing back. That's slow, uses more tokens, and races if the file changes between the two calls.
+
+**Why this priority**: This is the biggest daily papercut with the current surface. Append is the primary need; prepend is a small extra that costs nothing to support.
+
+**Independent Test**: Create a text file at `wp-content/uploads/test-090.txt` containing `"line 1\n"`. Call `file-manager/append-file` with `content: "line 2\n"`. Read the file back — it must contain exactly `"line 1\nline 2\n"`. Call with `prepend:true` and `content: "line 0\n"` — result must be `"line 0\nline 1\nline 2\n"`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the file exists, **When** the operator calls `file-manager/append-file` with a `content` string and no `prepend` flag, **Then** the response is `{success:true, bytes_written: N, new_size: M}` and the file's tail is the new content.
+2. **Given** the file exists, **When** the operator calls with `prepend:true`, **Then** the file's head is the new content and the tail is unchanged.
+3. **Given** the file does not exist, **When** the operator calls `file-manager/append-file`, **Then** the response is `{success:false}` with a message directing the caller to `file-manager/create-file` — this ability MUST NOT auto-create.
+4. **Given** the path resolves to `wp-config.php` or `.htaccess` at ABSPATH root, **When** any append/prepend call is made, **Then** the response returns `{success:false, blocked_reason:"protected_write"}`.
+5. **Given** `DISALLOW_FILE_MODS` is defined truthy, **When** the operator calls the ability, **Then** the response reports the file-mods lockout with the same envelope used by other write abilities.
+
+---
+
+### User Story 2 — Create a directory anywhere under ABSPATH (Priority: P1)
+
+An operator needs to prepare a destination folder before copying files, staging an upload, or scaffolding a plugin. Today the consolidated `file-manager/*` surface has no way to create a directory — the operator has to trigger it by side-effect (e.g., `create-file` with `create_dirs:true`), which is awkward and leaves an unwanted stub file.
+
+**Why this priority**: Standalone directory creation is a primitive that copy/move/upload workflows all depend on. Without it, callers hack around the gap.
+
+**Independent Test**: With no existing directory at `wp-content/uploads/acrossai-test-090/nested/deeper/`, call `file-manager/create-directory` on that path. Response is `{success:true, created:true}`. The directory tree now exists. Call again — response is `{success:true, created:false, message:"Directory already exists."}` (idempotent).
+
+**Acceptance Scenarios**:
+
+1. **Given** the parent directory chain does not exist and `recursive:true` (default), **When** the operator calls the ability, **Then** every missing parent is created and the response returns `{success:true, created:true}`.
+2. **Given** the parent chain does not exist and `recursive:false`, **When** the operator calls the ability, **Then** the response returns `{success:false}` with a message indicating the parent must exist first.
+3. **Given** the target path already exists as a directory, **When** the operator calls the ability, **Then** the response returns `{success:true, created:false}` — safe to re-run.
+4. **Given** the target path exists as a file, **When** the operator calls the ability, **Then** the response returns `{success:false}` with a message identifying the collision.
+5. **Given** the requested path escapes ABSPATH via `..` or a symlink, **When** the operator calls the ability, **Then** the response refuses with an invalid-path error.
+
+---
+
+### User Story 3 — Delete a directory (empty-only by default, opt-in recursive) (Priority: P1)
+
+An operator has just moved the last file out of a scratch directory and needs to remove the empty parent. Or, less often, they need to wipe an entire scratch tree that they created. Today the consolidated `file-manager/*` surface has no directory-delete at all.
+
+**Why this priority**: Symmetric with `create-directory`. Without it, scratch dirs pile up and there's no clean way to reverse a `create-directory` call.
+
+**Independent Test**: Create `wp-content/uploads/acrossai-test-090/scratch/` with one file inside. Call `file-manager/delete-directory` with `confirm:true` — response is `{success:false}` because the directory is not empty. Call with `recursive:true, confirm:true` — response is `{success:true, entries_removed: 2}` (the file + the directory). Call again — response is `{success:true, entries_removed: 0, message:"Directory does not exist."}` (safe re-run).
+
+**Acceptance Scenarios**:
+
+1. **Given** the directory is empty and `confirm:true` is passed, **When** the operator calls the ability, **Then** the directory is removed and the response returns `{success:true, entries_removed:1}`.
+2. **Given** the directory contains entries and `recursive:false` (default), **When** the operator calls the ability with `confirm:true`, **Then** the response returns `{success:false}` with a message identifying the non-empty state.
+3. **Given** the directory contains entries and `recursive:true, confirm:true`, **When** the operator calls the ability, **Then** every entry is removed bottom-up and the response reports the total count via `entries_removed`.
+4. **Given** `confirm:true` is missing or false, **When** the operator calls the ability, **Then** the response refuses with `{success:false, blocked_reason:"confirmation_required"}` — mirrors `file-manager/delete-file`.
+5. **Given** the target path is a critical WordPress directory (`ABSPATH` itself, `wp-admin`, `wp-includes`, `wp-content`, `wp-content/plugins`, `wp-content/themes`, `wp-content/mu-plugins`, `wp-content/uploads`, or this plugin's own directory), **When** the operator calls the ability with `confirm:true, recursive:true`, **Then** the response refuses with `{success:false, blocked_reason:"protected_directory"}`.
+6. **Given** the path resolves outside ABSPATH, **When** the operator calls the ability, **Then** the response refuses with an invalid-path error.
+
+---
+
+### User Story 4 — Inspect a file or directory's metadata (Priority: P1)
+
+An operator wants to know how big a file is, when it was last modified, its mode/permissions, and whether the current process can read/write it — without opening it. Right now the only way to learn this is to call `read-file` (which loads content) or `list-directory` on the parent (which returns every sibling too).
+
+**Why this priority**: Cheap read-only primitive that unlocks smarter workflows (e.g., decide whether to skip an unmodified file, or check writability before attempting an edit). Independent of the three write abilities — could be shipped first as a warm-up.
+
+**Independent Test**: Call `file-manager/file-info` with `path:"wp-content/uploads/acrossai-test-090.txt"` (an existing text file). Response includes `type:"file"`, correct `size`, plausible `mtime`/`ctime`/`atime` (Unix epoch integers), 4-char octal `mode_octal` (e.g., `"0644"`), boolean `readable:true`, and boolean `writable:true`. Call on a directory — `type:"dir"`. Call on a symlink to a file — `is_link:true`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the path resolves to a regular file under ABSPATH, **When** the operator calls the ability, **Then** the response returns the file's stat fields (`type:"file"`, `size`, `mtime`, `ctime`, `atime`, `mode_octal`, `readable`, `writable`, `is_link:false`).
+2. **Given** the path resolves to a directory, **When** the operator calls the ability, **Then** the response returns `type:"dir"` with the same stat fields.
+3. **Given** the path resolves to a symlink and symlinks are followed by default, **When** the operator calls the ability, **Then** the response includes `is_link:true` and the target's stat fields.
+4. **Given** the path does not exist, **When** the operator calls the ability, **Then** the response returns `{success:false}` with a "path not found" message.
+5. **Given** the path escapes ABSPATH via `..` or a symlink, **When** the operator calls the ability, **Then** the response refuses with an invalid-path error.
+6. **Given** the operating system exposes POSIX name-resolution functions (`posix_getpwuid` / `posix_getgrgid`), **When** the operator calls the ability, **Then** the response includes `owner_name` and `group_name` in addition to `owner_uid` and `group_gid`. If POSIX functions are absent, the response omits the name fields.
+
+---
+
+### Edge Cases
+
+- `append-file` is called with an empty `content` string. The response returns `{success:true, bytes_written:0}` — a no-op is not an error.
+- `append-file` is called on a very large existing file with `prepend:true`. The whole file must be loaded and rewritten (documented as a caveat in the ability description); large-file operations may exceed PHP memory limits. Acceptable — the ability is intended for small config/log/text files.
+- `create-directory` is called with `recursive:true` but every intermediate directory already exists. Response returns `{success:true, created:false}` — no error.
+- `delete-directory` is called with a path that is actually a regular file. Response returns `{success:false}` with a message indicating the type mismatch — do NOT silently delete the file.
+- `delete-directory` recursive walk encounters a symlink. The symlink itself is unlinked (removes the reference); the target is never followed.
+- `delete-directory` walk permission-fails on one child. The partial state is reported: `entries_removed` counts what did complete; `success:false` with a message naming the child that blocked.
+- `file-info` is called on a broken symlink (target doesn't exist). Response returns `{success:true, type:"link", is_link:true}` with the size/mtime of the symlink itself, and `readable:false, writable:false`.
+- `file-info` is called on wp-config.php. The response returns the file's stat fields — metadata is not protected the way content is. This is intentional (owner/perms of wp-config.php are visible to anyone with shell access anyway).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Adding the four abilities**
+
+- **FR-001**: The plugin MUST register a new ability that appends or prepends caller-supplied bytes to an existing file under the WordPress installation.
+- **FR-002**: The append/prepend ability MUST default to append; a boolean input opts in to prepend semantics.
+- **FR-003**: The append/prepend ability MUST refuse when the target file does not exist and MUST NOT auto-create.
+- **FR-004**: The plugin MUST register a new ability that creates a directory under the WordPress installation, with a boolean input controlling whether missing parent directories are created (default: yes).
+- **FR-005**: The create-directory ability MUST be idempotent when the target already exists as a directory (returns success with a flag indicating no creation occurred).
+- **FR-006**: The create-directory ability MUST refuse when the target path exists as a file.
+- **FR-007**: The plugin MUST register a new ability that removes a directory under the WordPress installation.
+- **FR-008**: The delete-directory ability MUST default to refusing non-empty directories; a boolean input opts in to recursive deletion.
+- **FR-009**: The delete-directory ability MUST require `confirm:true` (parity with the existing `file-manager/delete-file` ability).
+- **FR-010**: The delete-directory ability MUST refuse a hardcoded list of critical WordPress directories: the installation root, `wp-admin`, `wp-includes`, `wp-content`, `wp-content/plugins`, `wp-content/themes`, `wp-content/mu-plugins`, `wp-content/uploads`, and this plugin's own directory.
+- **FR-011**: The delete-directory ability MUST NOT follow symlinks during recursive walks.
+- **FR-012**: The plugin MUST register a new ability that returns metadata for any file or directory under the WordPress installation (type, size, timestamps, mode/permissions, ownership, readability, writability, symlink flag) without returning the file's content.
+- **FR-013**: The file-info ability MUST include POSIX owner/group name resolution when the operating system provides `posix_getpwuid` / `posix_getgrgid`, and MUST degrade gracefully (omit name fields) when those functions are absent.
+
+**Guards (apply to all four abilities as noted)**
+
+- **FR-014**: Every ability MUST require the `manage_options` capability (parity with existing `file-manager/*` abilities).
+- **FR-015**: Every ability MUST reject any path that resolves outside the WordPress installation root, including paths that reach outside via `..` traversal or symlinks.
+- **FR-016**: The three write-capable abilities (append, create-directory, delete-directory) MUST route through the same file-modification lockout guard used by existing write abilities and refuse when the lockout is active.
+- **FR-017**: The append/prepend ability MUST refuse writes to `wp-config.php` or `.htaccess` at the WordPress installation root, using the same `PROTECTED_FILES` guard shape as existing write abilities.
+- **FR-018**: The response envelope and blocked-reason strings MUST match the conventions used by the existing `file-manager/*` abilities.
+
+**Not in scope for this feature**
+
+- **FR-019**: This feature MUST NOT ship an audit log, backup directory, polyglot PHP content scan, or `.htaccess` directive allowlist. Those may be added by a later feature but are explicitly deferred.
+- **FR-020**: This feature MUST NOT change any existing `file-manager/*` ability's behaviour.
+
+### Key Entities
+
+- **File-manager ability set** — the ability collection under the `file-manager/*` namespace. After this feature it grows from 18 to 22 members. All new members follow the same registration + response conventions as their peers.
+- **Protected directories** — the hardcoded list of critical WordPress directories that `delete-directory` refuses regardless of recursive/confirm inputs. Symmetric to the existing `PROTECTED_FILES` list used by write abilities.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After the release is installed, `wp ability list` returns exactly four new file-manager slugs — `file-manager/append-file`, `file-manager/create-directory`, `file-manager/delete-directory`, `file-manager/file-info` — and every previously-registered ability remains registered unchanged.
+- **SC-002**: An operator can create, append to, inspect, and remove a scratch directory tree under `wp-content/uploads/` using only these four new abilities plus the existing `create-file` / `delete-file` — no unsupported gap remains in the file-management workflow.
+- **SC-003**: No call to any of the four new abilities can write to or delete `wp-config.php`, `.htaccess`, or any of the nine protected directories, regardless of inputs.
+- **SC-004**: The change adds four ability slugs, extends the `file-manager/*` namespace from 18 to 22 members, and preserves every guard convention already used by peer abilities (capability, ABSPATH scoping, protected-target refusal, file-mods lockout, response envelope).
+- **SC-005**: PHPUnit remains fully green after the addition; PHPStan level 8 clean; PHPCS WPCS strict clean; no new warnings on the pre-existing baseline (baseline as of feature 089 merge: 6 warnings, none from feature-089 code).
+
+## Assumptions
+
+- The audience for this feature is the same operators driving the plugin through MCP clients (including Claude) — not a UI change.
+- Symmetry with the existing `file-manager/*` conventions is the primary design constraint. New abilities do not introduce novel shapes or new utility classes.
+- Defense-in-depth extras from `mcp-abilities-filesystem` (audit log, polyglot PHP scan, backup infrastructure, `.htaccess` directive allowlist) are valuable but are explicitly out of scope; they may become feature 091 if evidence justifies them.
+- Large-file prepend is not chunked. Operators are expected to use these abilities on small config / log / text files. The ability description warns about the memory cost of prepend on large inputs.
+- Directory operations use raw PHP built-ins (`wp_mkdir_p`, `mkdir`, `rmdir`, `unlink`, `RecursiveDirectoryIterator`) rather than the `WP_Filesystem` abstraction — consistent with the existing `file-manager/*` abilities which do the same for `read-file`, `create-file`, `edit-file`, `delete-file`, `copy-file`, `move-file`.

--- a/specs/090-file-manager-additions/tasks.md
+++ b/specs/090-file-manager-additions/tasks.md
@@ -1,0 +1,98 @@
+---
+description: "Task list for feature 090 — File-Manager Additions"
+---
+
+# Tasks: File-Manager Additions
+
+**Input**: Design documents from `specs/090-file-manager-additions/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+**Tests**: INCLUDED — Constitution §VII mandates PHPUnit tests for all new logic.
+
+**Organization**: Tasks are grouped by user story. All four stories are P1 and fully independent — each ability can be implemented in isolation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm `composer test`, `vendor/bin/phpstan analyse`, and `vendor/bin/phpcs` all pass on `main` before this feature adds diff. Baseline noted in spec SC-005.
+
+## Phase 2: Foundational
+
+Skip. Reused utilities (`File_Mods_Guard`, `Ability_Definition`, `PROTECTED_FILES` pattern) already exist and were validated by feature 089.
+
+**Checkpoint**: Foundation ready — user story implementation can begin in parallel.
+
+## Phase 3: User Story 4 — File-info (Priority: P1) 🎯 MVP-first pick
+
+**Why first**: Read-only, no `File_Mods_Guard` needed, no protected-file guard, no confirm flag. Smallest surface. Ship it first as a warm-up + smoke-test the module wiring.
+
+- [ ] T010 [P] [US4] Create `includes/Abilities/FileManager/File_Info.php`. Extend `Ability_Definition`. Namespace `AcrossAI_Abilities_Manager\Includes\Abilities\FileManager`. Slug `file-manager/file-info`, category `acrossai-abilities-manager-file-manager`. Ability spec per contract `specs/090-file-manager-additions/contracts/file-manager-file-info.json`. Execute: `manage_options` check → ABSPATH-scope check (mirror `Read_File.php:114-123`) → `path_not_found` if `!file_exists && !is_link` → `stat($abs)` → derive `type` (`is_link` first, else `is_dir` → `"dir"`, else `"file"`) → `mode_octal` = `substr(decoct($stat['mode']), -4)` → conditional POSIX name resolution guarded by `function_exists('posix_getpwuid')` / `posix_getgrgid`. Annotations `readonly:true, idempotent:true`.
+
+**Checkpoint**: US4 complete — file-info registers, gates, returns stat + optional POSIX names.
+
+## Phase 4: User Story 2 — Create-directory (Priority: P1)
+
+- [ ] T020 [P] [US2] Create `includes/Abilities/FileManager/Create_Directory.php`. Extend `Ability_Definition`. Slug `file-manager/create-directory`. Contract: `contracts/file-manager-create-directory.json`. Execute: `manage_options` → `File_Mods_Guard::blocked_response()` → resolve `$abs = base + rel` → parent-must-be-inside-ABSPATH check → if `is_dir($abs)` return `{success:true, created:false, message:"Directory already exists."}` → if `file_exists($abs)` (not dir) return `blocked_reason:'path_is_file'` → if `recursive` → `wp_mkdir_p($abs)`; else → `mkdir($abs)` and if false + parent missing return `blocked_reason:'parent_missing'`. Annotations `readonly:false, destructive:false, idempotent:true`.
+
+**Checkpoint**: US2 complete — create-directory recursive default, idempotent.
+
+## Phase 5: User Story 1 — Append-file (Priority: P1)
+
+- [ ] T030 [P] [US1] Create `includes/Abilities/FileManager/Append_File.php`. Extend `Ability_Definition`. Slug `file-manager/append-file`. Contract: `contracts/file-manager-append-file.json`. Declare `PROTECTED_FILES = ['wp-config.php', '.htaccess']`. Execute: `manage_options` → `File_Mods_Guard::blocked_response()` → sanitize `path` + read `content` (string, `''` valid) + `prepend` bool → ABSPATH-scope check → protected-file refusal (basename at ABSPATH root) → `is_file($abs)` guard, else `blocked_reason:'source_not_found'` → if `prepend` → read existing + concat + `file_put_contents($abs, $joined, LOCK_EX)`; else → `file_put_contents($abs, $content, FILE_APPEND | LOCK_EX)` → report `bytes_written = strlen($content)`, `new_size = filesize($abs)`, `prepended = $prepend`. Annotations `readonly:false, destructive:false, idempotent:false`.
+
+**Checkpoint**: US1 complete — append + prepend, protected-file refusal, file-must-exist.
+
+## Phase 6: User Story 3 — Delete-directory (Priority: P1)
+
+- [ ] T040 [P] [US3] Create `includes/Abilities/FileManager/Delete_Directory.php`. Extend `Ability_Definition`. Slug `file-manager/delete-directory`. Contract: `contracts/file-manager-delete-directory.json`. Declare `PROTECTED_DIRS` constant (nine entries per data-model §6). Execute: `confirm:true` gate first (mirror `Delete_File.php:104-111`) → `File_Mods_Guard::blocked_response()` → sanitize `path` + read `recursive` bool → resolve `$abs` → if `!is_dir($abs)` and `file_exists($abs)` return `blocked_reason:'not_a_directory'`; if not exists return `{success:true, entries_removed:0, message:"Directory does not exist."}` → ABSPATH-scope check → protected-directory refusal (compare `realpath($abs)` against `realpath(ABSPATH . <entry>)` for each `PROTECTED_DIRS` member) → if `!recursive` → `rmdir($abs)`, fail with `blocked_reason:'not_empty'` on failure; if `recursive` → `RecursiveIteratorIterator(new RecursiveDirectoryIterator($abs, RecursiveDirectoryIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST)`, for each entry skip `isLink()`, then `unlink` file / `rmdir` dir, increment `$entries_removed`, capture first failure and return partial `success:false`. Finally `rmdir($abs)` on the top directory, increment on success. Annotations `readonly:false, destructive:true, idempotent:true`.
+
+**Checkpoint**: US3 complete — delete-directory with recursive off default, protected-dirs guard, symlink skip.
+
+## Phase 7: Wiring + Tests + Docs
+
+- [ ] T050 Edit `includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php`. Under the existing `// Feature 089 — consolidated file surface` block, add a `// Feature 090 — directory + append + file-info` block with four lines: `new FileManager\Append_File();`, `new FileManager\Create_Directory();`, `new FileManager\Delete_Directory();`, `new FileManager\File_Info();`.
+- [ ] T051 Create `tests/phpunit/abilities/Test_Feature_090_File_Manager_Additions.php` following the structural-inspection pattern of `Test_Feature_089_File_Consolidation.php`. Cover per-class: exists + extends `Ability_Definition`, slug + category strings present, `current_user_can('manage_options')` regex, guard invocation (`File_Mods_Guard::blocked_response()` in write-capable classes, absent in `File_Info`), key implementation calls (`FILE_APPEND | LOCK_EX`, `wp_mkdir_p`, `mkdir`, `RecursiveIteratorIterator` + `CHILD_FIRST`, `SKIP_DOTS`, `->isLink()`, `stat(`, `function_exists( 'posix_getpwuid' )`, `posix_getgrgid`, `decoct`), `PROTECTED_FILES` / `PROTECTED_DIRS` constant declarations with all expected members. Bootstrap wires all four. Set `$this->plugin_root = dirname( __DIR__, 3 );`.
+- [ ] T052 Edit `phpunit.xml.dist`. Insert after the `feature-089-unit` testsuite block:
+  ```xml
+  <!-- Feature 090 — file-manager small pick. -->
+  <testsuite name="feature-090-unit">
+      <file>tests/phpunit/abilities/Test_Feature_090_File_Manager_Additions.php</file>
+  </testsuite>
+  ```
+- [ ] T053 Edit `docs/abilities-inventory.md`: bump total `385 → 389`; bump `| file-manager/ | 18 |` row to `22`; insert four rows under the file-manager `files` sub-group, alphabetical:
+  - `| file-manager/ | file-manager/append-file | file-manager | files | Append to File |`
+  - `| file-manager/ | file-manager/create-directory | file-manager | files | Create Directory |`
+  - `| file-manager/ | file-manager/delete-directory | file-manager | files | Delete Directory |`
+  - `| file-manager/ | file-manager/file-info | file-manager | files | Get File Info |`
+- [ ] T054 Edit `README.txt`. Under `= Unreleased =`, append a paragraph naming the four new slugs and their intent. Do NOT bump `Stable tag`.
+
+## Phase 8: Gates + Delivery
+
+- [ ] T060 Run `composer test -- --testsuite feature-090-unit` → new suite green. Then `composer test` → full suite green with delta only on new tests + assertions.
+- [ ] T061 Run `vendor/bin/phpstan analyse` → level 8 clean.
+- [ ] T062 Run `vendor/bin/phpcs` on the four new class files + bootstrap + test → WPCS clean.
+- [ ] T063 Execute quickstart steps 1–8 against the local WordPress install.
+- [ ] T064 Commit implementation on branch `090-file-manager-additions`. Push. Open PR via `gh pr create` (per memory: ship via PR, not direct merge to main). Wait for CI green.
+
+## Dependencies
+
+```
+Setup (T001)
+     │
+     ├─→ US4 (T010) ─┐
+     ├─→ US2 (T020) ─┤
+     ├─→ US1 (T030) ─┤
+     └─→ US3 (T040) ─┴─→ Wiring (T050-T054) ─→ Gates + Delivery (T060-T064)
+```
+
+The four abilities are fully independent. Wiring / tests / docs consolidate them. Gates finalise.
+
+## Implementation Strategy
+
+**MVP scope**: any single one of US1–US4 is a viable increment. US4 (file-info) is the smallest and safest — ship it first if breaking the feature into multiple PRs. If shipping as one PR (recommended for this feature — 4 small classes, one CI run), all four together.
+
+## Parallel Execution
+
+- T010, T020, T030, T040 are independent — different files. Can be authored simultaneously.
+- Wiring tasks T050–T054 depend on all four class files existing.
+- Gates run after wiring.

--- a/tests/phpunit/abilities/Test_Feature_090_File_Manager_Additions.php
+++ b/tests/phpunit/abilities/Test_Feature_090_File_Manager_Additions.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Structural tests for Feature 090 — file-manager additions.
+ *
+ * Verifies (a) the four new ability classes are in place with the expected
+ * slugs, categories, capability checks, and guards; (b) File_Info is
+ * read-only and does NOT route through File_Mods_Guard; (c) Append_File
+ * declares the PROTECTED_FILES constant used by peers; (d) Delete_Directory
+ * declares PROTECTED_DIRS and requires confirm:true; (e) the bootstrap
+ * wires all four abilities.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Feature_090_File_Manager_Additions.
+ */
+class Test_Feature_090_File_Manager_Additions extends WP_UnitTestCase {
+
+	/** @var string */
+	private string $plugin_root = '';
+
+	/** @var array<string,string> Cached file contents keyed by slot name. */
+	private array $files = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->plugin_root = dirname( __DIR__, 3 );
+
+		foreach (
+			array(
+				'append_file'      => 'includes/Abilities/FileManager/Append_File.php',
+				'create_directory' => 'includes/Abilities/FileManager/Create_Directory.php',
+				'delete_directory' => 'includes/Abilities/FileManager/Delete_Directory.php',
+				'file_info'        => 'includes/Abilities/FileManager/File_Info.php',
+				'bootstrap'        => 'includes/Abilities/AcrossAI_Core_Abilities_Bootstrap.php',
+			) as $key => $rel
+		) {
+			$this->files[ $key ] = (string) file_get_contents( $this->plugin_root . '/' . $rel );
+		}
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* Append_File                                                           */
+	/* -------------------------------------------------------------------- */
+
+	public function test_append_file_class_exists_and_extends_ability_definition(): void {
+		$this->assertFileExists( $this->plugin_root . '/includes/Abilities/FileManager/Append_File.php' );
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->files['append_file'] );
+	}
+
+	public function test_append_file_uses_expected_slug_and_category(): void {
+		$this->assertStringContainsString( "'file-manager/append-file'", $this->files['append_file'] );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-file-manager'", $this->files['append_file'] );
+	}
+
+	public function test_append_file_gates_on_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\\(\\s*'manage_options'\\s*\\)/",
+			$this->files['append_file']
+		);
+	}
+
+	public function test_append_file_declares_protected_files_constant(): void {
+		$this->assertStringContainsString( 'private const PROTECTED_FILES', $this->files['append_file'] );
+		$this->assertStringContainsString( "'wp-config.php'", $this->files['append_file'] );
+		$this->assertStringContainsString( "'.htaccess'", $this->files['append_file'] );
+	}
+
+	public function test_append_file_routes_through_file_mods_guard(): void {
+		$this->assertStringContainsString( 'File_Mods_Guard::blocked_response()', $this->files['append_file'] );
+	}
+
+	public function test_append_file_uses_file_append_and_lock_ex(): void {
+		$this->assertStringContainsString( 'FILE_APPEND | LOCK_EX', $this->files['append_file'] );
+	}
+
+	public function test_append_file_refuses_missing_source(): void {
+		$this->assertStringContainsString( "'blocked_reason' => 'source_not_found'", $this->files['append_file'] );
+	}
+
+	public function test_append_file_refuses_protected_target(): void {
+		$this->assertStringContainsString( "'blocked_reason' => 'protected_write'", $this->files['append_file'] );
+	}
+
+	public function test_append_file_annotations_are_not_readonly_and_not_idempotent(): void {
+		$this->assertMatchesRegularExpression(
+			"/'readonly'\\s*=>\\s*false[^)]*'destructive'\\s*=>\\s*false[^)]*'idempotent'\\s*=>\\s*false/s",
+			$this->files['append_file']
+		);
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* Create_Directory                                                      */
+	/* -------------------------------------------------------------------- */
+
+	public function test_create_directory_class_exists_and_extends_ability_definition(): void {
+		$this->assertFileExists( $this->plugin_root . '/includes/Abilities/FileManager/Create_Directory.php' );
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->files['create_directory'] );
+	}
+
+	public function test_create_directory_uses_expected_slug_and_category(): void {
+		$this->assertStringContainsString( "'file-manager/create-directory'", $this->files['create_directory'] );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-file-manager'", $this->files['create_directory'] );
+	}
+
+	public function test_create_directory_gates_on_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\\(\\s*'manage_options'\\s*\\)/",
+			$this->files['create_directory']
+		);
+	}
+
+	public function test_create_directory_routes_through_file_mods_guard(): void {
+		$this->assertStringContainsString( 'File_Mods_Guard::blocked_response()', $this->files['create_directory'] );
+	}
+
+	public function test_create_directory_uses_wp_mkdir_p_for_recursive_path(): void {
+		$this->assertStringContainsString( 'wp_mkdir_p( $abs )', $this->files['create_directory'] );
+	}
+
+	public function test_create_directory_uses_mkdir_for_non_recursive_path(): void {
+		$this->assertMatchesRegularExpression(
+			"/mkdir\\(\\s*\\\$abs\\s*\\)/",
+			$this->files['create_directory']
+		);
+	}
+
+	public function test_create_directory_reports_created_false_when_already_exists(): void {
+		$this->assertStringContainsString( "'created' => false", $this->files['create_directory'] );
+	}
+
+	public function test_create_directory_refuses_path_that_is_a_file(): void {
+		$this->assertStringContainsString( "'blocked_reason' => 'path_is_file'", $this->files['create_directory'] );
+	}
+
+	public function test_create_directory_annotations_are_idempotent_non_destructive(): void {
+		$this->assertMatchesRegularExpression(
+			"/'readonly'\\s*=>\\s*false[^)]*'destructive'\\s*=>\\s*false[^)]*'idempotent'\\s*=>\\s*true/s",
+			$this->files['create_directory']
+		);
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* Delete_Directory                                                      */
+	/* -------------------------------------------------------------------- */
+
+	public function test_delete_directory_class_exists_and_extends_ability_definition(): void {
+		$this->assertFileExists( $this->plugin_root . '/includes/Abilities/FileManager/Delete_Directory.php' );
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->files['delete_directory'] );
+	}
+
+	public function test_delete_directory_uses_expected_slug_and_category(): void {
+		$this->assertStringContainsString( "'file-manager/delete-directory'", $this->files['delete_directory'] );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-file-manager'", $this->files['delete_directory'] );
+	}
+
+	public function test_delete_directory_gates_on_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\\(\\s*'manage_options'\\s*\\)/",
+			$this->files['delete_directory']
+		);
+	}
+
+	public function test_delete_directory_requires_confirm_true(): void {
+		$this->assertStringContainsString( "'blocked_reason' => 'confirmation_required'", $this->files['delete_directory'] );
+	}
+
+	public function test_delete_directory_routes_through_file_mods_guard(): void {
+		$this->assertStringContainsString( 'File_Mods_Guard::blocked_response()', $this->files['delete_directory'] );
+	}
+
+	public function test_delete_directory_declares_protected_dirs_constant(): void {
+		$this->assertStringContainsString( 'private const PROTECTED_DIRS', $this->files['delete_directory'] );
+		foreach (
+			array(
+				"''",
+				"'wp-admin'",
+				"'wp-includes'",
+				"'wp-content'",
+				"'wp-content/plugins'",
+				"'wp-content/themes'",
+				"'wp-content/mu-plugins'",
+				"'wp-content/uploads'",
+				"'wp-content/plugins/acrossai-abilities-manager'",
+			) as $needle
+		) {
+			$this->assertStringContainsString(
+				$needle,
+				$this->files['delete_directory'],
+				"PROTECTED_DIRS must include $needle"
+			);
+		}
+	}
+
+	public function test_delete_directory_refuses_protected_directory(): void {
+		$this->assertStringContainsString( "'blocked_reason' => 'protected_directory'", $this->files['delete_directory'] );
+	}
+
+	public function test_delete_directory_uses_recursive_iterator_with_child_first(): void {
+		$this->assertStringContainsString( 'RecursiveIteratorIterator::CHILD_FIRST', $this->files['delete_directory'] );
+		$this->assertStringContainsString( 'RecursiveDirectoryIterator::SKIP_DOTS', $this->files['delete_directory'] );
+	}
+
+	public function test_delete_directory_skips_symlinks(): void {
+		$this->assertStringContainsString( '->isLink()', $this->files['delete_directory'] );
+	}
+
+	public function test_delete_directory_reports_partial_entries_on_failure(): void {
+		$this->assertStringContainsString( "'entries_removed' => \$entries_removed", $this->files['delete_directory'] );
+	}
+
+	public function test_delete_directory_annotations_are_destructive_idempotent(): void {
+		$this->assertMatchesRegularExpression(
+			"/'readonly'\\s*=>\\s*false[^)]*'destructive'\\s*=>\\s*true[^)]*'idempotent'\\s*=>\\s*true/s",
+			$this->files['delete_directory']
+		);
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* File_Info                                                             */
+	/* -------------------------------------------------------------------- */
+
+	public function test_file_info_class_exists_and_extends_ability_definition(): void {
+		$this->assertFileExists( $this->plugin_root . '/includes/Abilities/FileManager/File_Info.php' );
+		$this->assertStringContainsString( 'extends Ability_Definition', $this->files['file_info'] );
+	}
+
+	public function test_file_info_uses_expected_slug_and_category(): void {
+		$this->assertStringContainsString( "'file-manager/file-info'", $this->files['file_info'] );
+		$this->assertStringContainsString( "'acrossai-abilities-manager-file-manager'", $this->files['file_info'] );
+	}
+
+	public function test_file_info_gates_on_manage_options(): void {
+		$this->assertMatchesRegularExpression(
+			"/current_user_can\\(\\s*'manage_options'\\s*\\)/",
+			$this->files['file_info']
+		);
+	}
+
+	public function test_file_info_does_not_route_through_file_mods_guard(): void {
+		$this->assertStringNotContainsString( 'File_Mods_Guard', $this->files['file_info'] );
+	}
+
+	public function test_file_info_calls_native_stat(): void {
+		$this->assertMatchesRegularExpression(
+			"/stat\\(\\s*\\\$candidate\\s*\\)/",
+			$this->files['file_info']
+		);
+	}
+
+	public function test_file_info_derives_octal_mode_from_stat(): void {
+		$this->assertStringContainsString( 'decoct(', $this->files['file_info'] );
+	}
+
+	public function test_file_info_guards_posix_functions_behind_function_exists(): void {
+		$this->assertMatchesRegularExpression(
+			"/function_exists\\(\\s*'posix_getpwuid'\\s*\\)/",
+			$this->files['file_info']
+		);
+		$this->assertMatchesRegularExpression(
+			"/function_exists\\(\\s*'posix_getgrgid'\\s*\\)/",
+			$this->files['file_info']
+		);
+	}
+
+	public function test_file_info_refuses_missing_path(): void {
+		$this->assertStringContainsString( "'blocked_reason' => 'path_not_found'", $this->files['file_info'] );
+	}
+
+	public function test_file_info_annotations_are_readonly_idempotent(): void {
+		$this->assertMatchesRegularExpression(
+			"/'readonly'\\s*=>\\s*true[^)]*'destructive'\\s*=>\\s*false[^)]*'idempotent'\\s*=>\\s*true/s",
+			$this->files['file_info']
+		);
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* Bootstrap wiring                                                      */
+	/* -------------------------------------------------------------------- */
+
+	public function test_bootstrap_wires_all_four_new_abilities(): void {
+		$this->assertStringContainsString( 'new FileManager\\Append_File()', $this->files['bootstrap'] );
+		$this->assertStringContainsString( 'new FileManager\\Create_Directory()', $this->files['bootstrap'] );
+		$this->assertStringContainsString( 'new FileManager\\Delete_Directory()', $this->files['bootstrap'] );
+		$this->assertStringContainsString( 'new FileManager\\File_Info()', $this->files['bootstrap'] );
+	}
+}


### PR DESCRIPTION
## Summary

Four new abilities extend the consolidated `file-manager/*` surface (from feature 089) with directory management and metadata primitives identified during the cross-check of the standalone `mcp-abilities-filesystem` plugin. `wp-file-manager` (elFinder) was evaluated for reuse and rejected — 10 MB of volume-abstraction overhead for four thin wrappers. All four use WordPress core / PHP built-ins consistent with peer implementations.

## Added

| Slug | What it does |
|---|---|
| \`file-manager/append-file\` | Append (default) or prepend bytes to an existing file. `FILE_APPEND \| LOCK_EX` for append; read+concat+rewrite for prepend (documented non-atomic). Refuses missing files (use `create-file`) and refuses `wp-config.php` / `.htaccess`. |
| \`file-manager/create-directory\` | Recursive-by-default `mkdir` under ABSPATH. Idempotent when the target exists as a directory. Refuses when the path exists as a file. `wp_mkdir_p` on the recursive path, `mkdir` on the non-recursive path. |
| \`file-manager/delete-directory\` | Empty-only by default; opt-in `recursive:true`. Requires `confirm:true` (parity with `delete-file`). Refuses a hardcoded list of nine critical WordPress directories. `RecursiveIteratorIterator` with `CHILD_FIRST` + `SKIP_DOTS`; symlinks are unlinked, never followed. |
| \`file-manager/file-info\` | Read-only stat wrapper: type, size, mtime/ctime/atime, `mode_octal`, owner uid+name, group gid+name, readable, writable, is_link. POSIX name resolution guarded by `function_exists()` — omitted on hosts without the extension. |

## Rejected / kept as-is

- **elFinder / wp-file-manager**: too heavy for our needs. See `specs/090-file-manager-additions/research.md` §1.
- **Version bump**: kept at `0.0.30` per your directive from feature 089 (bump on release, not per-feature).
- **Defense-in-depth hardening from mcp-abilities-filesystem** (audit log, polyglot PHP scan, .htaccess directive allowlist): explicitly deferred. See `spec.md` FR-019.

## Spec-kit artifacts

- \`specs/090-file-manager-additions/spec.md\` — 4 P1 user stories, 20 FRs, 5 SCs
- \`specs/090-file-manager-additions/plan.md\` — Constitution gate pass
- \`specs/090-file-manager-additions/research.md\` — elFinder rejection, decisions, alternatives
- \`specs/090-file-manager-additions/data-model.md\` — response envelopes, guard constants
- \`specs/090-file-manager-additions/contracts/\` — JSON schemas for all four
- \`specs/090-file-manager-additions/quickstart.md\` — WP-CLI + MCP verification
- \`specs/090-file-manager-additions/tasks.md\` — dependency-ordered task list

## Test plan

- [x] PHPUnit full suite: 1731 tests green (+39 vs baseline, +0 warnings)
- [x] Feature 090 suite: \`composer test -- --testsuite feature-090-unit\` → 39 tests, 63 assertions
- [x] PHPStan level 8 clean
- [x] PHPCS WPCS strict clean
- [ ] Manual: run \`specs/090-file-manager-additions/quickstart.md\` steps 1–8 on a local WP install
- [ ] Manual: MCP connector live check (quickstart step 9) via \`claude.ai acrosai\`

## Migration

None — this feature is purely additive. Nothing is removed or renamed. Existing MCP clients keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)