### PR TITLE
docs(specs): 096 ACF block abilities — feature brief for /speckit-specify

### DIFF
--- a/specs/096-acf-block-abilities/inputs.md
+++ b/specs/096-acf-block-abilities/inputs.md
@@ -1,0 +1,89 @@
+# Feature 096 — ACF block abilities (inputs for /speckit-specify)
+
+This file is the natural-language brief that `/speckit-specify` should turn into `spec.md`. Do not treat it as the spec itself.
+
+## One-sentence goal
+
+Add five new abilities that let an AI client register ACF-powered blocks, discover their fields, and insert or update ACF block instances inside post content — the workflow that ACF's own AI integration (6.8) does not cover.
+
+## Why now
+
+ACF 6.8 (released 2026-03-30) shipped a WordPress Abilities API integration exposing schema management (`acf/field-groups`, `acf/register-field-group`) and per-CPT / per-taxonomy content CRUD. That integration is already wired into this plugin through `includes/Abilities/Integrations/ACF.php` (Feature 060), which flips `acf/settings/enable_acf_ai`.
+
+**Gap:** ACF's own abilities do not touch **block registration** (no `BlockType.php` in ACF's `src/AI/Abilities/`) and do not scope field-group introspection to blocks. Our own `blocks/add-block` and `blocks/update-post-block` abilities can insert any block mechanically but require the AI to hand-craft the ACF-specific block markup (`<!-- wp:acf/{name} {"data":{...}} /-->`) and hand-craft the `data` payload without any way to discover which fields the block accepts.
+
+The AI-authored-block-with-ACF workflow is a common ask for content-authoring assistants that need to produce rich, editable, non-Gutenberg-native layouts. Today it requires the AI to compose Gutenberg markup manually and guess at field shapes.
+
+## Scope
+
+### Abilities to add (5)
+
+All under the `blocks/` topic namespace (per project convention — block-editor abilities live under `blocks/`, not under a vendor prefix).
+
+1. **`blocks/register-acf-block`** — Create an ACF block type. Inputs: name, title, category, icon, mode (edit/preview/auto), supports, render source (template path OR inline callback identifier), optional inline field-group definition (fields + location auto-bound to the new block). Wraps `acf_register_block_type()` and, when the inline field-group is supplied, calls ACF's field-group registration too so a single call yields a fully wired block.
+
+2. **`blocks/list-acf-blocks`** — Enumerate every ACF-registered block on the site with, per entry: block name, title, category, bound field-group ID (if any), and field count. Lets the AI discover what already exists before creating a duplicate.
+
+3. **`blocks/get-acf-block-fields`** — Given an ACF block name, return the fields defined by its bound field group: name, key, type, label, instructions, sub-fields (for repeaters / flex layouts / groups), default value. This is the piece the AI needs before building a valid `data` payload.
+
+4. **`blocks/insert-acf-block`** — Insert an ACF block instance into a post. Inputs: post_id, block name, `data` payload (validated against the field group's field names / types before insertion), optional `align` / `mode`, insert position (append / prepend / after-block-id). Thin wrapper over `blocks/add-block` that owns the ACF markup shape and validation.
+
+5. **`blocks/update-acf-block-data`** — Locate a specific ACF block instance in a post (by client_id or by name + index) and patch only its `data` attribute. Complements `blocks/update-post-block` for the ACF-specific patch case; does not re-serialize the whole post_content.
+
+### Explicitly out of scope
+
+- **ACF field-value abilities on posts** (`acf/get-field`, `acf/update-field`, etc.) — ACF block field values live in `post_content` as the block's `data` attribute, not in `postmeta`. `update_field()` is not the write path here. Tracked separately if we ever need it for classic-editor / non-block field values.
+- **Options-page fields, repeater-row-level operations, generic field-group CRUD** — none are on the critical path for authoring ACF blocks; wait for a real user pull.
+- **Modifying ACF's own registered abilities** — we do not touch `acf/*` slugs; ACF owns that namespace.
+- **Block.json generation on disk** — abilities operate at the runtime `acf_register_block_type()` layer. Filesystem-based `block.json` scaffolding is a separate concern (see the file-manager abilities cluster) and would be a follow-up.
+
+## Constraints
+
+- **ACF Pro required** — ACF blocks are a Pro-only feature (`acf_register_block_type` is undefined in free ACF). Guard every ability's `permission_callback` on `defined('ACF_VERSION') && function_exists('acf_register_block_type')`; return a clean "ACF Pro not active" error rather than a fatal when the function is missing.
+- **Live behind the existing integration toggle** — abilities should only register when the `Advanced Custom Fields (AI)` toggle on the Library page is on. Reuse `Integrations/ACF::is_plugin_active()` for the detection path.
+- **Consistent with the `apply_wp_slash` opt-out flag** — any ability that accepts caller strings and hands them to a WordPress core write function should merge `Slash_Input::schema_fragment()` into its input schema and use `Slash_Input::slash( $value, $input )` at the write boundary, matching PR #162 (this branch). `insert-acf-block` and `update-acf-block-data` are the two that need it, since block markup goes through `wp_insert_post()` / `wp_update_post()` under the hood.
+- **Category namespacing** — new abilities register under an existing block-editor ability category (probably `acrossai-abilities-manager-blocks` — confirm during planning by reading `includes/Abilities/Block/*.php`). Do not create a new category unless there is a UX reason.
+- **`suggested_abilities()` hints (Feature 095)** — `register-acf-block` should suggest `list-acf-blocks` first ("check what exists before creating a duplicate"). `insert-acf-block` should suggest `get-acf-block-fields` first ("know what fields the block accepts before building the data payload"). This mirrors the outline-first hint pattern used by `update-post`.
+
+## Non-goals
+
+- No changes to `Integrations/ACF.php` — that integration only flips ACF's own switch and lists the abilities ACF will register. New abilities are OURS and live under `includes/Abilities/Block/` or similar, not there.
+- No client-side UI. Abilities appear in the Library table via the standard registration path; no admin page changes.
+- No back-compat concerns — this is additive.
+
+## Files that will likely be touched
+
+- `includes/Abilities/Block/Register_Acf_Block.php` (new)
+- `includes/Abilities/Block/List_Acf_Blocks.php` (new)
+- `includes/Abilities/Block/Get_Acf_Block_Fields.php` (new)
+- `includes/Abilities/Block/Insert_Acf_Block.php` (new)
+- `includes/Abilities/Block/Update_Acf_Block_Data.php` (new)
+- Possibly `includes/Abilities/Utilities/Acf_Block_Helpers.php` (new) for shared field-group resolution + `data`-payload validation
+- `includes/Main.php` — register the five ability classes on `acrossai_abilities_api_init` (mirror how existing `Block/*` abilities are bootstrapped)
+
+## Existing code to reuse
+
+- `Slash_Input::schema_fragment()` / `Slash_Input::slash()` — for the two writers (added by branch `feat/apply-wp-slash-opt-out` / PR #162)
+- `Integrations/ACF::is_plugin_active()` — the compound `defined('ACF_VERSION') && function_exists('acf_get_setting')` detection pattern
+- `Ability_Definition` base class — every new ability extends this
+- Existing `blocks/add-block` and `blocks/update-post-block` internals — `insert-acf-block` and `update-acf-block-data` are conceptually thin wrappers around these plus ACF-shape validation
+
+## Verification (what "done" looks like)
+
+- All 5 abilities register when ACF Pro is loaded AND the integration toggle is on; do not register otherwise
+- `blocks/register-acf-block` end-to-end: given a name + field-group definition, the resulting block is visible in the Gutenberg block inserter and its fields render in the sidebar
+- `blocks/list-acf-blocks` returns the block registered above
+- `blocks/get-acf-block-fields` returns the field definitions with correct types and (for repeaters) sub-fields
+- `blocks/insert-acf-block` inserts a working block instance into a post; visiting the post in the editor shows the block with the supplied `data` populated
+- `blocks/update-acf-block-data` mutates an existing instance's data; other blocks in the post are untouched byte-for-byte
+- `composer run phpcs` and `composer run phpstan` (level 8) clean
+- `apply_wp_slash: false` opt-out works on both writers (round-trip test with a `\Foo\Bar`-containing text field)
+
+## Suggested next steps (for the human)
+
+1. `/speckit-specify` — read this brief and produce `specs/096-acf-block-abilities/spec.md`
+2. `/speckit-plan` — turn the spec into `plan.md`
+3. `/speckit-tasks` — decompose into `tasks.md`
+4. `/speckit-implement` (or hand-execute) — build
+
+I have NOT written spec.md / plan.md / tasks.md. Those are for the /speckit-* workflow you invoke.

--- a/specs/096-acf-block-abilities/inputs.md
+++ b/specs/096-acf-block-abilities/inputs.md
@@ -37,6 +37,43 @@ All under the `blocks/` topic namespace (per project convention — block-editor
 - **Modifying ACF's own registered abilities** — we do not touch `acf/*` slugs; ACF owns that namespace.
 - **Block.json generation on disk** — abilities operate at the runtime `acf_register_block_type()` layer. Filesystem-based `block.json` scaffolding is a separate concern (see the file-manager abilities cluster) and would be a follow-up.
 
+## Prior-art check (2026-09-02)
+
+Verified against installed ACF 6.8.9 + web/GitHub search — nobody occupies this space via the WP Abilities API today:
+
+- **ACF itself** ships 6 fixed abilities (`FieldGroup.php`, `PostType.php`, `Taxonomy.php`) + 5N dynamic per registered CPT + 5M dynamic per registered taxonomy. **No `BlockType.php`. No field-value abilities. No introspection beyond `list`.**
+- **[elementor/angie-acf-mcp](https://github.com/elementor/angie-acf-mcp)** (8★) — uses REST controllers, not the Abilities API. Legacy pattern.
+- **[Easy MCP AI](https://wordpress.org/plugins/easy-mcp-ai/)** — ships 6 ACF MCP tools (`wp_acf_update_fields`, `wp_acf_get_fields`, `wp_acf_get_term_fields`, `wp_acf_get_user_fields`, `wp_acf_list_field_groups`, `wp_acf_update_user_fields`). MCP tools, **not WP Abilities API**. Doesn't touch blocks.
+- **[Enable Abilities for MCP](https://wordpress.org/plugins/enable-abilities-for-mcp/)** — passthrough adapter, not ACF-specific.
+- **[MCP Content Manager Lite](https://wordpress.org/plugins/mcp-content-manager-lite/)** — auto-discovers ACF metadata for read-only surfacing.
+
+**Implication:** feature 096's 5 block abilities are the first Abilities-API-native ACF block coverage. No naming or namespace collisions to worry about.
+
+## Reuse ACF 6.8.1's inline field-group shape
+
+ACF 6.8.1 changelog: *"ACF PRO Blocks can now define their field group inline via an `acf.fields` array in `block.json`"*. Our `blocks/register-acf-block` ability's input schema **should mirror that `acf.fields` shape verbatim** rather than inventing a new binding format — reduces cognitive load for the AI (block.json is the current best practice per ACF docs) and simplifies validation (we can reuse ACF's own field validators).
+
+Reference the two changelog entries that shape this:
+- ACF 6.8.1 — `acf.fields` inline in `block.json`
+- ACF 6.8.9 — blocks default to v3 on WP 7.1+; `renderPreview` in `block.json`
+
+## Persistence — choose during /speckit-plan
+
+`acf_register_block_type()` is runtime-only; registrations vanish on next request unless re-fired. Two persistence options for the AI's newly-registered blocks:
+
+**Option A — option-backed runtime re-registration** *(recommended for MVP)*
+- Store block configs in a new option (e.g. `acrossai_acf_blocks_registry`)
+- Re-register on `init` P20 (before ACF's `acf/init` P25) via `acf_register_block_type()`
+- No filesystem writes; ACF-Pro-only guard; option-editor read/write path lives entirely inside the plugin
+- Trade-off: block metadata lives in the DB, not in code — harder to version-control; won't show in `wp acf json` sync output
+
+**Option B — `block.json` on disk**
+- Write `block.json` + `render.php` into a themes/plugins subdirectory using the existing file-manager module (specs 088–094)
+- Persistence and version control come for free
+- Trade-off: filesystem writes; must decide target directory (theme? mu-plugin? new dir under this plugin?); more moving parts
+
+Recommendation: ship **Option A** first, then follow-up ability `blocks/export-acf-block-to-json` if callers ask for on-disk persistence later.
+
 ## Constraints
 
 - **ACF Pro required** — ACF blocks are a Pro-only feature (`acf_register_block_type` is undefined in free ACF). Guard every ability's `permission_callback` on `defined('ACF_VERSION') && function_exists('acf_register_block_type')`; return a clean "ACF Pro not active" error rather than a fatal when the function is missing.


### PR DESCRIPTION
## Summary

Adds \`specs/096-acf-block-abilities/inputs.md\` — natural-language brief for \`/speckit-specify\` to turn into \`spec.md\`. No code changes, no runtime behaviour changes; just a planning artifact.

Scopes five new \`blocks/*\` abilities that let an AI client register ACF-powered blocks, introspect their fields, and insert/update instances in post_content:

- \`blocks/register-acf-block\`
- \`blocks/list-acf-blocks\`
- \`blocks/get-acf-block-fields\`
- \`blocks/insert-acf-block\`
- \`blocks/update-acf-block-data\`

Covers the gap between ACF 6.8's own Abilities API integration (schema management + per-CPT/taxonomy CRUD, no block registration or field-scoped introspection) and this plugin's existing generic block abilities (which require the AI to hand-craft ACF markup and payloads).

## Related

- Tracked in #163
- ACF integration this builds on: \`includes/Abilities/Integrations/ACF.php\` (Feature 060)
- \`apply_wp_slash\` opt-out flag reused by the two writers: #162

## Not included

\`spec.md\` / \`plan.md\` / \`tasks.md\` — those come from the \`/speckit-*\` workflow the human invokes against \`inputs.md\`.

## Test plan

- [x] File lands at the correct path
- [ ] \`/speckit-specify\` can pick it up and generate \`spec.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)