### PR TITLE
Release 0.0.31 — File Manager consolidation + hardening + audit log

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.30
+Stable tag: 0.0.31
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -139,6 +139,10 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased =
+
+= 0.0.31 - 2026-08-26 =
+**Release theme: File Manager consolidation + hardening + audit log.** Bundles the six-feature series (089 → 094) that turned `file-manager/*` from a loose collection of read/write primitives into a self-contained subsystem with an admin tab, allowlist-and-content-filter enforcement, and an append-only audit log with pre-image backups. Also cuts the inline `.bak.<timestamp>` scheme in `Delete_File` (BREAKING for callers of `response.backup` — new canonical field is `response.backup_path`).
+
 **Feature 094 — File Manager Audit Log + Backup Harness (partial).** Consumes the four Backup & Audit option keys shipped as scaffold in PR #144 and enforced-toggle-only in PR #146. New `Audit_Trail` utility owns pre-image backups (into `wp-content/acrossai-file-manager-backups/<YYYY-MM-DD>/`) + append-only log (into `wp-content/acrossai-file-manager-logs/acrossai-file-manager.log`) + amortised 1-in-10 cleanup + stats. Both storage locations get a `Deny from all` `.htaccess` on first creation. All I/O goes through `WP_Filesystem`.
 
 **New ability:** `file-manager/get-changelog` — tails the last N entries (default 100, max 500) via MCP. Honours the read allowlist. Empty log returns a friendly message, not an error. `manage_options` gated.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.30
+ * Version:           0.0.31
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.30' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.31' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Bundles the six-feature series (089 → 094) that turned \`file-manager/*\` from a loose collection of read/write primitives into a self-contained subsystem with an admin tab, allowlist-and-content-filter enforcement, and an append-only audit log with pre-image backups.

## Version bumps

- \`acrossai-abilities-manager.php\` — \`Version:\` header \`0.0.30 → 0.0.31\`
- \`includes/Main.php\` — \`ACROSSAI_ABILITIES_MANAGER_VERSION\` constant
- \`README.txt\` — \`Stable tag\` \`0.0.30 → 0.0.31\`
- \`README.txt\` — Unreleased section becomes \`= 0.0.31 - 2026-08-26 =\` with a release-theme header, followed by the full 089/090/091/092/093/094 feature notes already accumulated

## Features rolled up

| # | Feature | PRs |
|---|---|---|
| 089 | file-manager consolidation (list-directory, copy-file, move-file; 6 duplicates removed) | earlier PRs |
| 090 | file-manager additions (append-file, create-directory, delete-directory, file-info) | earlier PRs |
| 091 | WP_Filesystem migration (19 abilities; new \`filesystem_unavailable\` blocked_reason) | earlier PRs |
| 092 | File Manager admin tab: read+write allowlists, secret redactor | #143 |
| 092 | Fix follow-ups (Read_File missing imports, 9 output_schema gaps, File_Info is_link, Delete_Directory ordering) | bundled in #143 |
| 092-scaffold | Content Filters + Backup & Audit scaffolded settings | #144 |
| — | \`Create_Zip_Backup\` \`File_Mods_Guard\` fix | #145 |
| 093 | Content Filters enforcement (8 knobs + sensitive-read denylist) + dotfile carve-out for \`.htaccess\` / \`.htpasswd\` / \`.user.ini\` | #146 |
| 094 | Audit log + backup harness + \`get-changelog\` ability + \`context\` input field on 10 mutation abilities | #147 |
| 094-complete | Wire remaining 7 abilities + panel banner flip + \`/backup-audit-stats\` endpoint + uninstall extension | #148 |
| — | Behavioural test coverage + tab integration tests | #149, #150 |

## BREAKING for callers

- \`file-manager/delete-file\` \`response.backup\`: inline \`.bak.<time>\` scheme replaced by centralised \`backup_path\`; \`response.backup\` mirrors it for one transition release then goes away
- \`file-manager/read-file\`: no more \`blocked_reason:"protected_read"\` on \`wp-config.php\` / \`.htaccess\` — those files are readable and content is redacted per the new Secret_Redactor
- \`file-manager/file-info\`: response no longer includes \`ctime\` / \`atime\`
- Six ability slugs removed (\`themes/read-theme-code\`, \`themes/edit-theme-file\`, \`themes/read-theme-structure\`, \`plugins/read-plugin-code\`, \`plugins/read-plugin-structure\`, \`plugins/manage-plugin-files\`) — migrate to \`file-manager/*\` equivalents
- Every ability slug moved from \`acrossai/*\` to topic-based prefix in 0.0.30 (no back-compat alias)

## Gates on this release branch

- ✅ PHPUnit **1990 / 1990** passing
- ✅ PHPCS + PHPStan clean
- Full 089–094 CHANGELOG copy verbatim in \`README.txt\` — no re-wording, so past PR bodies stay authoritative

## Post-merge checklist

- [ ] Tag \`0.0.31\` on the merge commit
- [ ] GitHub release notes from the \`= 0.0.31 - 2026-08-26 =\` section
- [ ] Downstream sites can upgrade — no data migration required

🤖 Generated with [Claude Code](https://claude.com/claude-code)