### PR TITLE
feat(content): return_content:false default for six write abilities

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -139,6 +139,13 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased =
+**Token-efficiency default for six content writers.** `content/create-page`, `content/update-page`, `content/create-post`, `content/update-post`, `content/create-cpt-item`, `content/update-cpt-item` gain a new optional input `return_content:boolean, default:false`. When false (the default), the response's `page` / `post` / `item` object strips three large fields — `post_content`, `post_content_filtered`, `post_excerpt` — and adds `content_bytes:integer` so callers still see the saved payload size at a glance.
+
+**Why.** A single-word edit on a ~97 KB page via `content/update-page` previously round-tripped ~60 K LLM tokens (the caller sent the whole new body and the ability echoed the same body back). With this default, the echo drops to ~0 tokens — the caller pays only for the upload it already had to make. Fine-grained edits via `blocks/update-post-block` remain ~10× cheaper still because they never touch the surrounding content.
+
+**BREAKING for callers reading `response.page.post_content` (or `.post` / `.item` equivalents).** Existing callers that need the saved content back — e.g. to diff against what they sent — must pass `return_content:true` explicitly. The three stripped fields remain queryable via `content/get-page` / `content/get-post` after the write.
+
+**Not affected.** Every other content ability (get / list / delete / block-tree operations / meta ops) is unchanged. The block-tree writers (`blocks/update-post-block`, `blocks/add-block`, etc.) already returned just the modified block, not the whole page — nothing to strip.
 
 = 0.0.31 - 2026-08-26 =
 **Release theme: File Manager consolidation + hardening + audit log.** Bundles the six-feature series (089 → 094) that turned `file-manager/*` from a loose collection of read/write primitives into a self-contained subsystem with an admin tab, allowlist-and-content-filter enforcement, and an append-only audit log with pre-image backups. Also cuts the inline `.bak.<timestamp>` scheme in `Delete_File` (BREAKING for callers of `response.backup` — new canonical field is `response.backup_path`).

--- a/includes/Abilities/Content/Create_Cpt_Item.php
+++ b/includes/Abilities/Content/Create_Cpt_Item.php
@@ -51,6 +51,11 @@ class Create_Cpt_Item extends Ability_Definition {
 						'slug'      => array( 'type' => 'string' ),
 						'author'    => array( 'type' => 'integer' ),
 						'meta'      => array( 'type' => 'object' ),
+						'return_content' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead.', 'acrossai-abilities-manager' ),
+						),
 					),
 					'required'             => array( 'post_type', 'title' ),
 					'additionalProperties' => false,
@@ -58,10 +63,11 @@ class Create_Cpt_Item extends Ability_Definition {
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'id'      => array( 'type' => 'integer' ),
-						'item'    => array( 'type' => 'object' ),
-						'message' => array( 'type' => 'string' ),
+						'success'       => array( 'type' => 'boolean' ),
+						'id'            => array( 'type' => 'integer' ),
+						'item'          => array( 'type' => 'object' ),
+						'content_bytes' => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
 					'additionalProperties' => false,
@@ -136,12 +142,24 @@ class Create_Cpt_Item extends Ability_Definition {
 			);
 		}
 
+		$fetched        = (array) get_post( (int) $id, ARRAY_A );
+		$content_bytes  = strlen( (string) ( $fetched['post_content'] ?? '' ) );
+		$return_content = ! empty( $input['return_content'] );
+		if ( ! $return_content ) {
+			unset(
+				$fetched['post_content'],
+				$fetched['post_content_filtered'],
+				$fetched['post_excerpt']
+			);
+		}
+
 		return array(
-			'success' => true,
-			'id'      => (int) $id,
-			'item'    => (array) get_post( (int) $id, ARRAY_A ),
+			'success'       => true,
+			'id'            => (int) $id,
+			'item'          => $fetched,
+			'content_bytes' => $content_bytes,
 			/* translators: 1: post type, 2: ID */
-			'message' => sprintf( __( 'Created %1$s #%2$d.', 'acrossai-abilities-manager' ), $post_type, $id ),
+			'message'       => sprintf( __( 'Created %1$s #%2$d.', 'acrossai-abilities-manager' ), $post_type, $id ),
 		);
 	}
 }

