### PR TITLE
Release 0.0.33 — closing the cheap-edit loop

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: abilities, ability management, access control, site management, ai
 Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 0.0.32
+Stable tag: 0.0.33
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -139,6 +139,10 @@ No data is sent to any external server without an explicit administrator action.
 == Changelog ==
 
 = Unreleased =
+
+= 0.0.33 - 2026-08-28 =
+**Release theme: closing the cheap-edit loop.** A follow-up to 0.0.32 that closes the last two gaps between "locate a block cheaply" and "modify it cheaply". Two changes, both surgical and backwards-compatible.
+
 **`return_content:false` default now covers the two block-tree writers.** `blocks/add-block` and `blocks/update-post-block` gain the same `return_content:{boolean, default:false}` input as the six content writers (PR #152) and nine block-editor writers (PR #153). When false (default), the response's `block` object strips its `innerHTML`, `innerContent`, and `innerBlocks` — leaving `blockName`, `attrs`, and `path` — and `content_bytes` reports the saved `innerHTML` size. Container blocks (columns, cover, group) previously echoed their entire innerBlocks subtree; now they don't unless the caller passes `return_content:true`. BREAKING for callers reading `response.block.innerHTML` on these two abilities — pass `return_content:true` explicitly. Every other block-tree read/write (mutate-block-tree, replace-block-text, remove-block, duplicate-block, move-block) already returned lightweight envelopes and is unchanged.
 
 **`blocks/get-post-blocks` gains scoping inputs.** Three new optional inputs close the "read one block's markup" gap between `blocks/get-post-blocks` (full tree, full content) and `blocks/outline-post-blocks` (scoped but never returns content). `path: int[]` scopes the response to a subtree (uses the same raw parse_blocks() index scheme as add-block / update-post-block / remove-block, so returned paths interchange). `depth: integer` bounds descent below the subtree root (-1 unlimited, 0 subtree root only, N below). `include_html: boolean` (default true = backwards-compat) strips innerHTML + innerContent from every returned node when false. Backwards-compatible: existing callers passing only `post_id` see identical responses. An unresolvable `path` returns a standard error envelope with `error_code: invalid_path` naming which depth failed and how many blocks exist at that level.

--- a/acrossai-abilities-manager.php
+++ b/acrossai-abilities-manager.php
@@ -23,7 +23,7 @@ namespace AcrossAI_Abilities_Manager;
  * Plugin Name:       AcrossAI Abilities Manager
  * Plugin URI:        https://acrossai.co/
  * Description:       Manage and customize the abilities of AcrossAI on your WordPress site. Tailor the AI's capabilities to suit your needs, enhancing user experience and engagement.
- * Version:           0.0.32
+ * Version:           0.0.33
  * Requires PHP:      8.1
  * Requires at least: 6.9
  * Tested up to:      7.0

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -191,7 +191,7 @@ final class Main {
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_URL', plugin_dir_url( \ACROSSAI_ABILITIES_MANAGER_PLUGIN_FILE ) );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME_SLUG', $this->plugin_name );
 		$this->define( 'ACROSSAI_ABILITIES_MANAGER_PLUGIN_NAME', 'AcrossAI Abilities Manager' );
-		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.32' );
+		$this->define( 'ACROSSAI_ABILITIES_MANAGER_VERSION', '0.0.33' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Version bump to **0.0.33**. Follow-up to 0.0.32 that closes the last two gaps between "locate a block cheaply" and "modify it cheaply". Bundles PRs #158 → #159.

## Release theme — closing the cheap-edit loop

0.0.32 shipped `blocks/outline-post-blocks` (cheap locate) and `return_content:false` on 15 write abilities (cheap write). The middle step — "read the current markup of one block" — was still expensive: `blocks/get-post-blocks` had no scoping, so callers had to pull the whole tree just to see one paragraph. And the two block-tree writers (`add-block`, `update-post-block`) still echoed their inserted/updated block objects without an opt-out.

This release fixes both.

## What's in 0.0.33

| PR | What |
|---|---|
| #158 | `blocks/get-post-blocks` gains `path`, `depth`, `include_html` inputs. Scoped read of a single block via `path=[3,1,0], depth=0` runs at ~hundreds of bytes instead of pulling the whole ~76 KB tree. Backwards-compatible: callers passing only `post_id` see identical responses. Same raw parse_blocks() path scheme as add-block / update-post-block / remove-block — paths interchange. |
| #159 | `return_content:false` default on `blocks/add-block` + `blocks/update-post-block`. Parity with the six content writers (0.0.32 PR #152) and nine block-editor writers (PR #153). Response's `block` object strips `innerHTML`, `innerContent`, and `innerBlocks`; `content_bytes` reports the saved size. Container blocks (columns, cover, group) previously echoed their entire innerBlocks subtree — now they don't unless the caller passes `return_content:true`. |

## The cheap-edit loop now works end-to-end

1. **Locate**: `blocks/outline-post-blocks` — paths + text previews, no content. ~kilobytes.
2. **Read current markup of one block**: `blocks/get-post-blocks {path, depth:0}` — single block, no whole tree. ~hundreds of bytes.
3. **Write**: `blocks/update-post-block {path, return_content:false}` — small envelope back, no echo.

## Version stamps updated

- `acrossai-abilities-manager.php` — plugin header `Version: 0.0.33`
- `README.txt` — `Stable tag: 0.0.33`
- `includes/Main.php` — `ACROSSAI_ABILITIES_MANAGER_VERSION` constant
- `README.txt` — Unreleased section converted to `0.0.33 - 2026-08-28`, fresh empty Unreleased above it

## Test plan

- [x] `./vendor/bin/phpunit` — 2196 / 2196 (unchanged since PR #159 merged)
- [x] Version constant, plugin-header version, and README stable tag all read `0.0.33`
- [x] Changelog Unreleased header preserved for future PRs; 0.0.33 entry inserted at top of the version list
- [ ] After merge: tag `v0.0.33` + GitHub release with plugin zip attached

## BREAKING for existing callers

- `blocks/add-block` / `blocks/update-post-block` callers reading `response.block.innerHTML` must now pass `return_content:true` explicitly.
- No other callers affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)