### PR TITLE
fix(file-manager): honour DISALLOW_FILE_MODS in create-zip-backup

### DIFF
--- a/includes/Abilities/FileManager/Create_Zip_Backup.php
+++ b/includes/Abilities/FileManager/Create_Zip_Backup.php
@@ -17,6 +17,7 @@ namespace AcrossAI_Abilities_Manager\Includes\Abilities\FileManager;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
 use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Backups_Storage;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\File_Mods_Guard;
 use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Zip_Target_Resolver;
 
 defined( 'ABSPATH' ) || exit;
@@ -109,6 +110,17 @@ class Create_Zip_Backup extends Ability_Definition {
 	 * @return array
 	 */
 	public function execute( array $input = array() ): array {
+		// Honour DISALLOW_FILE_MODS the same way every other write-side
+		// file-manager ability does. 'install' context (matches the other
+		// zip-related abilities: Upload_Zip_Backup, Extract_Zip_Backup,
+		// Delete_Zip_Backup) — checks DISALLOW_FILE_MODS only, not
+		// DISALLOW_FILE_EDIT, since creating a backup is not in-place
+		// theme/plugin editing.
+		$blocked = File_Mods_Guard::blocked_response( 'install' );
+		if ( null !== $blocked ) {
+			return $blocked;
+		}
+
 		if ( ! class_exists( '\ZipArchive' ) ) {
 			return array(
 				'success' => false,


### PR DESCRIPTION
## Summary

\`file-manager/create-zip-backup\` was the only write-side file-manager ability that did not call \`File_Mods_Guard\`. On a site with \`DISALLOW_FILE_MODS\` defined, this ability would still produce backup archives — a small but real consistency gap.

Every peer already honours the constant:

| Ability | Context |
|---|---|
| \`file-manager/upload-zip-backup\` | \`install\` |
| \`file-manager/extract-zip-backup\` | \`install\` |
| \`file-manager/delete-zip-backup\` | \`install\` |
| \`file-manager/create-zip-backup\` | ❌ **missing → this PR adds it as \`install\`** |

## Change

One \`use\` statement + one guard call at the top of \`execute()\`. Same shape as the other three zip abilities.

- Context is \`install\` (not \`edit\`) because creating a backup is not in-place theme/plugin editing.
- Runs before the \`ZipArchive\` extension check, source resolver, and size estimator — so a site with the constant set gets the expected refusal without hitting downstream work.

## Verified

- PHPUnit 1806/1806 pass
- PHPCS clean
- PHPStan clean
- Live-probed on wordpress-7-0.local: \`create-zip-backup\` still produces a backup zip when \`DISALLOW_FILE_MODS\` is undefined (happy path unchanged)

## Context

This is **item 19** from the reference-plugin gap analysis. The other content-filter / audit-log items land in the follow-up specs 093 + 094; this one was a genuine one-line consistency fix that didn't need a spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)