--- a/includes/Abilities/Content/Create_Page.php
+++ b/includes/Abilities/Content/Create_Page.php
@@ -55,6 +55,11 @@ class Create_Page extends Ability_Definition {
 						'slug'       => array( 'type' => 'string' ),
 						'author'     => array( 'type' => 'integer' ),
 						'meta'       => array( 'type' => 'object' ),
+						'return_content' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead.', 'acrossai-abilities-manager' ),
+						),
 					),
 					'required'             => array( 'title' ),
 					'additionalProperties' => false,
@@ -62,10 +67,11 @@ class Create_Page extends Ability_Definition {
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'id'      => array( 'type' => 'integer' ),
-						'page'    => array( 'type' => 'object' ),
-						'message' => array( 'type' => 'string' ),
+						'success'       => array( 'type' => 'boolean' ),
+						'id'            => array( 'type' => 'integer' ),
+						'page'          => array( 'type' => 'object' ),
+						'content_bytes' => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
 					'additionalProperties' => false,
@@ -124,12 +130,24 @@ class Create_Page extends Ability_Definition {
 			);
 		}
 
+		$fetched        = (array) get_post( (int) $id, ARRAY_A );
+		$content_bytes  = strlen( (string) ( $fetched['post_content'] ?? '' ) );
+		$return_content = ! empty( $input['return_content'] );
+		if ( ! $return_content ) {
+			unset(
+				$fetched['post_content'],
+				$fetched['post_content_filtered'],
+				$fetched['post_excerpt']
+			);
+		}
+
 		return array(
-			'success' => true,
-			'id'      => (int) $id,
-			'page'    => (array) get_post( (int) $id, ARRAY_A ),
+			'success'       => true,
+			'id'            => (int) $id,
+			'page'          => $fetched,
+			'content_bytes' => $content_bytes,
 			/* translators: %d: page ID */
-			'message' => sprintf( __( 'Created page #%d.', 'acrossai-abilities-manager' ), $id ),
+			'message'       => sprintf( __( 'Created page #%d.', 'acrossai-abilities-manager' ), $id ),
 		);
 	}
 }

--- a/includes/Abilities/Content/Create_Post.php
+++ b/includes/Abilities/Content/Create_Post.php
@@ -53,6 +53,11 @@ class Create_Post extends Ability_Definition {
 						'slug'      => array( 'type' => 'string' ),
 						'date'      => array( 'type' => 'string' ),
 						'meta'      => array( 'type' => 'object' ),
+						'return_content' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead.', 'acrossai-abilities-manager' ),
+						),
 					),
 					'required'             => array( 'title' ),
 					'additionalProperties' => false,
@@ -60,10 +65,11 @@ class Create_Post extends Ability_Definition {
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'id'      => array( 'type' => 'integer' ),
-						'post'    => array( 'type' => 'object' ),
-						'message' => array( 'type' => 'string' ),
+						'success'       => array( 'type' => 'boolean' ),
+						'id'            => array( 'type' => 'integer' ),
+						'post'          => array( 'type' => 'object' ),
+						'content_bytes' => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
 					'additionalProperties' => false,
@@ -135,12 +141,24 @@ class Create_Post extends Ability_Definition {
 			);
 		}
 
+		$fetched        = (array) get_post( (int) $id, ARRAY_A );
+		$content_bytes  = strlen( (string) ( $fetched['post_content'] ?? '' ) );
+		$return_content = ! empty( $input['return_content'] );
+		if ( ! $return_content ) {
+			unset(
+				$fetched['post_content'],
+				$fetched['post_content_filtered'],
+				$fetched['post_excerpt']
+			);
+		}
+
 		return array(
-			'success' => true,
-			'id'      => (int) $id,
-			'post'    => (array) get_post( (int) $id, ARRAY_A ),
+			'success'       => true,
+			'id'            => (int) $id,
+			'post'          => $fetched,
+			'content_bytes' => $content_bytes,
 			/* translators: %d: post ID */
-			'message' => sprintf( __( 'Created post #%d.', 'acrossai-abilities-manager' ), $id ),
+			'message'       => sprintf( __( 'Created post #%d.', 'acrossai-abilities-manager' ), $id ),
 		);
 	}
 }

