### PR TITLE
feat: apply_wp_slash opt-out flag on core-API write abilities

### DIFF
--- a/includes/Abilities/Comments/Create_Comment.php
+++ b/includes/Abilities/Comments/Create_Comment.php
@@ -84,6 +84,7 @@ class Create_Comment extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => false,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Comments/Create_Comment.php
+++ b/includes/Abilities/Comments/Create_Comment.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Comments;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -52,6 +53,7 @@ class Create_Comment extends Ability_Definition {
 							'default' => 0,
 						),
 						'status'       => array( 'type' => 'string' ),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'post', 'content' ),
 					'additionalProperties' => false,
@@ -123,7 +125,7 @@ class Create_Comment extends Ability_Definition {
 			$data['comment_author_url'] = (string) $input['author_url'];
 		}
 
-		$new_id = wp_insert_comment( wp_slash( $data ) );
+		$new_id = wp_insert_comment( Slash_Input::slash( $data, $input ) );
 		if ( ! $new_id ) {
 			return Comment_Formatter::error_from( false, __( 'Could not create comment.', 'acrossai-abilities-manager' ) );
 		}

--- a/includes/Abilities/Comments/Update_Comment.php
+++ b/includes/Abilities/Comments/Update_Comment.php
@@ -79,6 +79,7 @@ class Update_Comment extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Comments/Update_Comment.php
+++ b/includes/Abilities/Comments/Update_Comment.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Comments;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -47,6 +48,7 @@ class Update_Comment extends Ability_Definition {
 						'author_name'  => array( 'type' => 'string' ),
 						'author_email' => array( 'type' => 'string' ),
 						'author_url'   => array( 'type' => 'string' ),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'id' ),
 					'additionalProperties' => false,
@@ -128,7 +130,7 @@ class Update_Comment extends Ability_Definition {
 			);
 		}
 
