### PR TITLE
test(094): behavioural coverage parity with the live MCP smoke matrix

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -628,6 +628,173 @@ if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
 	define( 'HOUR_IN_SECONDS', 60 * 60 );
 }
 
+if ( ! function_exists( 'wp_unslash' ) ) {
+	/** Feature 094 stub — strips leading slashes WP core adds via magic-quotes. */
+	function wp_unslash( $value ) {
+		if ( is_string( $value ) ) {
+			return stripslashes( $value );
+		}
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_mkdir_p' ) ) {
+	/**
+	 * Feature 094 stub — recursive mkdir with mode 0755. Returns true on
+	 * success (or if the directory already exists), false on failure.
+	 */
+	function wp_mkdir_p( string $target ): bool {
+		if ( is_dir( $target ) ) {
+			return true;
+		}
+		return @mkdir( $target, 0755, true ) || is_dir( $target );
+	}
+}
+
+if ( ! function_exists( 'wp_delete_file' ) ) {
+	/** Feature 094 stub — native unlink wrapped. */
+	function wp_delete_file( string $file ): void {
+		if ( is_file( $file ) ) {
+			@unlink( $file );
+		}
+	}
+}
+
+if ( ! function_exists( 'wp_get_current_user' ) ) {
+	/**
+	 * Feature 094 stub — returns a fake current user with the fields
+	 * Audit_Trail reads (user_email, ID). Tests can override by seeding
+	 * $__acrossai_test_current_user before invoking the SUT.
+	 */
+	function wp_get_current_user(): object {
+		global $__acrossai_test_current_user;
+		if ( is_object( $__acrossai_test_current_user ) ) {
+			return $__acrossai_test_current_user;
+		}
+		return (object) array( 'ID' => 0, 'user_email' => '' );
+	}
+}
+
+if ( ! class_exists( 'WP_Filesystem_Base' ) ) {
+	/**
+	 * Feature 094 stub — minimal abstract for `instanceof` checks the
+	 * plugin's Wp_Filesystem_Init::get() uses. The concrete
+	 * Test_Fake_WP_Filesystem below is the actual test-time transport.
+	 */
+	abstract class WP_Filesystem_Base {}
+}
+
+if ( ! class_exists( 'Test_Fake_WP_Filesystem' ) ) {
+	/**
+	 * Native-PHP-backed WP_Filesystem shim for behavioural tests. Implements
+	 * the subset of the WP_Filesystem interface that Audit_Trail and the
+	 * ability classes actually call. Tests seed $wp_filesystem with an
+	 * instance of this before calling the SUT — Wp_Filesystem_Init::get()
+	 * then short-circuits at its `instanceof` check.
+	 */
+	// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound -- test helper co-located with WP shims
+	class Test_Fake_WP_Filesystem extends WP_Filesystem_Base {
+		public function exists( string $file ): bool {
+			return file_exists( $file );
+		}
+		public function is_file( string $file ): bool {
+			return is_file( $file );
+		}
+		public function is_dir( string $path ): bool {
+			return is_dir( $path );
+		}
+		public function size( string $file ) {
+			return is_file( $file ) ? filesize( $file ) : 0;
+		}
+		public function get_contents( string $file ) {
+			return is_file( $file ) ? file_get_contents( $file ) : false;
+		}
+		public function put_contents( string $file, string $contents, $mode = false ): bool {
+			$ok = false !== file_put_contents( $file, $contents );
+			if ( $ok && is_int( $mode ) ) {
+				@chmod( $file, $mode );
+			}
+			return $ok;
+		}
+		public function copy( string $source, string $destination, $overwrite = false, $mode = false ): bool {
+			if ( ! $overwrite && file_exists( $destination ) ) {
+				return false;
+			}
+			$ok = copy( $source, $destination );
+			if ( $ok && is_int( $mode ) ) {
+				@chmod( $destination, $mode );
+			}
+			return $ok;
+		}
+		public function mkdir( string $path, $chmod = false, $chown = false, $chgrp = false ): bool {
+			return @mkdir( $path, is_int( $chmod ) ? $chmod : 0755, true );
+		}
+		public function rmdir( string $path, bool $recursive = false ): bool {
+			if ( ! is_dir( $path ) ) {
+				return false;
+			}
+			if ( $recursive ) {
+				$iter = new \RecursiveIteratorIterator(
+					new \RecursiveDirectoryIterator( $path, \FilesystemIterator::SKIP_DOTS ),
+					\RecursiveIteratorIterator::CHILD_FIRST
+				);
+				foreach ( $iter as $entry ) {
+					if ( $entry->isDir() ) {
+						@rmdir( $entry->getPathname() );
+					} else {
+						@unlink( $entry->getPathname() );
+					}
+				}
+			}
+			return @rmdir( $path );
+		}
+		public function delete( string $file, bool $recursive = false, $type = false ): bool {
+			if ( is_dir( $file ) ) {
+				return $this->rmdir( $file, $recursive );
+			}
+			return @unlink( $file );
+		}
+		public function dirlist( string $path, bool $include_hidden = true, bool $recursive = false ): array {
+			if ( ! is_dir( $path ) ) {
+				return array();
+			}
+			$out     = array();
+			$entries = @scandir( $path );
+			foreach ( (array) $entries as $name ) {
+				if ( '.' === $name || '..' === $name ) {
+					continue;
+				}
+				if ( ! $include_hidden && '.' === $name[0] ) {
+					continue;
+				}
+				$full     = $path . DIRECTORY_SEPARATOR . $name;
+				$out[ $name ] = array(
+					'name' => $name,
+					'type' => is_dir( $full ) ? 'd' : 'f',
+					'size' => is_file( $full ) ? filesize( $full ) : 0,
+				);
+			}
+			return $out;
+		}
+	}
+}
+
+if ( ! defined( 'FS_CHMOD_FILE' ) ) {
+	define( 'FS_CHMOD_FILE', 0644 );
+}
+if ( ! defined( 'FS_CHMOD_DIR' ) ) {
+	define( 'FS_CHMOD_DIR', 0755 );
+}
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	// Point tests' WP_CONTENT_DIR into a unique temp workspace so
+	// Audit_Trail's real backup + log paths land inside the test sandbox.
+	// A single per-test-run dir keeps the ability × trail matrix consistent.
+	define( 'WP_CONTENT_DIR', sys_get_temp_dir() . '/acrossai-094-tests-' . getmypid() );
+	if ( ! is_dir( WP_CONTENT_DIR ) ) {
+		mkdir( WP_CONTENT_DIR, 0777, true );
+	}
+}
+
 if ( ! class_exists( 'WP_UnitTestCase' ) ) {
 	/**
 	 * Alias: in unit-only mode WP_UnitTestCase is a plain PHPUnit TestCase.

--- a/tests/phpunit/abilities/Test_Feature_094_Audit_Log_And_Backups.php
+++ b/tests/phpunit/abilities/Test_Feature_094_Audit_Log_And_Backups.php
@@ -36,14 +36,50 @@ class Test_Feature_094_Audit_Log_And_Backups extends WP_UnitTestCase {
 		parent::setUp();
 		$this->plugin_root = dirname( __DIR__, 3 );
 
-		global $__acrossai_test_options;
-		$__acrossai_test_options = array();
+		global $__acrossai_test_options, $wp_filesystem, $__acrossai_test_current_user;
+		$__acrossai_test_options       = array();
+		$wp_filesystem                 = new \Test_Fake_WP_Filesystem();
+		$__acrossai_test_current_user  = (object) array( 'ID' => 42, 'user_email' => 'phpunit@acrossai.test' );
+		$_SERVER['REMOTE_ADDR']        = '127.0.0.1';
+
+		// Fully wipe the test-time WP_CONTENT_DIR between tests so each case
+		// starts from a clean disk. The bootstrap points WP_CONTENT_DIR into
+		// a per-PID temp workspace, so this rm-rf can never touch real data.
+		$this->purge_dir( Audit_Trail::backup_base_dir() );
+		$this->purge_dir( Audit_Trail::log_dir() );
 	}
 
 	protected function tearDown(): void {
-		global $__acrossai_test_options;
-		$__acrossai_test_options = array();
+		global $__acrossai_test_options, $wp_filesystem, $__acrossai_test_current_user;
+		$this->purge_dir( Audit_Trail::backup_base_dir() );
+		$this->purge_dir( Audit_Trail::log_dir() );
+		$__acrossai_test_options      = array();
+		$wp_filesystem                = null;
+		$__acrossai_test_current_user = null;
 		parent::tearDown();
+	}
+
+	private function purge_dir( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		$iter = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $iter as $entry ) {
+			if ( $entry->isDir() ) {
+				@rmdir( $entry->getPathname() );
+			} else {
+				@unlink( $entry->getPathname() );
+			}
+		}
+		@rmdir( $dir );
+	}
+
+	private function seed_toggles( bool $backup, bool $log ): void {
+		update_option( Hardening_Settings::OPTION_BACKUP_ENABLED, $backup );
+		update_option( Hardening_Settings::OPTION_AUDIT_LOG_ENABLED, $log );
 	}
 
 	private function read_source( string $rel ): string {
@@ -420,5 +456,344 @@ class Test_Feature_094_Audit_Log_And_Backups extends WP_UnitTestCase {
 				"{$file} input_schema must declare context:{type:string, maxLength:2000}"
 			);
 		}
+	}
+
+	/* ==================================================================== */
+	/* Behavioural — full-loop over the Test_Fake_WP_Filesystem shim         */
+	/* ==================================================================== */
+	/* Mirrors the live MCP smoke test recorded in the session: enables the
+	 * toggles, fires each Audit_Trail entrypoint against real files in a
+	 * temp workspace, asserts on-disk state + parsed log entries. Every one
+	 * of the 10 operation labels the ability classes emit is exercised. */
+
+	private function tmp_source( string $basename, string $content ): string {
+		$dir = WP_CONTENT_DIR . '/uploads';
+		if ( ! is_dir( $dir ) ) {
+			mkdir( $dir, 0755, true );
+		}
+		$path = $dir . '/' . $basename;
+		file_put_contents( $path, $content );
+		return $path;
+	}
+
+	private function log_contents(): string {
+		$log = Audit_Trail::log_path();
+		return is_file( $log ) ? (string) file_get_contents( $log ) : '';
+	}
+
+	private function log_entries(): array {
+		$blocks = preg_split( '/\n{2,}/', trim( $this->log_contents() ) );
+		return array_values( array_filter( (array) $blocks, static fn( string $b ): bool => '' !== trim( $b ) ) );
+	}
+
+	public function test_backup_writer_creates_dated_dir_and_htaccess(): void {
+		$this->seed_toggles( true, false );
+		$src = $this->tmp_source( 'backup-me.txt', 'the pre-image' );
+
+		$result = Audit_Trail::write_backup( $src );
+		$this->assertIsString( $result );
+		$this->assertFileExists( $result );
+		$this->assertSame( 'the pre-image', file_get_contents( $result ) );
+		$this->assertStringContainsString( gmdate( 'Y-m-d' ), $result );
+		$this->assertStringContainsString( '.bak.', $result );
+
+		// .htaccess guard on the backup base dir.
+		$htaccess = Audit_Trail::backup_base_dir() . '/.htaccess';
+		$this->assertFileExists( $htaccess );
+		$this->assertStringContainsString( 'Deny from all', (string) file_get_contents( $htaccess ) );
+	}
+
+	public function test_backup_writer_returns_null_when_target_missing(): void {
+		$this->seed_toggles( true, false );
+		$this->assertNull( Audit_Trail::write_backup( WP_CONTENT_DIR . '/uploads/nothing-here.txt' ) );
+	}
+
+	public function test_backup_writer_returns_null_when_disabled(): void {
+		$this->seed_toggles( false, false );
+		$src = $this->tmp_source( 'still-here.txt', 'x' );
+		$this->assertNull( Audit_Trail::write_backup( $src ) );
+	}
+
+	public function test_backup_collision_produces_counter_suffix(): void {
+		$this->seed_toggles( true, false );
+		$src = $this->tmp_source( 'same-second.txt', 'x' );
+
+		$a = Audit_Trail::write_backup( $src );
+		$b = Audit_Trail::write_backup( $src );
+		$c = Audit_Trail::write_backup( $src );
+
+		$this->assertIsString( $a );
+		$this->assertIsString( $b );
+		$this->assertIsString( $c );
+		$this->assertNotSame( $a, $b );
+		$this->assertNotSame( $b, $c );
+		// b and c should carry .1 / .2 counter suffixes.
+		$this->assertMatchesRegularExpression( '/\.bak\.\d{6}(\.\d+)?$/', $b );
+	}
+
+	public function test_log_writer_creates_dir_htaccess_and_wellformed_entry(): void {
+		$this->seed_toggles( false, true );
+
+		Audit_Trail::write_log(
+			'EDIT',
+			'/abs/path/foo.txt',
+			array(
+				'ability_slug'  => 'file-manager/edit-file',
+				'size_before'   => 100,
+				'size_after'    => 250,
+				'backup_status' => 'disabled',
+				'context'       => 'phpunit-behavioural',
+			)
+		);
+
+		// .htaccess guard on the log dir.
+		$this->assertFileExists( Audit_Trail::log_dir() . '/.htaccess' );
+
+		$log = $this->log_contents();
+		$this->assertNotSame( '', $log );
+		$this->assertMatchesRegularExpression( '/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC\] EDIT$/m', $log );
+		$this->assertStringContainsString( '  Ability: file-manager/edit-file', $log );
+		$this->assertStringContainsString( '  File: /abs/path/foo.txt', $log );
+		$this->assertStringContainsString( '  User: phpunit@acrossai.test (ID:42) IP:127.0.0.1', $log );
+		$this->assertStringContainsString( '  Size: 100 -> 250 bytes', $log );
+		$this->assertStringContainsString( '  Backup: DISABLED', $log );
+		$this->assertStringContainsString( '  Context: phpunit-behavioural', $log );
+	}
+
+	public function test_log_noop_when_disabled(): void {
+		$this->seed_toggles( false, false );
+		Audit_Trail::write_log( 'DELETE', '/abs/path/x', array( 'ability_slug' => 'file-manager/delete-file' ) );
+		$this->assertSame( '', $this->log_contents() );
+		$this->assertFileDoesNotExist( Audit_Trail::log_path() );
+	}
+
+	public function test_log_context_truncates_at_500_chars(): void {
+		$this->seed_toggles( false, true );
+		Audit_Trail::write_log(
+			'CREATE',
+			'/abs/path/x',
+			array( 'ability_slug' => 'file-manager/create-file', 'context' => str_repeat( 'a', 800 ) )
+		);
+		$log = $this->log_contents();
+		$this->assertStringContainsString( 'Context: ' . str_repeat( 'a', 500 ), $log );
+		$this->assertStringNotContainsString( 'Context: ' . str_repeat( 'a', 501 ), $log );
+	}
+
+	public function test_log_context_sanitises_tags_and_control_chars(): void {
+		$this->seed_toggles( false, true );
+		Audit_Trail::write_log(
+			'DELETE',
+			'/abs/path/x',
+			array( 'ability_slug' => 'file-manager/delete-file', 'context' => "<script>alert(1)</script>\n\tbad" )
+		);
+		$log = $this->log_contents();
+		$this->assertStringNotContainsString( '<script>', $log );
+	}
+
+	public function test_log_captures_destination_for_move_and_copy_only(): void {
+		$this->seed_toggles( false, true );
+
+		Audit_Trail::write_log(
+			'MOVE',
+			'/abs/src.txt',
+			array( 'ability_slug' => 'file-manager/move-file', 'destination' => '/abs/dest.txt' )
+		);
+		Audit_Trail::write_log(
+			'CREATE',
+			'/abs/created.txt',
+			array( 'ability_slug' => 'file-manager/create-file', 'size_after' => 5 )
+		);
+
+		$log = $this->log_contents();
+		// MOVE entry has Destination line.
+		$this->assertStringContainsString( '  Destination: /abs/dest.txt', $log );
+		// CREATE entry does NOT have a Destination line (only the MOVE one does).
+		$create_block = null;
+		foreach ( $this->log_entries() as $block ) {
+			if ( str_contains( $block, ' CREATE' ) ) {
+				$create_block = $block;
+				break;
+			}
+		}
+		$this->assertNotNull( $create_block );
+		$this->assertStringNotContainsString( 'Destination:', $create_block );
+	}
+
+	public function test_log_backup_line_reports_written_path(): void {
+		$this->seed_toggles( true, true );
+
+		$src         = $this->tmp_source( 'bkp-line.txt', 'seed' );
+		$backup_path = Audit_Trail::write_backup( $src );
+		$this->assertIsString( $backup_path );
+
+		Audit_Trail::write_log(
+			'EDIT',
+			$src,
+			array(
+				'ability_slug'  => 'file-manager/edit-file',
+				'size_before'   => 4,
+				'size_after'    => 8,
+				'backup_status' => 'written',
+				'backup_path'   => $backup_path,
+				'context'       => 'behavioural',
+			)
+		);
+
+		$log = $this->log_contents();
+		$this->assertStringContainsString( '  Backup: ' . $backup_path, $log );
+	}
+
+	public function test_log_backup_line_reports_failed_reason(): void {
+		$this->seed_toggles( false, true );
+		Audit_Trail::write_log(
+			'EDIT',
+			'/abs/path.txt',
+			array(
+				'ability_slug'  => 'file-manager/edit-file',
+				'backup_status' => 'failed',
+				'backup_reason' => 'disk full',
+			)
+		);
+		$this->assertStringContainsString( '  Backup: FAILED (disk full)', $this->log_contents() );
+	}
+
+	public function test_log_backup_line_reports_skipped_reason(): void {
+		$this->seed_toggles( false, true );
+		Audit_Trail::write_log(
+			'CREATE',
+			'/abs/new.txt',
+			array(
+				'ability_slug'  => 'file-manager/create-file',
+				'backup_status' => 'skipped',
+				'backup_reason' => 'target did not exist',
+			)
+		);
+		$this->assertStringContainsString( '  Backup: SKIPPED (target did not exist)', $this->log_contents() );
+	}
+
+	public function test_log_size_string_renders_n_a_for_null_sides(): void {
+		$this->seed_toggles( false, true );
+
+		// CREATE: null size_before → "n/a"
+		Audit_Trail::write_log(
+			'CREATE',
+			'/abs/new.txt',
+			array( 'ability_slug' => 'file-manager/create-file', 'size_before' => null, 'size_after' => 10 )
+		);
+		// DELETE: null size_after → "n/a"
+		Audit_Trail::write_log(
+			'DELETE',
+			'/abs/gone.txt',
+			array( 'ability_slug' => 'file-manager/delete-file', 'size_before' => 20, 'size_after' => null )
+		);
+
+		$log = $this->log_contents();
+		$this->assertStringContainsString( '  Size: n/a -> 10 bytes', $log );
+		$this->assertStringContainsString( '  Size: 20 -> n/a bytes', $log );
+	}
+
+	/*
+	 * Note on action-hook behavioural coverage: the WP-less bootstrap stubs
+	 * add_action/do_action as no-ops (deliberate — other tests rely on that
+	 * to isolate side effects). Hook firing is instead covered by
+	 * test_audit_trail_fires_action_hook above (structural — asserts the
+	 * do_action call site is present in Audit_Trail source) and by the
+	 * live MCP smoke test in the session log.
+	 */
+
+	public function test_stats_reflects_disk_state_after_writes(): void {
+		$this->seed_toggles( true, true );
+
+		// Prime one backup + two log entries.
+		$src = $this->tmp_source( 'stats.txt', 'seed' );
+		Audit_Trail::write_backup( $src );
+		Audit_Trail::write_log( 'CREATE', $src, array( 'ability_slug' => 'file-manager/create-file', 'size_after' => 4 ) );
+		Audit_Trail::write_log( 'EDIT',   $src, array( 'ability_slug' => 'file-manager/edit-file', 'size_before' => 4, 'size_after' => 8 ) );
+
+		$stats = Audit_Trail::stats();
+		$this->assertGreaterThanOrEqual( 2, (int) $stats['log_total_lines'] );
+		$this->assertGreaterThan( 0, (int) $stats['log_size_bytes'] );
+		$this->assertGreaterThanOrEqual( 1, (int) $stats['backup_days_present'] );
+		$this->assertGreaterThan( 0, (int) $stats['backup_total_size_bytes'] );
+		$this->assertNotNull( $stats['log_last_entry_timestamp'] );
+	}
+
+	public function test_run_cleanup_now_deletes_old_backup_dirs(): void {
+		$this->seed_toggles( true, false );
+		update_option( Hardening_Settings::OPTION_BACKUP_RETENTION_DAYS, 1 );
+
+		$base   = Audit_Trail::backup_base_dir();
+		$today  = Audit_Trail::backup_today_dir();
+		$stale  = $base . '/2020-01-01';
+		mkdir( $today, 0755, true );
+		mkdir( $stale, 0755, true );
+		file_put_contents( $stale . '/leftover.bak.000000', 'stale' );
+
+		Audit_Trail::run_cleanup_now();
+
+		$this->assertFileDoesNotExist( $stale );
+		$this->assertDirectoryExists( $today );
+	}
+
+	public function test_run_cleanup_now_trims_old_log_entries(): void {
+		$this->seed_toggles( false, true );
+		update_option( Hardening_Settings::OPTION_AUDIT_LOG_RETENTION_DAYS, 1 );
+
+		// Prime the log with one very-old entry and one fresh entry.
+		$log = Audit_Trail::log_path();
+		mkdir( Audit_Trail::log_dir(), 0755, true );
+		$old = "[2020-01-01 00:00:00 UTC] EDIT\n  Ability: file-manager/edit-file\n  File: /old\n  User:  (ID:0) IP:unknown\n  Size: 0 -> 0 bytes\n  Backup: DISABLED\n  Context: ancient\n";
+		$new = '[' . gmdate( 'Y-m-d H:i:s' ) . " UTC] EDIT\n  Ability: file-manager/edit-file\n  File: /new\n  User:  (ID:0) IP:unknown\n  Size: 0 -> 0 bytes\n  Backup: DISABLED\n  Context: fresh\n";
+		file_put_contents( $log, $old . "\n" . $new );
+
+		Audit_Trail::run_cleanup_now();
+
+		$after = (string) file_get_contents( $log );
+		$this->assertStringNotContainsString( 'ancient', $after );
+		$this->assertStringContainsString( 'fresh', $after );
+	}
+
+	/**
+	 * End-to-end matrix mirroring the live MCP smoke test — every one of
+	 * the 10 operation labels the ability classes emit is exercised here.
+	 * When this passes we have parity between what CI covers and what the
+	 * live MCP session covered.
+	 *
+	 * @dataProvider operation_label_provider
+	 */
+	public function test_every_operation_label_writes_wellformed_entry( string $operation, string $ability_slug, array $details ): void {
+		$this->seed_toggles( false, true );
+
+		Audit_Trail::write_log(
+			$operation,
+			'/abs/fixture/' . strtolower( $operation ) . '.tgt',
+			array_merge(
+				array( 'ability_slug' => $ability_slug, 'context' => 'matrix-' . $operation ),
+				$details
+			)
+		);
+
+		$log = $this->log_contents();
+		$this->assertStringContainsString( '] ' . $operation, $log );
+		$this->assertStringContainsString( '  Ability: ' . $ability_slug, $log );
+		$this->assertStringContainsString( '  Context: matrix-' . $operation, $log );
+	}
+
+	/**
+	 * @return array<string, array{0:string,1:string,2:array<string,mixed>}>
+	 */
+	public static function operation_label_provider(): array {
+		return array(
+			'CREATE'          => array( 'CREATE',          'file-manager/create-file',     array( 'size_before' => null, 'size_after' => 10 ) ),
+			'EDIT'            => array( 'EDIT',            'file-manager/edit-file',       array( 'size_before' => 10, 'size_after' => 12 ) ),
+			'APPEND'          => array( 'APPEND',          'file-manager/append-file',     array( 'size_before' => 10, 'size_after' => 14 ) ),
+			'COPY'            => array( 'COPY',            'file-manager/copy-file',       array( 'size_before' => null, 'size_after' => 10, 'destination' => '/abs/copy-dest.txt' ) ),
+			'MOVE'            => array( 'MOVE',            'file-manager/move-file',       array( 'size_before' => 10, 'size_after' => 10, 'destination' => '/abs/move-dest.txt' ) ),
+			'DELETE'          => array( 'DELETE',          'file-manager/delete-file',     array( 'size_before' => 10, 'size_after' => null ) ),
+			'MKDIR'           => array( 'MKDIR',           'file-manager/create-directory', array( 'size_before' => null, 'size_after' => null ) ),
+			'RMDIR'           => array( 'RMDIR',           'file-manager/delete-directory', array( 'size_before' => null, 'size_after' => null ) ),
+			'EDIT_WP_CONFIG'  => array( 'EDIT_WP_CONFIG',  'file-manager/edit-wp-config',  array( 'size_before' => 1000, 'size_after' => 1005 ) ),
+			'CLEAR_DEBUG_LOG' => array( 'CLEAR_DEBUG_LOG', 'file-manager/clear-debug-log', array( 'size_before' => 500, 'size_after' => 0 ) ),
+		);
 	}
 }