--- a/includes/Abilities/Content/Update_Cpt_Item.php
+++ b/includes/Abilities/Content/Update_Cpt_Item.php
@@ -49,6 +49,11 @@ class Update_Cpt_Item extends Ability_Definition {
 						'status'    => array( 'type' => 'string' ),
 						'slug'      => array( 'type' => 'string' ),
 						'meta'      => array( 'type' => 'object' ),
+						'return_content' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead.', 'acrossai-abilities-manager' ),
+						),
 					),
 					'required'             => array( 'post_type', 'id' ),
 					'additionalProperties' => false,
@@ -56,10 +61,11 @@ class Update_Cpt_Item extends Ability_Definition {
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'id'      => array( 'type' => 'integer' ),
-						'item'    => array( 'type' => 'object' ),
-						'message' => array( 'type' => 'string' ),
+						'success'       => array( 'type' => 'boolean' ),
+						'id'            => array( 'type' => 'integer' ),
+						'item'          => array( 'type' => 'object' ),
+						'content_bytes' => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
 					'additionalProperties' => false,
@@ -137,12 +143,24 @@ class Update_Cpt_Item extends Ability_Definition {
 			);
 		}
 
+		$fetched        = (array) get_post( (int) $result, ARRAY_A );
+		$content_bytes  = strlen( (string) ( $fetched['post_content'] ?? '' ) );
+		$return_content = ! empty( $input['return_content'] );
+		if ( ! $return_content ) {
+			unset(
+				$fetched['post_content'],
+				$fetched['post_content_filtered'],
+				$fetched['post_excerpt']
+			);
+		}
+
 		return array(
-			'success' => true,
-			'id'      => (int) $result,
-			'item'    => (array) get_post( (int) $result, ARRAY_A ),
+			'success'       => true,
+			'id'            => (int) $result,
+			'item'          => $fetched,
+			'content_bytes' => $content_bytes,
 			/* translators: 1: post type, 2: ID */
-			'message' => sprintf( __( 'Updated %1$s #%2$d.', 'acrossai-abilities-manager' ), $post_type, $result ),
+			'message'       => sprintf( __( 'Updated %1$s #%2$d.', 'acrossai-abilities-manager' ), $post_type, $result ),
 		);
 	}
 }

--- a/includes/Abilities/Content/Update_Page.php
+++ b/includes/Abilities/Content/Update_Page.php
@@ -49,6 +49,11 @@ class Update_Page extends Ability_Definition {
 						'menu_order' => array( 'type' => 'integer' ),
 						'slug'       => array( 'type' => 'string' ),
 						'meta'       => array( 'type' => 'object' ),
+						'return_content' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead, so a "one-word edit" round-trip does not echo the whole page body back through the tunnel. Callers who need the saved bytes should pass true explicitly.', 'acrossai-abilities-manager' ),
+						),
 					),
 					'required'             => array( 'id' ),
 					'additionalProperties' => false,
@@ -56,10 +61,11 @@ class Update_Page extends Ability_Definition {
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'success' => array( 'type' => 'boolean' ),
-						'id'      => array( 'type' => 'integer' ),
-						'page'    => array( 'type' => 'object' ),
-						'message' => array( 'type' => 'string' ),
+						'success'       => array( 'type' => 'boolean' ),
+						'id'            => array( 'type' => 'integer' ),
+						'page'          => array( 'type' => 'object' ),
+						'content_bytes' => array( 'type' => 'integer' ),
+						'message'       => array( 'type' => 'string' ),
 					),
 					'required'             => array( 'success' ),
 					'additionalProperties' => false,
@@ -132,12 +138,27 @@ class Update_Page extends Ability_Definition {
 			);
 		}
 
+		$fetched        = (array) get_post( (int) $result, ARRAY_A );
+		$content_bytes  = strlen( (string) ( $fetched['post_content'] ?? '' ) );
+		$return_content = ! empty( $input['return_content'] );
+		if ( ! $return_content ) {
+			// Strip the three large fields so a one-word edit doesn't echo the
+			// whole page body back to the caller. Callers who need the saved
+			// bytes pass return_content:true explicitly.
+			unset(
+				$fetched['post_content'],
+				$fetched['post_content_filtered'],
+				$fetched['post_excerpt']
+			);
+		}
+
 		return array(
-			'success' => true,
-			'id'      => (int) $result,
-			'page'    => (array) get_post( (int) $result, ARRAY_A ),
+			'success'       => true,
+			'id'            => (int) $result,
+			'page'          => $fetched,
+			'content_bytes' => $content_bytes,
 			/* translators: %d: page ID */
-			'message' => sprintf( __( 'Updated page #%d.', 'acrossai-abilities-manager' ), $result ),
+			'message'       => sprintf( __( 'Updated page #%d.', 'acrossai-abilities-manager' ), $result ),
 		);
 	}
 }