-		$result = wp_update_comment( wp_slash( $data ), true );
+		$result = wp_update_comment( Slash_Input::slash( $data, $input ), true );
 		if ( is_wp_error( $result ) || false === $result ) {
 			return Comment_Formatter::error_from(
 				$result,

--- a/includes/Abilities/Comments/Update_Comment_Meta.php
+++ b/includes/Abilities/Comments/Update_Comment_Meta.php
@@ -78,6 +78,7 @@ class Update_Comment_Meta extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Comments/Update_Comment_Meta.php
+++ b/includes/Abilities/Comments/Update_Comment_Meta.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Comments;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -46,6 +47,7 @@ class Update_Comment_Meta extends Ability_Definition {
 							'type'        => 'object',
 							'description' => __( 'Object of meta keys → values to write.', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'id', 'meta' ),
 					'additionalProperties' => false,
@@ -110,7 +112,7 @@ class Update_Comment_Meta extends Ability_Definition {
 				continue;
 			}
 			$sanitized = sanitize_meta( $key, $value, 'comment' );
-			update_comment_meta( $id, $key, wp_slash( $sanitized ) );
+			update_comment_meta( $id, $key, Slash_Input::slash( $sanitized, $input ) );
 		}
 
 		return array(

--- a/includes/Abilities/Content/Add_Post_Meta.php
+++ b/includes/Abilities/Content/Add_Post_Meta.php
@@ -100,6 +100,7 @@ class Add_Post_Meta extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => false,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Content/Add_Post_Meta.php
+++ b/includes/Abilities/Content/Add_Post_Meta.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -60,6 +61,7 @@ class Add_Post_Meta extends Ability_Definition {
 							'type'    => 'boolean',
 							'default' => false,
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'allOf'                => array(
 						array( 'required' => array( 'post_id' ) ),
@@ -134,7 +136,7 @@ class Add_Post_Meta extends Ability_Definition {
 		$value  = array_key_exists( 'value', $input ) ? $input['value'] : ( $input['meta_value'] ?? '' );
 		$unique = ! empty( $input['unique'] );
 
-		$meta_id = add_post_meta( $post_id, $key, wp_slash( $value ), $unique );
+		$meta_id = add_post_meta( $post_id, $key, Slash_Input::slash( $value, $input ), $unique );
 
 		return array(
 			'success' => true,

--- a/includes/Abilities/Content/Create_Cpt_Item.php
+++ b/includes/Abilities/Content/Create_Cpt_Item.php
@@ -90,6 +90,7 @@ class Create_Cpt_Item extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => false,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Content/Create_Cpt_Item.php
+++ b/includes/Abilities/Content/Create_Cpt_Item.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -56,6 +57,7 @@ class Create_Cpt_Item extends Ability_Definition {
 							'default'     => false,
 							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead.', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'post_type', 'title' ),
 					'additionalProperties' => false,
@@ -134,7 +136,7 @@ class Create_Cpt_Item extends Ability_Definition {
 			$args['meta_input'] = $input['meta'];
 		}
 
-		$id = wp_insert_post( wp_slash( $args ), true );
+		$id = wp_insert_post( Slash_Input::slash( $args, $input ), true );
 		if ( is_wp_error( $id ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/Content/Create_Page.php
+++ b/includes/Abilities/Content/Create_Page.php
@@ -94,6 +94,7 @@ class Create_Page extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => false,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Content/Create_Page.php
+++ b/includes/Abilities/Content/Create_Page.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -60,6 +61,7 @@ class Create_Page extends Ability_Definition {
 							'default'     => false,
 							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead.', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'title' ),
 					'additionalProperties' => false,
@@ -122,7 +124,7 @@ class Create_Page extends Ability_Definition {
 			$args['meta_input'] = $input['meta'];
 		}
 
-		$id = wp_insert_post( wp_slash( $args ), true );
+		$id = wp_insert_post( Slash_Input::slash( $args, $input ), true );
 		if ( is_wp_error( $id ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/Content/Create_Post.php
+++ b/includes/Abilities/Content/Create_Post.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -58,6 +59,7 @@ class Create_Post extends Ability_Definition {
 							'default'     => false,
 							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead.', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'title' ),
 					'additionalProperties' => false,
@@ -133,7 +135,7 @@ class Create_Post extends Ability_Definition {
 			$args['meta_input'] = $input['meta'];
 		}
 
-		$id = wp_insert_post( wp_slash( $args ), true );
+		$id = wp_insert_post( Slash_Input::slash( $args, $input ), true );
 		if ( is_wp_error( $id ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/Content/Create_Post.php
+++ b/includes/Abilities/Content/Create_Post.php
@@ -92,6 +92,7 @@ class Create_Post extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => false,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Content/Update_Cpt_Item.php
+++ b/includes/Abilities/Content/Update_Cpt_Item.php
@@ -88,6 +88,7 @@ class Update_Cpt_Item extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Content/Update_Cpt_Item.php
+++ b/includes/Abilities/Content/Update_Cpt_Item.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -54,6 +55,7 @@ class Update_Cpt_Item extends Ability_Definition {
 							'default'     => false,
 							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead.', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'post_type', 'id' ),
 					'additionalProperties' => false,
@@ -156,7 +158,7 @@ class Update_Cpt_Item extends Ability_Definition {
 			$args['meta_input'] = $input['meta'];
 		}
 
-		$result = wp_update_post( wp_slash( $args ), true );
+		$result = wp_update_post( Slash_Input::slash( $args, $input ), true );
 		if ( is_wp_error( $result ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/Content/Update_Page.php
+++ b/includes/Abilities/Content/Update_Page.php
@@ -88,6 +88,7 @@ class Update_Page extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Content/Update_Page.php
+++ b/includes/Abilities/Content/Update_Page.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -54,6 +55,7 @@ class Update_Page extends Ability_Definition {
 							'default'     => false,
 							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead, so a "one-word edit" round-trip does not echo the whole page body back through the tunnel. Callers who need the saved bytes should pass true explicitly.', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'id' ),
 					'additionalProperties' => false,
@@ -151,7 +153,7 @@ class Update_Page extends Ability_Definition {
 			$args['meta_input'] = $input['meta'];
 		}
 
-		$result = wp_update_post( wp_slash( $args ), true );
+		$result = wp_update_post( Slash_Input::slash( $args, $input ), true );
 		if ( is_wp_error( $result ) ) {
 			return array(
 				'success' => false,

--- a/includes/Abilities/Content/Update_Post.php
+++ b/includes/Abilities/Content/Update_Post.php
@@ -95,6 +95,7 @@ class Update_Post extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Content/Update_Post.php
+++ b/includes/Abilities/Content/Update_Post.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -56,6 +57,7 @@ class Update_Post extends Ability_Definition {
 							'default'     => false,
 							'description' => __( 'When true, the response includes the saved post_content / post_excerpt / post_content_filtered fields. Default false: those large fields are stripped and content_bytes is returned instead, so a "one-word edit" round-trip does not echo the whole post body back through the tunnel.', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'id' ),
 					'additionalProperties' => false,
@@ -216,7 +218,7 @@ class Update_Post extends Ability_Definition {
 			}
 		}
 
-		$result = wp_update_post( wp_slash( $args ), true );
+		$result = wp_update_post( Slash_Input::slash( $args, $input ), true );
 		if ( is_wp_error( $result ) ) {
 			return array(
 				'success'           => false,

--- a/includes/Abilities/Content/Update_Post_Meta.php
+++ b/includes/Abilities/Content/Update_Post_Meta.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Content;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -52,6 +53,7 @@ class Update_Post_Meta extends Ability_Definition {
 							'type'        => array( 'string', 'integer', 'number', 'boolean', 'array', 'object', 'null' ),
 							'description' => __( 'Alias for "value" (matches WordPress core naming). If both are provided, "value" wins.', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'allOf'                => array(
 						array( 'required' => array( 'post_id' ) ),
@@ -120,7 +122,7 @@ class Update_Post_Meta extends Ability_Definition {
 		}
 
 		$value  = array_key_exists( 'value', $input ) ? $input['value'] : ( $input['meta_value'] ?? '' );
-		$result = update_post_meta( $post_id, $key, wp_slash( $value ) );
+		$result = update_post_meta( $post_id, $key, Slash_Input::slash( $value, $input ) );
 
 		return array(
 			'success' => true,

--- a/includes/Abilities/Content/Update_Post_Meta.php
+++ b/includes/Abilities/Content/Update_Post_Meta.php
@@ -92,6 +92,7 @@ class Update_Post_Meta extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Media/Update_Media.php
+++ b/includes/Abilities/Media/Update_Media.php
@@ -82,6 +82,7 @@ class Update_Media extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Media/Update_Media.php
+++ b/includes/Abilities/Media/Update_Media.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Media;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -46,6 +47,7 @@ class Update_Media extends Ability_Definition {
 						'caption'     => array( 'type' => 'string' ),
 						'description' => array( 'type' => 'string' ),
 						'alt_text'    => array( 'type' => 'string' ),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'id' ),
 					'additionalProperties' => false,
@@ -128,7 +130,7 @@ class Update_Media extends Ability_Definition {
 		}
 
 		if ( $has_change ) {
-			$result = wp_update_post( wp_slash( $post_data ), true );
+			$result = wp_update_post( Slash_Input::slash( $post_data, $input ), true );
 			if ( is_wp_error( $result ) || 0 === $result ) {
 				return Media_Formatter::error_from(
 					$result,
@@ -139,7 +141,7 @@ class Update_Media extends Ability_Definition {
 		}
 
 		if ( isset( $input['alt_text'] ) ) {
-			update_post_meta( $id, '_wp_attachment_image_alt', wp_slash( (string) $input['alt_text'] ) );
+			update_post_meta( $id, '_wp_attachment_image_alt', Slash_Input::slash( (string) $input['alt_text'], $input ) );
 			$updated[] = 'alt_text';
 		}
 

--- a/includes/Abilities/Media/Update_Media_Meta.php
+++ b/includes/Abilities/Media/Update_Media_Meta.php
@@ -78,6 +78,7 @@ class Update_Media_Meta extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Media/Update_Media_Meta.php
+++ b/includes/Abilities/Media/Update_Media_Meta.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Media;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -46,6 +47,7 @@ class Update_Media_Meta extends Ability_Definition {
 							'type'        => 'object',
 							'description' => __( 'Object of meta keys → values to write.', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'id', 'meta' ),
 					'additionalProperties' => false,
@@ -111,7 +113,7 @@ class Update_Media_Meta extends Ability_Definition {
 				continue;
 			}
 			$sanitized = sanitize_meta( $key, $value, 'post' );
-			update_post_meta( $id, $key, wp_slash( $sanitized ) );
+			update_post_meta( $id, $key, Slash_Input::slash( $sanitized, $input ) );
 		}
 
 		return array(

--- a/includes/Abilities/Menus/Create_Menu.php
+++ b/includes/Abilities/Menus/Create_Menu.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Menus;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -45,6 +46,7 @@ class Create_Menu extends Ability_Definition {
 							'type'  => 'array',
 							'items' => array( 'type' => 'string' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'name' ),
 					'additionalProperties' => false,
@@ -103,13 +105,13 @@ class Create_Menu extends Ability_Definition {
 			$args['description'] = (string) $input['description'];
 		}
 
-		$menu_id = wp_create_nav_menu( wp_slash( $name ) );
+		$menu_id = wp_create_nav_menu( Slash_Input::slash( $name, $input ) );
 		if ( is_wp_error( $menu_id ) ) {
 			return Menu_Formatter::error_from( $menu_id, __( 'Could not create menu.', 'acrossai-abilities-manager' ) );
 		}
 
 		if ( ! empty( $args ) ) {
-			wp_update_nav_menu_object( (int) $menu_id, wp_slash( $args ) );
+			wp_update_nav_menu_object( (int) $menu_id, Slash_Input::slash( $args, $input ) );
 		}
 
 		if ( ! empty( $input['locations'] ) && is_array( $input['locations'] ) ) {

--- a/includes/Abilities/Menus/Create_Menu.php
+++ b/includes/Abilities/Menus/Create_Menu.php
@@ -77,6 +77,7 @@ class Create_Menu extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => false,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Menus/Create_Menu_Item.php
+++ b/includes/Abilities/Menus/Create_Menu_Item.php
@@ -101,6 +101,7 @@ class Create_Menu_Item extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => false,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Menus/Create_Menu_Item.php
+++ b/includes/Abilities/Menus/Create_Menu_Item.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Menus;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -69,6 +70,7 @@ class Create_Menu_Item extends Ability_Definition {
 							'type'  => 'array',
 							'items' => array( 'type' => 'string' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'title' ),
 					'additionalProperties' => false,
@@ -134,7 +136,7 @@ class Create_Menu_Item extends Ability_Definition {
 
 		$args = self::build_item_args( $title, $input );
 
-		$new_id = wp_update_nav_menu_item( $menu_id, 0, wp_slash( $args ) );
+		$new_id = wp_update_nav_menu_item( $menu_id, 0, Slash_Input::slash( $args, $input ) );
 		if ( is_wp_error( $new_id ) || 0 === $new_id ) {
 			return Menu_Formatter::error_from( $new_id, __( 'Could not create menu item.', 'acrossai-abilities-manager' ) );
 		}

--- a/includes/Abilities/Menus/Update_Menu.php
+++ b/includes/Abilities/Menus/Update_Menu.php
@@ -81,6 +81,7 @@ class Update_Menu extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Menus/Update_Menu.php
+++ b/includes/Abilities/Menus/Update_Menu.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Menus;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -49,6 +50,7 @@ class Update_Menu extends Ability_Definition {
 							'type'  => 'array',
 							'items' => array( 'type' => 'string' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'id' ),
 					'additionalProperties' => false,
@@ -119,7 +121,7 @@ class Update_Menu extends Ability_Definition {
 		}
 
 		if ( ! empty( $args ) ) {
-			$result = wp_update_nav_menu_object( $id, wp_slash( $args ) );
+			$result = wp_update_nav_menu_object( $id, Slash_Input::slash( $args, $input ) );
 			if ( is_wp_error( $result ) ) {
 				return Menu_Formatter::error_from(
 					$result,

--- a/includes/Abilities/Menus/Update_Menu_Item.php
+++ b/includes/Abilities/Menus/Update_Menu_Item.php
@@ -92,6 +92,7 @@ class Update_Menu_Item extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Menus/Update_Menu_Item.php
+++ b/includes/Abilities/Menus/Update_Menu_Item.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Menus;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -60,6 +61,7 @@ class Update_Menu_Item extends Ability_Definition {
 							'type'  => 'array',
 							'items' => array( 'type' => 'string' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'id' ),
 					'additionalProperties' => false,
@@ -155,7 +157,7 @@ class Update_Menu_Item extends Ability_Definition {
 
 		$args = Create_Menu_Item::build_item_args( (string) $merged['title'], $merged );
 
-		$result = wp_update_nav_menu_item( $menu_id, $id, wp_slash( $args ) );
+		$result = wp_update_nav_menu_item( $menu_id, $id, Slash_Input::slash( $args, $input ) );
 		if ( is_wp_error( $result ) || 0 === $result ) {
 			return Menu_Formatter::error_from(
 				$result,

--- a/includes/Abilities/Taxonomies/Create_Term.php
+++ b/includes/Abilities/Taxonomies/Create_Term.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Taxonomies;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -46,6 +47,7 @@ class Create_Term extends Ability_Definition {
 							'type'    => 'integer',
 							'default' => 0,
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'taxonomy', 'name' ),
 					'additionalProperties' => false,
@@ -116,7 +118,7 @@ class Create_Term extends Ability_Definition {
 			$args['parent'] = (int) $input['parent'];
 		}
 
-		$result = wp_insert_term( wp_slash( $name ), $taxonomy, wp_slash( $args ) );
+		$result = wp_insert_term( Slash_Input::slash( $name, $input ), $taxonomy, Slash_Input::slash( $args, $input ) );
 		if ( is_wp_error( $result ) ) {
 			return Term_Formatter::error_from( $result, __( 'Could not create term.', 'acrossai-abilities-manager' ) );
 		}

--- a/includes/Abilities/Taxonomies/Create_Term.php
+++ b/includes/Abilities/Taxonomies/Create_Term.php
@@ -78,6 +78,7 @@ class Create_Term extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => false,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Taxonomies/Update_Term.php
+++ b/includes/Abilities/Taxonomies/Update_Term.php
@@ -79,6 +79,7 @@ class Update_Term extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Taxonomies/Update_Term.php
+++ b/includes/Abilities/Taxonomies/Update_Term.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Taxonomies;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -47,6 +48,7 @@ class Update_Term extends Ability_Definition {
 						'slug'        => array( 'type' => 'string' ),
 						'description' => array( 'type' => 'string' ),
 						'parent'      => array( 'type' => 'integer' ),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'taxonomy', 'id' ),
 					'additionalProperties' => false,
@@ -133,7 +135,7 @@ class Update_Term extends Ability_Definition {
 			);
 		}
 
-		$result = wp_update_term( $id, $taxonomy, wp_slash( $args ) );
+		$result = wp_update_term( $id, $taxonomy, Slash_Input::slash( $args, $input ) );
 		if ( is_wp_error( $result ) ) {
 			return Term_Formatter::error_from(
 				$result,

--- a/includes/Abilities/Users/Create_User.php
+++ b/includes/Abilities/Users/Create_User.php
@@ -94,6 +94,7 @@ class Create_User extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => false,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Users/Create_User.php
+++ b/includes/Abilities/Users/Create_User.php
@@ -11,6 +11,7 @@
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Users;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -62,6 +63,7 @@ class Create_User extends Ability_Definition {
 							'type'        => 'string',
 							'description' => __( 'Role slug to assign (defaults to default_role option).', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'username', 'email' ),
 					'additionalProperties' => false,
@@ -174,7 +176,7 @@ class Create_User extends Ability_Definition {
 			$user_data['role'] = $role;
 		}
 
-		$user_id = wp_insert_user( wp_slash( $user_data ) );
+		$user_id = wp_insert_user( Slash_Input::slash( $user_data, $input ) );
 
 		if ( is_wp_error( $user_id ) ) {
 			return array(

--- a/includes/Abilities/Users/Update_User.php
+++ b/includes/Abilities/Users/Update_User.php
@@ -12,6 +12,7 @@ namespace AcrossAI_Abilities_Manager\Includes\Abilities\Users;
 
 use AcrossAI_Abilities_Manager\Includes\Modules\Library\Ability_Definition;
 use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\User_Helpers;
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -84,6 +85,7 @@ class Update_User extends Ability_Definition {
 							'default'     => false,
 							'description' => __( 'Destroy every active login session for this user after the update completes.', 'acrossai-abilities-manager' ),
 						),
+						'apply_wp_slash' => Slash_Input::schema_fragment()['apply_wp_slash'],
 					),
 					'required'             => array( 'user' ),
 					'additionalProperties' => false,
@@ -180,7 +182,7 @@ class Update_User extends Ability_Definition {
 
 		// Apply core-field update only if at least one field was supplied.
 		if ( $has_field ) {
-			$result = wp_update_user( wp_slash( $update ) );
+			$result = wp_update_user( Slash_Input::slash( $update, $input ) );
 
 			if ( is_wp_error( $result ) ) {
 				return array(
@@ -196,7 +198,7 @@ class Update_User extends Ability_Definition {
 		$meta_updated = array();
 		$meta_failed  = array();
 		if ( ! empty( $input['meta'] ) && ( is_array( $input['meta'] ) || is_object( $input['meta'] ) ) ) {
-			$meta_result  = User_Helpers::apply_meta( $user_id, (array) $input['meta'] );
+			$meta_result  = User_Helpers::apply_meta( $user_id, (array) $input['meta'], false !== ( $input['apply_wp_slash'] ?? true ) );
 			$meta_updated = $meta_result['updated'];
 			$meta_failed  = $meta_result['failed'];
 		}

--- a/includes/Abilities/Users/Update_User.php
+++ b/includes/Abilities/Users/Update_User.php
@@ -117,6 +117,7 @@ class Update_User extends Ability_Definition {
 						'destructive' => false,
 						'idempotent'  => true,
 					),
+					'input_flags'  => Slash_Input::meta_flags(),
 				),
 			),
 		);

--- a/includes/Abilities/Users/Update_User.php
+++ b/includes/Abilities/Users/Update_User.php
@@ -198,7 +198,7 @@ class Update_User extends Ability_Definition {
 		$meta_updated = array();
 		$meta_failed  = array();
 		if ( ! empty( $input['meta'] ) && ( is_array( $input['meta'] ) || is_object( $input['meta'] ) ) ) {
-			$meta_result  = User_Helpers::apply_meta( $user_id, (array) $input['meta'], false !== ( $input['apply_wp_slash'] ?? true ) );
+			$meta_result  = User_Helpers::apply_meta( $user_id, (array) $input['meta'], $input );
 			$meta_updated = $meta_result['updated'];
 			$meta_failed  = $meta_result['failed'];
 		}

--- a/includes/Abilities/Utilities/Slash_Input.php
+++ b/includes/Abilities/Utilities/Slash_Input.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Slash_Input helper — per-call opt-out for wp_slash() on write abilities.
+ *
+ * @license    GPL-2.0-or-later
+ * @package    AcrossAI_Abilities_Manager
+ * @subpackage Includes\Abilities\Utilities
+ * @since      0.1.0
+ */
+
+namespace AcrossAI_Abilities_Manager\Includes\Abilities\Utilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Bridge between an ability's `apply_wp_slash` input flag and the wp_slash()
+ * call it wraps around WordPress core write functions.
+ *
+ * Merge schema_fragment() into an ability's input_schema `properties` array,
+ * then call self::slash() at every wp_slash() site the ability previously
+ * called directly. Default behaviour (missing key OR true) preserves the
+ * #131 fix; passing `apply_wp_slash: false` on the ability call opts out.
+ */
+class Slash_Input {
+
+	/**
+	 * Schema fragment to merge into an ability's `input_schema['properties']`.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function schema_fragment(): array {
+		return array(
+			'apply_wp_slash' => array(
+				'type'        => 'boolean',
+				'default'     => true,
+				'description' => __( 'Apply wp_slash() to caller-supplied strings before writing. Default true; keeps literal backslashes intact (e.g. PHP namespaces \\Foo\\Bar, regex \\d+, Windows paths C:\\Users). Set false only when the caller has already slashed the payload — otherwise WordPress core will silently strip backslashes.', 'acrossai-abilities-manager' ),
+			),
+		);
+	}
+
+	/**
+	 * Wrap $value with wp_slash() unless the ability input explicitly opts out.
+	 *
+	 * Missing key OR true → slash. Only literal boolean false skips.
+	 *
+	 * @param mixed              $value Value about to be handed to a WP core write function.
+	 * @param array<mixed,mixed> $input Ability input payload.
+	 * @return mixed Slashed value, or the original value if opted out.
+	 */
+	public static function slash( $value, array $input ) {
+		if ( false === ( $input['apply_wp_slash'] ?? true ) ) {
+			return $value;
+		}
+		return wp_slash( $value );
+	}
+}

--- a/includes/Abilities/Utilities/Slash_Input.php
+++ b/includes/Abilities/Utilities/Slash_Input.php
@@ -39,6 +39,26 @@ class Slash_Input {
 	}
 
 	/**
+	 * Meta annotation advertising the flag on the ability's `meta` block. Lets
+	 * discovery tooling and AI clients see that this ability supports the
+	 * apply_wp_slash opt-out without fetching the full input_schema.
+	 *
+	 * Merge into an ability's top-level `meta` array as
+	 *   'input_flags' => Slash_Input::meta_flags(),
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function meta_flags(): array {
+		return array(
+			'apply_wp_slash' => array(
+				'default'     => true,
+				'summary'     => __( 'Toggle wp_slash() on caller-supplied strings before the core write. Default true preserves backslashes; false skips escaping.', 'acrossai-abilities-manager' ),
+				'schema_path' => 'input_schema.properties.apply_wp_slash',
+			),
+		);
+	}
+
+	/**
 	 * Wrap $value with wp_slash() unless the ability input explicitly opts out.
 	 *
 	 * Missing key OR true → slash. Only literal boolean false skips.

--- a/includes/Abilities/Utilities/User_Helpers.php
+++ b/includes/Abilities/Utilities/User_Helpers.php
@@ -144,9 +144,10 @@ class User_Helpers {
 	 *
 	 * @param int                  $user_id
 	 * @param array<string, mixed> $meta
+	 * @param bool                 $apply_slash Whether to wp_slash values before writing. Default true (matches WP core wp_unslash contract).
 	 * @return array{updated: string[], failed: string[]}
 	 */
-	public static function apply_meta( int $user_id, array $meta ): array {
+	public static function apply_meta( int $user_id, array $meta, bool $apply_slash = true ): array {
 		$updated = array();
 		$failed  = array();
 		foreach ( $meta as $key => $value ) {
@@ -155,7 +156,7 @@ class User_Helpers {
 				continue;
 			}
 			$value  = self::maybe_decode_json( $value );
-			$result = update_user_meta( $user_id, $key, wp_slash( $value ) );
+			$result = update_user_meta( $user_id, $key, $apply_slash ? wp_slash( $value ) : $value );
 			if ( false === $result ) {
 				$failed[] = $key;
 			} else {

--- a/includes/Abilities/Utilities/User_Helpers.php
+++ b/includes/Abilities/Utilities/User_Helpers.php
@@ -10,6 +10,8 @@
 
 namespace AcrossAI_Abilities_Manager\Includes\Abilities\Utilities;
 
+use AcrossAI_Abilities_Manager\Includes\Abilities\Utilities\Slash_Input;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -144,10 +146,10 @@ class User_Helpers {
 	 *
 	 * @param int                  $user_id
 	 * @param array<string, mixed> $meta
-	 * @param bool                 $apply_slash Whether to wp_slash values before writing. Default true (matches WP core wp_unslash contract).
+	 * @param array<mixed,mixed>   $input Ability input payload; forwarded to Slash_Input::slash() so the caller's apply_wp_slash flag governs whether values are slashed. Defaults to empty (= slash on, matches WP core wp_unslash contract).
 	 * @return array{updated: string[], failed: string[]}
 	 */
-	public static function apply_meta( int $user_id, array $meta, bool $apply_slash = true ): array {
+	public static function apply_meta( int $user_id, array $meta, array $input = array() ): array {
 		$updated = array();
 		$failed  = array();
 		foreach ( $meta as $key => $value ) {
@@ -156,7 +158,7 @@ class User_Helpers {
 				continue;
 			}
 			$value  = self::maybe_decode_json( $value );
-			$result = update_user_meta( $user_id, $key, $apply_slash ? wp_slash( $value ) : $value );
+			$result = update_user_meta( $user_id, $key, Slash_Input::slash( $value, $input ) );
 			if ( false === $result ) {
 				$failed[] = $key;
 			} else {

--- a/tests/phpunit/abilities/Test_Add_Post_Meta.php
+++ b/tests/phpunit/abilities/Test_Add_Post_Meta.php
@@ -54,7 +54,7 @@ class Test_Add_Post_Meta extends WP_UnitTestCase {
 	}
 
 	public function test_calls_add_post_meta_with_unique_flag(): void {
-		$this->assertStringContainsString( 'add_post_meta( $post_id, $key, $value, $unique )', $this->src );
+		$this->assertStringContainsString( 'add_post_meta( $post_id, $key, Slash_Input::slash( $value, $input ), $unique )', $this->src );
 	}
 
 	public function test_accepts_key_and_meta_key_aliases(): void {


### PR DESCRIPTION
## Summary

Stacked on top of #161. Adds an `apply_wp_slash` boolean input parameter on every ability that wraps caller strings with `wp_slash()` before a WordPress core write. Default `true` (preserves the #131 fix); passing `false` lets a caller opt out per-call when the payload has already been slashed and going through `wp_slash()` again would double-escape.

## New helper

`includes/Abilities/Utilities/Slash_Input.php`:

- `Slash_Input::schema_fragment()` returns the `apply_wp_slash` property definition, merged into each ability's `input_schema['properties']`.
- `Slash_Input::slash( \$value, \$input )` replaces every direct `wp_slash()` call at the write boundary. Missing key or `true` → slash. Only literal boolean `false` skips.

## Ability files touched (21)

- **Comments/** — Create_Comment, Update_Comment, Update_Comment_Meta
- **Content/** — Create_Post, Update_Post, Update_Post_Meta, Create_Page, Update_Page, Add_Post_Meta, Create_Cpt_Item, Update_Cpt_Item
- **Users/** — Create_User, Update_User
- **Menus/** — Create_Menu, Create_Menu_Item, Update_Menu, Update_Menu_Item
- **Taxonomies/** — Create_Term, Update_Term
- **Media/** — Update_Media, Update_Media_Meta

Each gets one property added to `input_schema` and every `wp_slash( \$x )` call swapped for `Slash_Input::slash( \$x, \$input )`. `Utilities/User_Helpers::apply_meta()` gains a matching \$apply_slash param so Update_User can plumb the flag through.

## Out of scope

- `Utilities/Elementor/Document_Repository::save_data()` — encodes an Elementor JSON tree and slashes the encoded JSON, not caller-supplied text. Toggling `wp_slash` on encoded JSON would corrupt Elementor's escape sequences. Left always-slashed; separate ticket if a real need surfaces.
- `Options/*`, `Settings/*` — `update_option()` doesn't `wp_unslash()` internally, so these paths never slash today and don't need the flag.

## Test plan

- [x] \`composer run phpcs\` clean on all touched files (verified locally)
- [x] \`composer run phpstan\` (level 8) clean
- [ ] Manual (default preserves backslashes): call \`acrossai/create-post\` with \`content = "\\Elementor\\Plugin"\` and no \`apply_wp_slash\` field; assert stored bytes preserve the backslashes
- [ ] Manual (opt-out reverts to pre-#131 broken behaviour): repeat with \`apply_wp_slash: false\`; assert backslashes stripped
- [ ] Spot-check one representative per group: \`update-user\` (display_name), \`update-term\` (name), \`update-menu\` (title), \`update-media\` (caption), \`update-comment-meta\` (value)

## Base branch

Opened against \`fix/131-wp-slash-core-writes\` for clean-diff review. GitHub will auto-retarget to \`main\` when #161 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)