### PR DESCRIPTION
## Summary

The 094 test file shipped structural-only for \`Audit_Trail\` — the WP-less bootstrap has no \`WP_Filesystem\`, so I/O paths were exercised via live MCP smoke test but never in CI. This PR closes that gap.

Adds a minimal \`Test_Fake_WP_Filesystem\` shim to \`tests/bootstrap.php\` and **26 new behavioural tests** that mirror what the live smoke matrix ran against \`wordpress-7-0.local\`.

## Bootstrap additions

- \`WP_Filesystem_Base\` empty abstract for \`instanceof\` checks
- \`Test_Fake_WP_Filesystem\` — native-PHP-backed subclass (exists / is_file / is_dir / size / get_contents / put_contents / copy / mkdir / rmdir / delete / dirlist)
- \`wp_mkdir_p\`, \`wp_delete_file\`, \`wp_unslash\`, \`wp_get_current_user\` stubs
- \`FS_CHMOD_FILE\`, \`FS_CHMOD_DIR\`, \`WP_CONTENT_DIR\` constants
- \`WP_CONTENT_DIR\` points into a per-PID \`sys_get_temp_dir\` workspace so \`Audit_Trail\`'s real backup + log paths land in the sandbox — no risk of touching real content

## New behavioural tests (26 total)

**Backup writer**
- Creates dated dir + \`.htaccess\` guard, writes byte-identical pre-image
- Returns \`null\` when target missing / feature disabled
- Same-second collision produces \`.N\` counter suffix

**Log writer**
- Well-formed entry per \`contracts/log-entry-format.md\` — every field asserted
- No file created when disabled
- Context truncated at 500 chars, tags sanitised
- \`Destination\` line only for MOVE / COPY
- \`Backup:\` line reports written path / \`FAILED (...)\` / \`SKIPPED (...)\`
- \`Size:\` line renders \`n/a\` for null sides

**Stats + cleanup**
- \`stats()\` reflects live disk state after writes
- \`run_cleanup_now()\` deletes old backup dirs (respects retention), preserves today
- \`run_cleanup_now()\` trims old log entries, preserves fresh

**Operation label matrix (dataProvider ×10)**
- Every one of the 10 operation labels the ability classes emit (\`CREATE\`, \`EDIT\`, \`APPEND\`, \`COPY\`, \`MOVE\`, \`DELETE\`, \`MKDIR\`, \`RMDIR\`, \`EDIT_WP_CONFIG\`, \`CLEAR_DEBUG_LOG\`) is exercised — PHPUnit parity for the live MCP smoke test

## Note on action-hook coverage

The action-hook behavioural test stayed structural (assert \`do_action\` call site is present in Audit_Trail source). The bootstrap's existing \`add_action\` / \`do_action\` stubs are deliberate no-ops that other tests rely on for isolation, so a real hook-firing test would require reworking those stubs with a static registry. Documented inline. Live hook firing is verified end-to-end in the session's MCP smoke test.

## Gates

- ✅ PHPUnit **1964 / 1964** (baseline 1938 → +26 behavioural)
- ✅ PHPCS clean on both changed files
- ✅ PHPStan level 8 clean

## Context

Closes the coverage gap I flagged after the session smoke test: 12/12 rows in the smoke matrix now have PHPUnit parity, so CI catches regressions the live test caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)