--- a/includes/Abilities/Content/Update_Post.php
+++ b/includes/Abilities/Content/Update_Post.php
@@ -51,6 +51,11 @@ class Update_Post extends Ability_Definition {
 						'author'  => array( 'type' => 'integer' ),
 						'date'    => array( 'type' => 'string' ),
 						'meta'    => array( 'type' => 'object' ),
+						'return_content' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead, so a "one-word edit" round-trip does not echo the whole post body back through the tunnel.', 'acrossai-abilities-manager' ),
+						),
 					),
 					'required'             => array( 'id' ),
 					'additionalProperties' => false,
@@ -61,6 +66,7 @@ class Update_Post extends Ability_Definition {
 						'success'           => array( 'type' => 'boolean' ),
 						'id'                => array( 'type' => 'integer' ),
 						'post'              => array( 'type' => 'object' ),
+						'content_bytes'     => array( 'type' => 'integer' ),
 						'dropped_meta_keys' => array(
 							'type'  => 'array',
 							'items' => array( 'type' => 'string' ),
@@ -198,10 +204,22 @@ class Update_Post extends Ability_Definition {
 			);
 		}
 
+		$fetched        = (array) get_post( (int) $result, ARRAY_A );
+		$content_bytes  = strlen( (string) ( $fetched['post_content'] ?? '' ) );
+		$return_content = ! empty( $input['return_content'] );
+		if ( ! $return_content ) {
+			unset(
+				$fetched['post_content'],
+				$fetched['post_content_filtered'],
+				$fetched['post_excerpt']
+			);
+		}
+
 		return array(
 			'success'           => true,
 			'id'                => (int) $result,
-			'post'              => (array) get_post( (int) $result, ARRAY_A ),
+			'post'              => $fetched,
+			'content_bytes'     => $content_bytes,
 			'dropped_meta_keys' => $dropped_meta_keys,
 			/* translators: %d: post ID */
 			'message'           => sprintf( __( 'Updated post #%d.', 'acrossai-abilities-manager' ), $result ),

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,7 @@
 			<file>tests/phpunit/abilities/Test_Feature_093_Hardening_Enforcement.php</file>
 			<file>tests/phpunit/abilities/Test_Feature_094_Audit_Log_And_Backups.php</file>
 			<file>tests/phpunit/abilities/Test_File_Manager_Tab_Integration.php</file>
+			<file>tests/phpunit/abilities/Test_Return_Content_Default_False.php</file>
 		</testsuite>
 		<testsuite name="library-unit">
 			<file>tests/phpunit/Modules/Library/Test_Ability_Definition.php</file>

--- a/tests/phpunit/abilities/Test_Return_Content_Default_False.php
+++ b/tests/phpunit/abilities/Test_Return_Content_Default_False.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Coverage for the return_content:false default across the six content
+ * write abilities (Create/Update Page/Post/Cpt_Item).
+ *
+ * Behavioural round-trip tests would need a full WP install to drive
+ * wp_update_post / wp_insert_post / get_post — out of scope for the
+ * WP-less bootstrap. What we CAN cover statically:
+ *
+ *   1. Every ability declares `return_content:{type:boolean, default:false}`
+ *      in its input_schema.
+ *   2. Every ability declares `content_bytes:{type:integer}` in its output_schema.
+ *   3. Every ability's execute() strips the three large fields
+ *      (post_content, post_content_filtered, post_excerpt) when
+ *      return_content is falsy.
+ *   4. Every ability's execute() computes content_bytes BEFORE stripping.
+ *
+ * Together these prove the wiring is uniform across the six abilities —
+ * a "one-word edit" round-trip via any of them will not echo the full
+ * body back through the tunnel unless the caller opts in.
+ *
+ * @package AcrossAI_Abilities_Manager
+ * @since   0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Tests\PHPUnit\Abilities;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Test_Return_Content_Default_False.
+ */
+class Test_Return_Content_Default_False extends WP_UnitTestCase {
+
+	/** @var string */
+	private string $plugin_root = '';
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->plugin_root = dirname( __DIR__, 3 );
+	}
+
+	private function read( string $rel ): string {
+		return (string) file_get_contents( $this->plugin_root . '/' . $rel );
+	}
+
+	/**
+	 * @return array<string, array{0:string,1:string}>
+	 */
+	public static function content_writer_provider(): array {
+		return array(
+			'update-page'     => array( 'includes/Abilities/Content/Update_Page.php', 'page' ),
+			'update-post'     => array( 'includes/Abilities/Content/Update_Post.php', 'post' ),
+			'create-page'     => array( 'includes/Abilities/Content/Create_Page.php', 'page' ),
+			'create-post'     => array( 'includes/Abilities/Content/Create_Post.php', 'post' ),
+			'update-cpt-item' => array( 'includes/Abilities/Content/Update_Cpt_Item.php', 'item' ),
+			'create-cpt-item' => array( 'includes/Abilities/Content/Create_Cpt_Item.php', 'item' ),
+		);
+	}
+
+	/**
+	 * @dataProvider content_writer_provider
+	 */
+	public function test_input_schema_declares_return_content_default_false( string $relative_path ): void {
+		$src = $this->read( $relative_path );
+		$this->assertMatchesRegularExpression(
+			"/'return_content'\\s*=>\\s*array\\(\\s*'type'\\s*=>\\s*'boolean'\\s*,\\s*'default'\\s*=>\\s*false/",
+			$src,
+			"{$relative_path} input_schema must declare return_content:{type:boolean, default:false}"
+		);
+	}
+
+	/**
+	 * @dataProvider content_writer_provider
+	 */
+	public function test_output_schema_declares_content_bytes( string $relative_path ): void {
+		$src = $this->read( $relative_path );
+		$this->assertMatchesRegularExpression(
+			"/'content_bytes'\\s*=>\\s*array\\(\\s*'type'\\s*=>\\s*'integer'/",
+			$src,
+			"{$relative_path} output_schema must declare content_bytes:integer"
+		);
+	}
+
+	/**
+	 * @dataProvider content_writer_provider
+	 */
+	public function test_execute_strips_three_large_fields_when_return_content_falsy( string $relative_path ): void {
+		$src = $this->read( $relative_path );
+
+		// Reads $input['return_content'] and gates on it.
+		$this->assertMatchesRegularExpression(
+			"/\\\$return_content\\s*=\\s*!\\s*empty\\(\\s*\\\$input\\[\\s*'return_content'\\s*\\]\\s*\\)/",
+			$src,
+			"{$relative_path} must read \$input['return_content'] and gate on it"
+		);
+
+		// Unsets the three large fields inside the gate.
+		$this->assertStringContainsString( "unset(", $src );
+		$this->assertStringContainsString( "\$fetched['post_content']", $src );
+		$this->assertStringContainsString( "\$fetched['post_content_filtered']", $src );
+		$this->assertStringContainsString( "\$fetched['post_excerpt']", $src );
+	}
+
+	/**
+	 * Guardrail: content_bytes MUST be computed from $fetched['post_content']
+	 * BEFORE the unset — otherwise it always reports 0.
+	 *
+	 * @dataProvider content_writer_provider
+	 */
+	public function test_content_bytes_computed_before_strip( string $relative_path ): void {
+		$src = $this->read( $relative_path );
+
+		$strlen_pos = strpos( $src, "\$content_bytes  = strlen( (string) ( \$fetched['post_content']" );
+		$unset_pos  = strpos( $src, "unset(\n\t\t\t\t\$fetched['post_content']" );
+
+		// The plain-position check is enough for the pattern we ship; if
+		// either sentinel is missing the test fails informatively.
+		$this->assertNotFalse( $strlen_pos, "{$relative_path}: strlen(...post_content...) sentinel not found" );
+		$this->assertNotFalse( $unset_pos, "{$relative_path}: unset(post_content...) sentinel not found" );
+		$this->assertLessThan(
+			$unset_pos,
+			$strlen_pos,
+			"{$relative_path}: content_bytes must be computed BEFORE the unset, otherwise it reports 0"
+		);
+	}
+
+	/**
+	 * Every response includes the content_bytes field.
+	 *
+	 * @dataProvider content_writer_provider
+	 */
+	public function test_execute_returns_content_bytes_in_response( string $relative_path, string $object_key ): void {
+		$src = $this->read( $relative_path );
+		$this->assertMatchesRegularExpression(
+			"/'content_bytes'\\s*=>\\s*\\\$content_bytes/",
+			$src,
+			"{$relative_path}: response array must include content_bytes"
+		);
+		$this->assertMatchesRegularExpression(
+			"/'{$object_key}'\\s*=>\\s*\\\$fetched/",
+			$src,
+			"{$relative_path}: response array must return the (possibly-stripped) \$fetched under '{$object_key}'"
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Six content writers previously echoed the whole saved post/page/item back through the response. On a ~97 KB page, a single-word edit through \`content/update-page\` cost ~60 K LLM tokens (~29K in, ~29K echoed back). The echo is almost pure waste — the caller just wrote that content and doesn't need it read back.

Adds an optional \`return_content:boolean, default:false\` input on the six abilities. When false (the default), the response's \`page\` / \`post\` / \`item\` object strips \`post_content\` + \`post_content_filtered\` + \`post_excerpt\`, and adds \`content_bytes:integer\` so callers still see the saved payload size.

## Cost effect on the "one-word edit" scenario (97 KB page)

| Path | Cost | Change |
|---|---|---|
| \`content/update-page\` + \`return_content\` default | ~29K tokens (upload only) | **~2× cheaper** |
| \`content/update-page\` + \`return_content:true\` | ~60K tokens (as before) | unchanged |
| \`blocks/update-post-block\` (unchanged) | ~6K tokens (targeted block) | **~10× cheaper still** |

For fine-grained edits, admins should still prefer \`blocks/update-post-block\`. This PR just stops the coarse-grained path from double-charging by default.

## BREAKING

For callers reading \`response.page.post_content\` (or \`.post\` / \`.item\` equivalents). Existing callers that need the saved content back — e.g. to diff against what they sent — must pass \`return_content:true\` explicitly. The three stripped fields remain queryable via \`content/get-page\` / \`content/get-post\` after the write.

## Six abilities changed

- \`content/create-page\`
- \`content/update-page\`
- \`content/create-post\`
- \`content/update-post\`
- \`content/create-cpt-item\`
- \`content/update-cpt-item\`

Uniform pattern in each:

- Input schema: add \`return_content:{type:boolean, default:false, description:"…"}\`
- Output schema: add \`content_bytes:{type:integer}\`
- Execute: compute \`content_bytes\` from \`\$fetched['post_content']\` BEFORE the unset, gate on \`!empty(\$input['return_content'])\`, unset the three fields when false, return \`content_bytes\` in the response

## Not affected

Every other content ability (get / list / delete / block-tree operations / meta ops) is unchanged. The block-tree writers (\`blocks/update-post-block\`, \`blocks/add-block\`, etc.) already returned just the modified block, not the whole page — nothing to strip.

## Tests

\`Test_Return_Content_Default_False.php\` — **30 tests** (dataProvider ×6 for each of 5 assertions):

- \`test_input_schema_declares_return_content_default_false\` — the input field is present with correct shape
- \`test_output_schema_declares_content_bytes\` — the new response field is present
- \`test_execute_strips_three_large_fields_when_return_content_falsy\` — the gate + unset are wired
- \`test_content_bytes_computed_before_strip\` — guardrail: computing after the unset would always report 0
- \`test_execute_returns_content_bytes_in_response\` — the field actually reaches the response array

Behavioural round-trip coverage stays off-CI (needs a full WP install to drive \`wp_insert_post\` / \`wp_update_post\` / \`get_post\`). The structural proofs are uniform across the 6 files so the wiring is guaranteed identical.

## Gates

- ✅ PHPUnit **2020 / 2020** (baseline 1990 → +30 new)
- ✅ PHPCS clean on all changed files
- ✅ PHPStan level 8 clean

## CHANGELOG

Entry lands in the Unreleased section with the token-cost breakdown and BREAKING note. Will roll into the next release version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)