### PR TITLE
build: guard release autoloader against tests/ classmap leaks

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -26,6 +26,26 @@ jobs:
           test -f vendor/autoload_packages.php || { echo "::error::vendor/autoload_packages.php missing"; exit 1; }
           test -f build/js/abilities.js || { echo "::error::build/js/abilities.js missing"; exit 1; }
 
+      - name: Guard against tests/ leaking into the shipped autoloader
+        # The Jetpack Autoloader merges the root package's autoload-dev into
+        # jetpack_autoload_classmap.php even under --no-dev (its
+        # AutoloadGenerator::parseAutoloadsType merges getDevAutoload()
+        # unconditionally). tests/ is excluded from the zip, so any classmap
+        # entry pointing into tests/ is a dangling require that can fatal
+        # customer sites when a test class name collides with a real plugin's
+        # (acrossai-pro 0.9.8 shipped a MeprUser stub entry that fataled every
+        # MemberPress site — see acrossai-pro PR #74 / this repo's issue #171).
+        # composer.json has no autoload-dev today; this step keeps a future
+        # one from silently reintroducing the leak.
+        run: |
+          LEAKS="$(grep -rl "tests/" vendor/composer/*.php || true)"
+          if [ -n "$LEAKS" ]; then
+            echo "::error::Generated autoloader references tests/ paths, which are excluded from the release zip and would break on customer sites:" >&2
+            grep -rn "tests/" vendor/composer/*.php >&2 || true
+            exit 1
+          fi
+          echo "Autoloader clean: no tests/ references."
+
       - name: Create release zip
         run: |
           zip -r acrossai-abilities-manager.zip . \

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -19,6 +19,19 @@ jobs:
               run: composer install --no-dev --prefer-dist --optimize-autoloader --no-interaction
             - name: Verify Composer autoloader was generated
               run: test -f vendor/autoload_packages.php || { echo "::error::vendor/autoload_packages.php missing after composer install"; exit 1; }
+            - name: Guard against tests/ leaking into the shipped autoloader
+              # Jetpack Autoloader merges root autoload-dev even under --no-dev;
+              # dangling tests/ classmap entries can fatal customer sites (see
+              # acrossai-pro PR #74 / this repo's issue #171). Fails the deploy
+              # on any leak.
+              run: |
+                  LEAKS="$(grep -rl "tests/" vendor/composer/*.php || true)"
+                  if [ -n "$LEAKS" ]; then
+                    echo "::error::Generated autoloader references tests/ paths, which are excluded from the release and would break on customer sites:" >&2
+                    grep -rn "tests/" vendor/composer/*.php >&2 || true
+                    exit 1
+                  fi
+                  echo "Autoloader clean: no tests/ references."
             - name: Fix git safe directory
               run: git config --global --add safe.directory /github/workspace
             - name: WordPress Plugin Deploy

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,10 @@
 			"AcrossAI_Abilities_Manager\\Includes\\": "includes/",
 			"AcrossAI_Abilities_Manager\\Admin\\": "admin/",
 			"AcrossAI_Abilities_Manager\\Front\\": "public/"
-		}
+		},
+		"exclude-from-classmap": [
+			"/tests/"
+		]
 	},
 	"require-dev": {
 		"wp-coding-standards/wpcs": "*",


### PR DESCRIPTION
Closes #171.

## Context

acrossai-pro ≤ 0.9.8 shipped release zips whose `jetpack_autoload_classmap.php` contained dangling entries pointing into the distignored `tests/` directory, fataling MemberPress + BuddyBoss customer sites via a `MeprUser` test stub ([acrossai-pro#74](https://github.com/acrossaico/acrossai-pro/pull/74), shipped in v0.9.9). Root cause: Jetpack Autoloader v5 merges the **root package's `autoload-dev`** into its classmap even under `composer install --no-dev`. Sibling acrossai-mcp-manager was leaking 97 entries the same way ([acrossai-mcp-manager#105](https://github.com/acrossaico/acrossai-mcp-manager/pull/105)).

**This repo has no `autoload-dev` today, so nothing leaks yet.** This PR is purely preventive — one standard-looking future commit adding `"autoload-dev": {"psr-4": {"...\\Tests\\": "tests/"}}` would silently reintroduce the entire failure mode, and no build flag would catch it.

## Changes

1. **`build-zip.yml`** — guard step after the build: fail if any generated `vendor/composer/*.php` references a `tests/` path, printing the offending lines.
2. **`wordpress-plugin-deploy.yml`** — same guard before the WordPress.org SVN deploy.
3. **`composer.json`** — `exclude-from-classmap: ["/tests/"]` as a static fence: even if an `autoload-dev` mapping is added later, Composer's optimizer will skip `tests/` when building classmaps.

Zero runtime effect — all three changes act only at build/CI time, and the classmap exclusion is a no-op while `tests/` isn't mapped.

Reference write-up: acrossai-pro `docs/memory/BUGS.md` → B16 / BUG-JETPACK-AUTOLOAD-DEV-LEAK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7zGaCySW15oG92C2RGCUn