### PR TITLE
Release 0.0.32 — token-efficient AI callers (return_content, outline, suggested_abilities)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.31
+Stable tag: 0.0.32
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -139,6 +139,10 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased =
+
+= 0.0.32 - 2026-08-28 =
+**Release theme: token-efficient AI callers.** Two closely related shifts. First, response payloads shrink dramatically for the common "small edit" and "just tell me the block structure" intents. Second, ability descriptions gain author-declared hints pointing AI callers at cheaper sibling abilities when their intent maps to one. Every change is either strictly additive or opt-out only via an admin toggle — no ability's execute() behaviour changes.
+
 **Token-efficiency default for six content writers.** `content/create-page`, `content/update-page`, `content/create-post`, `content/update-post`, `content/create-cpt-item`, `content/update-cpt-item` gain a new optional input `return_content:boolean, default:false`. When false (the default), the response's `page` / `post` / `item` object strips three large fields — `post_content`, `post_content_filtered`, `post_excerpt` — and adds `content_bytes:integer` so callers still see the saved payload size at a glance.
 
 **Why.** A single-word edit on a ~97 KB page via `content/update-page` previously round-tripped ~60 K LLM tokens (the caller sent the whole new body and the ability echoed the same body back). With this default, the echo drops to ~0 tokens — the caller pays only for the upload it already had to make. Fine-grained edits via `blocks/update-post-block` remain ~10× cheaper still because they never touch the surrounding content.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.31
+ * Version:           0.0.32
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.31' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.32' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Version bump to **0.0.32**. Bundles five feature PRs (#152–#156) merged since 0.0.31.

## Release theme — token-efficient AI callers

Two closely related shifts. First, response payloads shrink dramatically for the common "small edit" and "just tell me the block structure" intents. Second, ability descriptions gain author-declared hints pointing AI callers at cheaper sibling abilities when their intent maps to one. Every change is either strictly additive or opt-out only via an admin toggle — no ability's `execute()` behaviour changes.

## What ships in 0.0.32

| PR | What |
|---|---|
| #152 | `return_content:false` default on six `content/{create,update}-{page,post,cpt-item}` writers (~29K tokens saved per one-word edit on a 97 KB page) |
| #153 | Same default on nine `blocks/{create,update}-*` writers — patterns, templates, template parts, style variations, global styles |
| #154 | New `blocks/outline-post-blocks` ability — flat content-free block index; ~28K tokens cheaper than `get-post-blocks` on the same page. Path convention matches `Block_Tree` (raw parse_blocks indices, whitespace nodes counted) so paths are drop-in usable with add-block / update-post-block / remove-block |
| #155 | Feature 095 `suggested_abilities()` framework + admin kill-switch + four initial overrides (`content/update-{page,post,cpt-item}`, `blocks/get-post-blocks`) |
| #156 | Ten more `suggested_abilities()` overrides on the hint catalog covering content reads, design-system reads, and list-vs-get-by-id pairs across media/users/options/blocks namespaces |

## Version stamps updated

- `acrossai-abilities-manager.php` — plugin header `Version: 0.0.32`
- `README.txt` — `Stable tag: 0.0.32`
- `includes/Main.php` — `ACROSSAI_ABILITIES_MANAGER_VERSION` constant
- `README.txt` — Unreleased section converted to `0.0.32 - 2026-08-28`, fresh empty Unreleased above it

## Test plan

- [x] `./vendor/bin/phpunit` — 2165 / 2165 (unchanged since PR #156 merged)
- [x] Version constant, plugin-header version, and README stable tag all read `0.0.32`
- [x] Changelog Unreleased header preserved for future PRs; 0.0.32 entry inserted at top of the version list
- [ ] After merge: create GitHub release tagged `v0.0.32` with plugin zip attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)