### PR TITLE
fix: wp_slash core-API write abilities to prevent backslash loss (#131)

### DIFF
--- a/includes/Abilities/Content/Add_Post_Meta.php
+++ b/includes/Abilities/Content/Add_Post_Meta.php
@@ -134,7 +134,7 @@ class Add_Post_Meta extends Ability_Definition {
 		$value  = array_key_exists( 'value', $input ) ? $input['value'] : ( $input['meta_value'] ?? '' );
 		$unique = ! empty( $input['unique'] );
 
-		$meta_id = add_post_meta( $post_id, $key, $value, $unique );
+		$meta_id = add_post_meta( $post_id, $key, wp_slash( $value ), $unique );
 
 		return array(
 			'success' => true,

--- a/includes/Abilities/Content/Create_Cpt_Item.php
+++ b/includes/Abilities/Content/Create_Cpt_Item.php
@@ -134,7 +134,7 @@ class Create_Cpt_Item extends Ability_Definition {
 			$args['meta_input'] = $input['meta'];
 		}
 
-		$id = wp_insert_post( $args, true );
+		$id = wp_insert_post( wp_slash( $args ), true );
 		if ( is_wp_error( $id ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/Content/Create_Page.php
+++ b/includes/Abilities/Content/Create_Page.php
@@ -122,7 +122,7 @@ class Create_Page extends Ability_Definition {
 			$args['meta_input'] = $input['meta'];
 		}
 
-		$id = wp_insert_post( $args, true );
+		$id = wp_insert_post( wp_slash( $args ), true );
 		if ( is_wp_error( $id ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/Content/Create_Post.php
+++ b/includes/Abilities/Content/Create_Post.php
@@ -133,7 +133,7 @@ class Create_Post extends Ability_Definition {
 			$args['meta_input'] = $input['meta'];
 		}
 
-		$id = wp_insert_post( $args, true );
+		$id = wp_insert_post( wp_slash( $args ), true );
 		if ( is_wp_error( $id ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/Content/Update_Cpt_Item.php
+++ b/includes/Abilities/Content/Update_Cpt_Item.php
@@ -156,7 +156,7 @@ class Update_Cpt_Item extends Ability_Definition {
 			$args['meta_input'] = $input['meta'];
 		}
 
-		$result = wp_update_post( $args, true );
+		$result = wp_update_post( wp_slash( $args ), true );
 		if ( is_wp_error( $result ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/Content/Update_Page.php
+++ b/includes/Abilities/Content/Update_Page.php
@@ -151,7 +151,7 @@ class Update_Page extends Ability_Definition {
 			$args['meta_input'] = $input['meta'];
 		}
 
-		$result = wp_update_post( $args, true );
+		$result = wp_update_post( wp_slash( $args ), true );
 		if ( is_wp_error( $result ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/Content/Update_Post.php
+++ b/includes/Abilities/Content/Update_Post.php
@@ -216,7 +216,7 @@ class Update_Post extends Ability_Definition {
 			}
 		}
 
-		$result = wp_update_post( $args, true );
+		$result = wp_update_post( wp_slash( $args ), true );
 		if ( is_wp_error( $result ) ) {
 			return array(
 				'success'           => false,

--- a/includes/Abilities/Content/Update_Post_Meta.php
+++ b/includes/Abilities/Content/Update_Post_Meta.php
@@ -120,7 +120,7 @@ class Update_Post_Meta extends Ability_Definition {
 		}
 
 		$value  = array_key_exists( 'value', $input ) ? $input['value'] : ( $input['meta_value'] ?? '' );
-		$result = update_post_meta( $post_id, $key, $value );
+		$result = update_post_meta( $post_id, $key, wp_slash( $value ) );
 
 		return array(
 			'success' => true,

--- a/includes/Abilities/Users/Create_User.php
+++ b/includes/Abilities/Users/Create_User.php
@@ -174,7 +174,7 @@ class Create_User extends Ability_Definition {
 			$user_data['role'] = $role;
 		}
 
-		$user_id = wp_insert_user( $user_data );
+		$user_id = wp_insert_user( wp_slash( $user_data ) );
 
 		if ( is_wp_error( $user_id ) ) {
 			return array(

--- a/includes/Abilities/Users/Update_User.php
+++ b/includes/Abilities/Users/Update_User.php
@@ -180,7 +180,7 @@ class Update_User extends Ability_Definition {
 
 		// Apply core-field update only if at least one field was supplied.
 		if ( $has_field ) {
-			$result = wp_update_user( $update );
+			$result = wp_update_user( wp_slash( $update ) );
 
 			if ( is_wp_error( $result ) ) {
 				return array(

--- a/includes/Abilities/Utilities/User_Helpers.php
+++ b/includes/Abilities/Utilities/User_Helpers.php
@@ -155,7 +155,7 @@ class User_Helpers {
 				continue;
 			}
 			$value  = self::maybe_decode_json( $value );
-			$result = update_user_meta( $user_id, $key, $value );
+			$result = update_user_meta( $user_id, $key, wp_slash( $value ) );
 			if ( false === $result ) {
 				$failed[] = $key;
 			} else {

--- a/tests/phpunit/abilities/Test_Add_Post_Meta.php
+++ b/tests/phpunit/abilities/Test_Add_Post_Meta.php
@@ -54,7 +54,7 @@ class Test_Add_Post_Meta extends WP_UnitTestCase {
 	}
 
 	public function test_calls_add_post_meta_with_unique_flag(): void {
-		$this->assertStringContainsString( 'add_post_meta( $post_id, $key, $value, $unique )', $this->src );
+		$this->assertStringContainsString( 'add_post_meta( $post_id, $key, wp_slash( $value ), $unique )', $this->src );
 	}
 
 	public function test_accepts_key_and_meta_key_aliases(): void {


### PR DESCRIPTION
## Summary

Closes #131.

Every write ability that hands caller-supplied strings to a WordPress core write function was losing one level of backslashes. `wp_insert_post()`, `wp_update_post()`, `update_post_meta()`, `add_post_meta()`, `wp_insert_user()`, `wp_update_user()`, and `update_user_meta()` all call `wp_unslash()` internally under the historical `\$_POST` magic-quotes contract. Data arriving over MCP/REST is not slashed, so passing it through unmodified means `wp_unslash()` eats a level. The response still returned `success:true` against the corrupted value.

## Fix

Wraps the caller-supplied array/value with `wp_slash()` at the boundary in the eight post-write and three user-write abilities:

- `Content/Create_Post.php` — `wp_insert_post( wp_slash( \$args ), true )`
- `Content/Update_Post.php` — `wp_update_post( wp_slash( \$args ), true )`
- `Content/Update_Post_Meta.php` — `update_post_meta( \$post_id, \$key, wp_slash( \$value ) )`
- `Content/Create_Page.php` — `wp_insert_post( wp_slash( \$args ), true )`
- `Content/Update_Page.php` — `wp_update_post( wp_slash( \$args ), true )`
- `Content/Add_Post_Meta.php` — `add_post_meta( \$post_id, \$key, wp_slash( \$value ), \$unique )`
- `Content/Create_Cpt_Item.php` — `wp_insert_post( wp_slash( \$args ), true )`
- `Content/Update_Cpt_Item.php` — `wp_update_post( wp_slash( \$args ), true )`
- `Users/Create_User.php` — `wp_insert_user( wp_slash( \$user_data ) )`
- `Users/Update_User.php` — `wp_update_user( wp_slash( \$update ) )`
- `Utilities/User_Helpers.php` — `update_user_meta( \$user_id, \$key, wp_slash( \$value ) )`

Peer abilities under `Comments/`, `Menus/`, `Taxonomies/`, `Media/`, and `Utilities/Elementor/Document_Repository.php` already apply this fix; this brings the `Content/` and `Users/` paths in line.

## Not fixed

`update_option()` does **not** call `wp_unslash()` internally — it stores the value via `\$wpdb->update()` after `sanitize_option()` / `maybe_serialize()`, neither of which unslashes. Wrapping option writes with `wp_slash()` would introduce literal `\\` characters. `Options/Update_Option.php`, `Options/Patch_Option_Value.php`, `Settings/Update_Site_Title.php`, and `Settings/Update_Tagline.php` are therefore intentionally unchanged.

## Recovery

Rows already corrupted by this are not recoverable in the general case — a stripped backslash is indistinguishable from text that never had one. Operators should re-check any content written through these abilities that legitimately contains backslashes (PHP FQNs, regex patterns, Windows paths, LaTeX, JSON escapes).

## Test plan

- [ ] `composer run phpcs` on changed files (verified clean locally)
- [ ] Manual: create a post via `acrossai/create-post` with `content = "A[\Elementor\Plugin] B[\\\\double] C[\d+\s]"`, then read back `post_content` via `\$wpdb` and assert byte equality
- [ ] Manual: same round-trip for `acrossai/update-post`, `acrossai/update-post-meta`, `acrossai/add-post-meta`, `acrossai/create-page`, `acrossai/update-page`, `acrossai/create-cpt-item`, `acrossai/update-cpt-item`
- [ ] Manual: create/update a user with a `\`-containing `display_name` or `description` and confirm no loss
- [ ] Cross-path oracle: write the same payload through the core-API ability and through `acrossai/insert-db-row`; stored bytes match

🤖 Generated with [Claude Code](https://claude.com/claude-code)